### PR TITLE
Fix to bootstrap.sh after move into submodule

### DIFF
--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,4 +1,4 @@
-./build*
+build*/
 src/wasi-sdk-*
 src/aztec/plonk/proof_system/proving_key/fixtures
 src/aztec/rollup/proofs/*/fixtures

--- a/cpp/bootstrap.sh
+++ b/cpp/bootstrap.sh
@@ -6,8 +6,14 @@ rm -rf ./build
 rm -rf ./build-wasm
 
 # Install formatting git hook.
-echo "cd ./barretenberg && ./format.sh staged" > ../.git/hooks/pre-commit
-chmod +x ../.git/hooks/pre-commit
+PREFIX=
+if [ -f ../.git ]; then
+  # this is a submodule, need to use .git in parent repo
+  # arg 1 is the path to the parent repo's top level
+  PREFIX=${1:-../}
+fi
+echo "cd ./barretenberg && ./format.sh staged" > $PREFIX../.git/hooks/pre-commit
+chmod +x $PREFIX../.git/hooks/pre-commit
 
 # Determine system.
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/cpp/bootstrap.sh
+++ b/cpp/bootstrap.sh
@@ -6,14 +6,13 @@ rm -rf ./build
 rm -rf ./build-wasm
 
 # Install formatting git hook.
-PREFIX=
-if [ -f ../.git ]; then
-  # this is a submodule, need to use .git in parent repo
-  # arg 1 is the path to the parent repo's top level
-  PREFIX=${1:-../}
-fi
-echo "cd ./barretenberg && ./format.sh staged" > $PREFIX../.git/hooks/pre-commit
-chmod +x $PREFIX../.git/hooks/pre-commit
+HOOKS_DIR=$(git rev-parse --git-path hooks)
+# The pre-commit script will live in a barretenberg-specific hooks directory
+# That may be just in the top level of this repository,
+# or may be in a .git/modules/barretenberg subdirectory when this is actually a submodule
+# Either way, running `git rev-parse --show-toplevel` from the hooks directory gives the path to barretenberg
+echo "cd \$(git rev-parse --show-toplevel)/cpp && ./format.sh staged" > $HOOKS_DIR/pre-commit
+chmod +x $HOOKS_DIR/pre-commit
 
 # Determine system.
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## Fixes to bootstrap and `.gitignore`
Had an issue with the `.gitignore`, and needed to fix the `pre-commit` section of `bootstrap.sh`.

### `.gitignore`
For some reason the `cpp/build*` directories were not properly being ignored by the line `./build*` in `cpp/.gitignore`. So, I changed it to `/build*/` and now it seems to work properly. I am not sure why this broke in the first place though...

### `pre-commit`-generation broke in `./bootstrap.sh`
The `pre-commit` hook lives in a different place when the barretenberg is a submodule, so this logic basically uses `git rev-parse --git-path hooks` to find it, then uses `git rev-parse --show-toplevel` inside of the generated `pre-commit` file to ensure `pre-commit` can find its way back to the submodule and run `./format.sh`.

### Concern
We will also likely want this `pre-commit` content for the parent repo itself as there will be other cpp code in the `circuits/` subdirectory. Do we just want to setup a static `pre-commit` configuration? Is there a benefit to dynamically generating it via inside `cpp/bootstrap.sh`?