### PR TITLE
Reapplying reverted bootstrap.sh precommit fix

### DIFF
--- a/cpp/bootstrap.sh
+++ b/cpp/bootstrap.sh
@@ -6,8 +6,13 @@ rm -rf ./build
 rm -rf ./build-wasm
 
 # Install formatting git hook.
-echo "cd ./cpp && ./format.sh staged" > ../.git/hooks/pre-commit
-chmod +x ../.git/hooks/pre-commit
+HOOKS_DIR=$(git rev-parse --git-path hooks)
+# The pre-commit script will live in a barretenberg-specific hooks directory
+# That may be just in the top level of this repository,
+# or may be in a .git/modules/barretenberg subdirectory when this is actually a submodule
+# Either way, running `git rev-parse --show-toplevel` from the hooks directory gives the path to barretenberg
+echo "cd \$(git rev-parse --show-toplevel)/cpp && ./format.sh staged" > $HOOKS_DIR/pre-commit
+chmod +x $HOOKS_DIR/pre-commit
 
 # Determine system.
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
Now that barretenberg is in its own submodule, it needs to dynamically determine the path to the precommit hook when generating the pre-commit directory. The pre-commit script then again needs to dynamically determine the path back to barretenberg's format.sh.