### PR TITLE
Small IPA change

### DIFF
--- a/cpp/src/aztec/honk/commitment_scheme/ipa/ipa.hpp
+++ b/cpp/src/aztec/honk/commitment_scheme/ipa/ipa.hpp
@@ -1,9 +1,6 @@
 #pragma once
 #include <numeric>
-#include <srs/reference_string/reference_string.hpp>
 #include <ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp>
-#include <ecc/curves/bn254/pairing.hpp>
-#include "../commitment_scheme.hpp"
 #include "stdlib/primitives/curves/bn254.hpp"
 
 // Suggested by Zac: Future optimisations

--- a/cpp/src/aztec/honk/commitment_scheme/ipa/ipa.test.cpp
+++ b/cpp/src/aztec/honk/commitment_scheme/ipa/ipa.test.cpp
@@ -4,7 +4,6 @@
 #include "./polynomials/polynomial_arithmetic.hpp"
 #include "./polynomials/polynomial.hpp"
 #include <ecc/curves/bn254/fq12.hpp>
-#include <ecc/curves/bn254/pairing.hpp>
 using namespace barretenberg;
 
 TEST(honk_commitment_scheme, ipa_commit)


### PR DESCRIPTION
Remove unnecessary inclusions of header file to fix gcc error.