### PR TITLE
Prover constructs sumcheck

### DIFF
--- a/cpp/src/aztec/honk/circuit_constructors/standard_circuit_constructor.hpp
+++ b/cpp/src/aztec/honk/circuit_constructors/standard_circuit_constructor.hpp
@@ -14,7 +14,7 @@ inline std::vector<std::string> standard_selector_names()
 class StandardCircuitConstructor : public CircuitConstructorBase<STANDARD_HONK_WIDTH> {
   public:
     // TODO: replace this with Honk enums after we have a verifier and no longer depend on plonk prover/verifier
-    static constexpr waffle::ComposerType type = waffle::ComposerType::STANDARD;
+    static constexpr waffle::ComposerType type = waffle::ComposerType::STANDARD_HONK;
     static constexpr size_t UINT_LOG2_BASE = 2;
 
     // These are variables that we have used a gate on, to enforce that they are

--- a/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
@@ -43,8 +43,8 @@ std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute
 
     // Initialize circuit_proving_key
     // TODO: replace composer types.
-    circuit_proving_key =
-        std::make_shared<waffle::proving_key>(subgroup_size, public_inputs.size(), crs, waffle::ComposerType::STANDARD);
+    circuit_proving_key = std::make_shared<waffle::proving_key>(
+        subgroup_size, public_inputs.size(), crs, waffle::ComposerType::STANDARD_HONK);
 
     for (size_t i = 0; i < constructor.num_selectors; ++i) {
         std::vector<barretenberg::fr>& selector_values = selectors[i];
@@ -225,7 +225,7 @@ std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute
         return circuit_proving_key;
     }
     // Compute q_l, q_r, q_o, etc polynomials
-    ComposerHelper::compute_proving_key_base(circuit_constructor, waffle::ComposerType::STANDARD);
+    ComposerHelper::compute_proving_key_base(circuit_constructor, waffle::ComposerType::STANDARD_HONK);
 
     // Compute sigma polynomials (we should update that late)
     compute_standard_honk_sigma_permutations<CircuitConstructor::program_width>(circuit_constructor,

--- a/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
@@ -234,6 +234,7 @@ std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute
 
     compute_first_and_last_lagrange_polynomials(circuit_proving_key.get());
 
+    // TODO(Cody): this is a workaround
     circuit_proving_key->polynomial_cache.put("z_perm", Polynomial<barretenberg::fr>(1));
 
     return circuit_proving_key;

--- a/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
@@ -1,4 +1,5 @@
 #include "composer_helper.hpp"
+#include "polynomials/polynomial.hpp"
 #include <cstddef>
 #include <proof_system/flavor/flavor.hpp>
 #include <honk/pcs/commitment_key.hpp>
@@ -232,6 +233,8 @@ std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute
     compute_standard_honk_id_polynomials<CircuitConstructor::program_width>(circuit_proving_key.get());
 
     compute_first_and_last_lagrange_polynomials(circuit_proving_key.get());
+
+    circuit_proving_key->polynomial_cache.put("z_perm", Polynomial<barretenberg::fr>(1));
 
     return circuit_proving_key;
 }

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.hpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.hpp
@@ -13,7 +13,7 @@ namespace honk {
  */
 class StandardHonkComposer {
   public:
-    static constexpr waffle::ComposerType type = waffle::ComposerType::STANDARD;
+    static constexpr waffle::ComposerType type = waffle::ComposerType::STANDARD_HONK;
 
     static constexpr size_t UINT_LOG2_BASE = 2;
     // An instantiation of the circuit constructor that only depends on arithmetization, not  on the proof system

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -2,7 +2,7 @@
 #include "numeric/uint256/uint256.hpp"
 #include <cstdint>
 #include <honk/proof_system/prover.hpp>
-
+#include <honk/sumcheck/polynomials/multivariates.hpp>
 #include <gtest/gtest.h>
 
 using namespace honk;
@@ -264,7 +264,10 @@ TEST(StandarHonkComposer, BaseCase)
 
     auto prover = composer.create_unrolled_prover();
     // waffle::Verifier verifier = composer.create_verifier();
+    // TODO(Cody): multivariate_d can't be a template parameter.
+    auto multivariates = honk::sumcheck::Multivariates<fr, 17, 1>(prover.proving_key);
 
+    // Next up: construct sumcheck module from multivariates.
     waffle::plonk_proof proof = prover.construct_proof();
 
     // bool result = verifier.verify_proof(proof); // instance, prover.reference_string.SRS_T2);

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -265,8 +265,8 @@ TEST(StandarHonkComposer, BaseCase)
     auto prover = composer.create_unrolled_prover();
     // waffle::Verifier verifier = composer.create_verifier();
     // TODO(Cody): multivariate_d can't be a template parameter.
-    auto multivariates = honk::sumcheck::Multivariates<fr, 17, 1>(prover.proving_key);
-    (void)multivariates;
+    // auto multivariates = honk::sumcheck::Multivariates<fr, 17, 1>(prover.proving_key);
+    // (void)multivariates;
     // Next up: construct sumcheck module from multivariates.
     waffle::plonk_proof proof = prover.construct_proof();
 

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -266,7 +266,7 @@ TEST(StandarHonkComposer, BaseCase)
     // waffle::Verifier verifier = composer.create_verifier();
     // TODO(Cody): multivariate_d can't be a template parameter.
     auto multivariates = honk::sumcheck::Multivariates<fr, 17, 1>(prover.proving_key);
-
+    (void)multivariates;
     // Next up: construct sumcheck module from multivariates.
     waffle::plonk_proof proof = prover.construct_proof();
 

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -264,10 +264,8 @@ TEST(StandarHonkComposer, BaseCase)
 
     auto prover = composer.create_unrolled_prover();
     // waffle::Verifier verifier = composer.create_verifier();
-    // TODO(Cody): multivariate_d can't be a template parameter.
-    // auto multivariates = honk::sumcheck::Multivariates<fr, 17, 1>(prover.proving_key);
-    // (void)multivariates;
-    // Next up: construct sumcheck module from multivariates.
+    auto multivariates = honk::sumcheck::Multivariates<fr, 17>(prover.proving_key);
+    (void)multivariates;
     waffle::plonk_proof proof = prover.construct_proof();
 
     // bool result = verifier.verify_proof(proof); // instance, prover.reference_string.SRS_T2);

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -1,5 +1,6 @@
 #include "standard_honk_composer.hpp"
 #include "numeric/uint256/uint256.hpp"
+#include "plonk/proof_system/types/polynomial_manifest.hpp"
 #include <cstdint>
 #include <honk/proof_system/prover.hpp>
 #include <honk/sumcheck/polynomials/multivariates.hpp>
@@ -264,7 +265,7 @@ TEST(StandarHonkComposer, BaseCase)
 
     auto prover = composer.create_unrolled_prover();
     // waffle::Verifier verifier = composer.create_verifier();
-    auto multivariates = honk::sumcheck::Multivariates<fr, 17>(prover.proving_key);
+    auto multivariates = honk::sumcheck::Multivariates<fr, waffle::STANDARD_HONK_MANIFEST_SIZE>(prover.proving_key);
     (void)multivariates;
     waffle::plonk_proof proof = prover.construct_proof();
 

--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -1,11 +1,18 @@
 #include "prover.hpp"
-// #include <honk/sumcheck/sumcheck.hpp> // will need
+#include <honk/sumcheck/sumcheck.hpp> // will need
+#include <array>
 #include <honk/sumcheck/polynomials/univariate.hpp> // will go away
 #include <honk/pcs/commitment_key.hpp>
 #include <vector>
 #include "ecc/curves/bn254/fr.hpp"
 #include "ecc/curves/bn254/g1.hpp"
+#include <honk/sumcheck/polynomials/multivariates.hpp>
+#include <honk/sumcheck/relations/arithmetic_relation.hpp>
+#include <honk/sumcheck/relations/grand_product_computation_relation.hpp>
+#include <honk/sumcheck/relations/grand_product_initialization_relation.hpp>
+#include "plonk/proof_system/types/polynomial_manifest.hpp"
 #include "proof_system/flavor/flavor.hpp"
+#include "transcript/transcript_wrappers.hpp"
 
 namespace honk {
 
@@ -273,32 +280,39 @@ template <typename settings> void Prover<settings>::execute_relation_check_round
 {
     // queue.flush_queue(); // NOTE: Don't remove; we may reinstate the queue
 
+    using Multivariates = sumcheck::Multivariates<barretenberg::fr, waffle::STANDARD_HONK_MANIFEST_SIZE>;
+    using Transcript = transcript::StandardTranscript;
+    using Sumcheck = sumcheck::Sumcheck<Multivariates,
+                                        Transcript,
+                                        sumcheck::ArithmeticRelation,
+                                        sumcheck::GrandProductComputationRelation,
+                                        sumcheck::GrandProductInitializationRelation>;
+
     // Compute alpha challenge
     transcript.apply_fiat_shamir("alpha");
 
-    // TODO(luke): Run Sumcheck. For now, mock univariates.
-    for (size_t round_idx = 0; round_idx < proving_key->log_n; round_idx++) {
-        honk::sumcheck::Univariate<barretenberg::fr, honk::StandardHonk::MAX_RELATION_LENGTH> round_univariate;
-        for (auto eval : round_univariate.evaluations) {
-            eval = round_idx;
-        }
-        transcript.add_element("univariate_" + std::to_string(proving_key->log_n - round_idx),
-                               round_univariate.to_buffer());
-        transcript.apply_fiat_shamir("u_" + std::to_string(proving_key->log_n - round_idx));
-    }
+    auto multivariates = Multivariates(proving_key);
+    auto sumcheck = Sumcheck(multivariates, transcript);
 
-    transcript.add_element("w_1", barretenberg::fr(100).to_buffer());
-    transcript.add_element("w_2", barretenberg::fr(101).to_buffer());
-    transcript.add_element("w_3", barretenberg::fr(102).to_buffer());
-    transcript.add_element("sigma_1", barretenberg::fr(103).to_buffer());
-    transcript.add_element("sigma_2", barretenberg::fr(104).to_buffer());
-    transcript.add_element("sigma_3", barretenberg::fr(105).to_buffer());
-    transcript.add_element("q_1", barretenberg::fr(106).to_buffer());
-    transcript.add_element("q_2", barretenberg::fr(107).to_buffer());
-    transcript.add_element("q_3", barretenberg::fr(108).to_buffer());
-    transcript.add_element("q_m", barretenberg::fr(109).to_buffer());
-    transcript.add_element("q_c", barretenberg::fr(110).to_buffer());
-    transcript.add_element("z_perm", barretenberg::fr(111).to_buffer());
+    sumcheck.execute_prover();
+
+    transcript.add_element("w_1", multivariates.folded_polynomials[1][0].to_buffer());
+    transcript.add_element("w_2", multivariates.folded_polynomials[1][0].to_buffer());
+    transcript.add_element("w_3", multivariates.folded_polynomials[2][0].to_buffer());
+    transcript.add_element("z_perm", multivariates.folded_polynomials[3][0].to_buffer());
+    transcript.add_element("q_m", multivariates.folded_polynomials[4][0].to_buffer());
+    transcript.add_element("q_1", multivariates.folded_polynomials[5][0].to_buffer());
+    transcript.add_element("q_2", multivariates.folded_polynomials[6][0].to_buffer());
+    transcript.add_element("q_3", multivariates.folded_polynomials[7][0].to_buffer());
+    transcript.add_element("q_c", multivariates.folded_polynomials[8][0].to_buffer());
+    transcript.add_element("sigma_1", multivariates.folded_polynomials[9][0].to_buffer());
+    transcript.add_element("sigma_2", multivariates.folded_polynomials[10][0].to_buffer());
+    transcript.add_element("sigma_3", multivariates.folded_polynomials[11][0].to_buffer());
+    transcript.add_element("id_1", multivariates.folded_polynomials[12][0].to_buffer());
+    transcript.add_element("id_2", multivariates.folded_polynomials[13][0].to_buffer());
+    transcript.add_element("id_3", multivariates.folded_polynomials[14][0].to_buffer());
+    transcript.add_element("L_first", multivariates.folded_polynomials[15][0].to_buffer());
+    transcript.add_element("L_last", multivariates.folded_polynomials[16][0].to_buffer());
 }
 
 /**

--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -296,6 +296,7 @@ template <typename settings> void Prover<settings>::execute_relation_check_round
 
     sumcheck.execute_prover();
 
+    // TODO(Cody): Execute as a loop over polynomial manifest? Things thare are called *_lagrange
     transcript.add_element("w_1", multivariates.folded_polynomials[1][0].to_buffer());
     transcript.add_element("w_2", multivariates.folded_polynomials[1][0].to_buffer());
     transcript.add_element("w_3", multivariates.folded_polynomials[2][0].to_buffer());

--- a/cpp/src/aztec/honk/proof_system/verifier.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.cpp
@@ -72,7 +72,7 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
     const size_t num_polys = program_settings::num_polys;
     using FF = typename program_settings::fr;
     using Transcript = typename program_settings::Transcript;
-    using Multivariates = Multivariates<FF, num_polys, multivariate_d>;
+    using Multivariates = Multivariates<FF, num_polys>;
 
     key->program_width = program_settings::program_width;
 

--- a/cpp/src/aztec/honk/proof_system/verifier.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.cpp
@@ -9,6 +9,8 @@
 #include <polynomials/polynomial_arithmetic.hpp>
 #include <math.h>
 
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
 using namespace barretenberg;
 using namespace honk::sumcheck;
 

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
@@ -1,5 +1,7 @@
 #pragma once // just adding these willy-nilly
+#include "numeric/bitop/get_msb.hpp"
 #include "proof_system/proving_key/proving_key.hpp"
+#include "transcript/transcript_wrappers.hpp"
 #include <array>
 #include <algorithm>
 #include <span>
@@ -55,24 +57,32 @@ bool span_arrays_equal(auto& lhs, auto& rhs)
  * NOTE: With ~40 columns, prob only want to allocate 256 EdgeGroup's at once to keep stack under 1MB?
  * TODO(Cody): might want to just do C-style multidimensional array? for guaranteed adjacency?
  */
-template <class FF_, size_t num_polys, size_t num_vars> class Multivariates {
+template <class FF_, size_t num_polys> class Multivariates {
   public:
     using FF = FF_;
-    const static size_t multivariate_d = num_vars;
-    const static size_t multivariate_n = 1 << num_vars;
+    const size_t multivariate_n;
+    const size_t multivariate_d;
     static constexpr size_t num = num_polys;
 
     std::array<std::span<FF>, num_polys> full_polynomials;
-    // TODO(Cody): adjacency issues with std::array of std::arrays?
+    // TODO(Cody): adjacency issues with std::array of std::vectors?
     // IMPROVEMENT(Cody): for each round after the first, we could release half of the memory reserved by
     // folded_polynomials.
-    std::array<std::array<FF, (multivariate_n >> 1)>, num_polys> folded_polynomials;
+    std::array<std::vector<FF>, num_polys> folded_polynomials;
 
     Multivariates() = default;
 
     // TODO(Cody): static span extent below more efficient
     explicit Multivariates(std::array<std::span<FF>, num_polys> full_polynomials)
-        : full_polynomials(full_polynomials){};
+        : multivariate_n(full_polynomials[0].size())
+        , multivariate_d(numeric::get_msb(multivariate_n))
+        , full_polynomials(full_polynomials)
+    {
+        for (auto& polynomial : folded_polynomials) {
+            polynomial.reserve(multivariate_n >> 1);
+            polynomial.resize(multivariate_n >> 1);
+        }
+    };
 
     explicit Multivariates(const std::shared_ptr<waffle::proving_key>& proving_key)
     {
@@ -81,6 +91,11 @@ template <class FF_, size_t num_polys, size_t num_vars> class Multivariates {
             full_polynomials[i] = proving_key->polynomial_cache.get(std::string(label));
         }
     }
+
+    explicit Multivariates(transcript::StandardTranscript transcript)
+        : multivariate_n(transcript.get_field_element("circuit_size"))
+        , multivariate_d(numeric::get_msb(multivariate_n))
+    {}
 
     // TODO(Cody): Rename. fold is not descriptive, and it's already in use in the Gemini context.
     //             Probably just call it partial_evaluation?
@@ -112,11 +127,10 @@ template <class FF_, size_t num_polys, size_t num_vars> class Multivariates {
         }
     };
 
-    std::array<FF, num_polys> batch_evaluate(std::array<FF, num_vars> input)
+    std::array<FF, num_polys> batch_evaluate()
     {
         // TODO(Cody): these just get extracted from the folded multivariates
         // For now, at least initialize properly.
-        static_cast<void>(input);
         std::array<FF, num_polys> result;
         for (auto& entry : result) {
             entry = 1;

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
@@ -1,4 +1,5 @@
 #pragma once // just adding these willy-nilly
+#include "proof_system/proving_key/proving_key.hpp"
 #include <array>
 #include <algorithm>
 #include <span>
@@ -73,6 +74,16 @@ template <class FF_, size_t num_polys, size_t num_vars> class Multivariates {
     explicit Multivariates(std::array<std::span<FF>, num_polys> full_polynomials)
         : full_polynomials(full_polynomials){};
 
+    explicit Multivariates(const std::shared_ptr<waffle::proving_key>& proving_key)
+    {
+        for (size_t i = 0; i < waffle::STANDARD_HONK_MANIFEST_SIZE; i++) {
+            auto label = proving_key->polynomial_manifest[i].polynomial_label;
+            full_polynomials[i] = proving_key->polynomial_cache.get(std::string(label));
+        }
+    }
+
+    // TODO(Cody): Rename. fold is not descriptive, and it's already in use in the Gemini context.
+    //             Probably just call it partial_evaluation?
     /**
      * @brief Evaluate at the round challenge and prepare class for next round.
      * Illustration of layout in example of first round when d==3 (showing just one Honk polynomial,
@@ -90,7 +101,6 @@ template <class FF_, size_t num_polys, size_t num_vars> class Multivariates {
      *
      * @param challenge
      */
-
     void fold(auto& polynomials, size_t round_size, const FF& round_challenge)
     {
         // after the first round, operate in place on folded_polynomials

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
@@ -98,7 +98,8 @@ template <class FF_, size_t num_polys> class Multivariates {
     }
 
     explicit Multivariates(transcript::StandardTranscript transcript)
-        : multivariate_n(transcript.get_field_element("circuit_size"))
+        : multivariate_n(
+              static_cast<size_t>(transcript.get_field_element("circuit_size").from_montgomery_form().data[0]))
         , multivariate_d(numeric::get_msb(multivariate_n))
     {}
 

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
@@ -79,16 +79,21 @@ template <class FF_, size_t num_polys> class Multivariates {
         , full_polynomials(full_polynomials)
     {
         for (auto& polynomial : folded_polynomials) {
-            polynomial.reserve(multivariate_n >> 1);
             polynomial.resize(multivariate_n >> 1);
         }
     };
 
     explicit Multivariates(const std::shared_ptr<waffle::proving_key>& proving_key)
+        : multivariate_n(proving_key->n)
+        , multivariate_d(proving_key->log_n)
     {
         for (size_t i = 0; i < waffle::STANDARD_HONK_MANIFEST_SIZE; i++) {
             auto label = proving_key->polynomial_manifest[i].polynomial_label;
             full_polynomials[i] = proving_key->polynomial_cache.get(std::string(label));
+        }
+
+        for (auto& polynomial : folded_polynomials) {
+            polynomial.resize(multivariate_n >> 1);
         }
     }
 

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.test.cpp
@@ -10,7 +10,7 @@ namespace test_sumcheck_polynomials {
 template <class FF> class MultivariatesTests : public testing::Test {
   public:
     // template <size_t num_polys, size_t multivariate_d>
-    // using Multivariates = Multivariates<FF, num_polys, multivariate_d>;
+    // using Multivariates = Multivariates<FF, num_polys>;
     // TODO(Cody): reinstate this
     //     /*
     //         u2 = 1
@@ -37,7 +37,7 @@ template <class FF> class MultivariatesTests : public testing::Test {
     //         auto group_2 = EdgeGroup<num_polys>({ Y12, Y22 });
 
     //         std::array<EdgeGroup<num_polys>, multivariate_d> groups{ group_1, group_2 };
-    //         auto polys = Multivariates<num_polys, multivariate_d>(groups);
+    //         auto polys = Multivariates<num_polys>(groups);
 
     //         FF u2 = 1;
     //         polys.fold(n, u2);
@@ -69,7 +69,7 @@ TYPED_TEST(MultivariatesTests, Constructor)
     std::array<FF, 3> f3 = { -1, -1, 1 };
 
     auto full_polynomials = std::array<std::span<FF>, num_polys>({ f0, f1, f2, f3 });
-    auto multivariates = Multivariates<FF, num_polys, multivariate_d>(full_polynomials);
+    auto multivariates = Multivariates<FF, num_polys>(full_polynomials);
 
     ASSERT_TRUE(span_arrays_equal(full_polynomials, multivariates.full_polynomials));
 }
@@ -85,12 +85,46 @@ TYPED_TEST(MultivariatesTests, Constructor)
     (v01 * (1-X1) + v11 * X1) *   X2   ~~>    (v00 * (1-u2) + v01 * u2) * (1-X1)
   + (v00 * (1-X1) + v10 * X1) * (1-X2) ~~>                                    + (v11 * u2 + v10 * (1-u2)) * X1
  */
-TYPED_TEST(MultivariatesTests, FoldTwo)
+TYPED_TEST(MultivariatesTests, FoldTwoRoundsSpecial)
 {
     MULTIVARIATES_TESTS_TYPE_ALIASES
 
-    const size_t num_polys(2);
-    const size_t multivariate_d(1);
+    const size_t num_polys(1);
+    const size_t multivariate_d(2);
+    const size_t multivariate_n(1 << multivariate_d);
+
+    FF v00 = 1;
+    FF v01 = 2;
+    FF v10 = 3;
+    FF v11 = 4;
+
+    std::array<FF, 4> f0 = { v00, v01, v10, v11 };
+
+    auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
+    auto multivariates = Multivariates<FF, num_polys>(full_polynomials);
+
+    FF round_challenge_2 = 1;
+    FF expected_lo = v00 * (FF(1) - round_challenge_2) + v01 * round_challenge_2; // 2
+    FF expected_hi = v11 * round_challenge_2 + v10 * (FF(1) - round_challenge_2); // 4
+
+    multivariates.fold(multivariates.full_polynomials, multivariate_n, round_challenge_2);
+
+    EXPECT_EQ(multivariates.folded_polynomials[0][0], expected_lo);
+    EXPECT_EQ(multivariates.folded_polynomials[0][1], expected_hi);
+
+    FF round_challenge_1 = 2;
+    FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1; // 6
+
+    multivariates.fold(multivariates.folded_polynomials, multivariate_n >> 1, round_challenge_1);
+    EXPECT_EQ(multivariates.folded_polynomials[0][0], expected_val);
+}
+
+TYPED_TEST(MultivariatesTests, FoldTwoRoundsGeneric)
+{
+    MULTIVARIATES_TESTS_TYPE_ALIASES
+
+    const size_t num_polys(1);
+    const size_t multivariate_d(2);
     const size_t multivariate_n(1 << multivariate_d);
 
     FF v00 = FF::random_element();
@@ -98,24 +132,24 @@ TYPED_TEST(MultivariatesTests, FoldTwo)
     FF v10 = FF::random_element();
     FF v11 = FF::random_element();
 
-    std::array<FF, 2> f0 = { v00, v10 };
-    std::array<FF, 2> f1 = { v01, v11 };
+    std::array<FF, 4> f0 = { v00, v01, v10, v11 };
 
-    auto full_polynomials = std::array<std::span<FF>, 2>({ f0, f1 });
-    auto multivariates = Multivariates<FF, num_polys, multivariate_d>(full_polynomials);
+    auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
+    auto multivariates = Multivariates<FF, num_polys>(full_polynomials);
 
     FF round_challenge_2 = FF::random_element();
-    FF expected_lo = v00 * (FF(1) - round_challenge_2) + v10 * round_challenge_2;
-    FF expected_hi = v11 * round_challenge_2 + v01 * (FF(1) - round_challenge_2);
+    FF expected_lo = v00 * (FF(1) - round_challenge_2) + v01 * round_challenge_2;
+    FF expected_hi = v11 * round_challenge_2 + v10 * (FF(1) - round_challenge_2);
 
     multivariates.fold(multivariates.full_polynomials, multivariate_n, round_challenge_2);
 
     EXPECT_EQ(multivariates.folded_polynomials[0][0], expected_lo);
-    EXPECT_EQ(multivariates.folded_polynomials[1][0], expected_hi);
+    EXPECT_EQ(multivariates.folded_polynomials[0][1], expected_hi);
 
     FF round_challenge_1 = FF::random_element();
     FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
 
+    info(expected_val);
     multivariates.fold(multivariates.folded_polynomials, multivariate_n >> 1, round_challenge_1);
     EXPECT_EQ(multivariates.folded_polynomials[0][0], expected_val);
 }

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.test.cpp
@@ -60,7 +60,7 @@ TYPED_TEST(MultivariatesTests, Constructor)
     MULTIVARIATES_TESTS_TYPE_ALIASES
 
     const size_t num_polys(4);
-    const size_t multivariate_d(2);
+    // const size_t multivariate_d(2);
     // const size_t multivariate_n(1 << multivariate_d);
 
     std::array<FF, 3> f0 = { 0, 0, 1 };

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
@@ -26,6 +26,8 @@ using FF = barretenberg::fr;
 template <size_t multivariate_d, size_t MAX_RELATION_LENGTH, size_t num_polys>
 void mock_prover_contributions_to_transcript(Transcript& transcript)
 {
+    transcript.add_element("circuit_size", FF(1 << multivariate_d).to_buffer());
+
     // Write d-many arbitrary round univariates to the transcript
     for (size_t round_idx = 0; round_idx < multivariate_d; round_idx++) {
         auto round_univariate = Univariate<FF, MAX_RELATION_LENGTH>();
@@ -44,7 +46,7 @@ TEST(Sumcheck, Prover)
     const size_t multivariate_n(1 << multivariate_d);
     const size_t max_relation_length = 4;
 
-    using Multivariates = ::Multivariates<FF, num_polys, multivariate_d>;
+    using Multivariates = ::Multivariates<FF, num_polys>;
 
     std::array<FF, 2> w_l = { 1, 2 };
     std::array<FF, 2> w_r = { 1, 2 };
@@ -91,7 +93,7 @@ TEST(Sumcheck, Verifier)
     const size_t multivariate_n(1 << multivariate_d);
     const size_t max_relation_length = 5;
 
-    using Multivariates = ::Multivariates<FF, num_polys, multivariate_d>;
+    using Multivariates = ::Multivariates<FF, num_polys>;
 
     auto transcript = Transcript(transcript::Manifest());
     mock_prover_contributions_to_transcript<multivariate_d, max_relation_length, num_polys>(transcript);

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
@@ -45,6 +45,7 @@ TEST(Sumcheck, Prover)
     const size_t multivariate_d(1);
     const size_t multivariate_n(1 << multivariate_d);
     const size_t max_relation_length = 4;
+    constexpr size_t fr_size = 32;
 
     using Multivariates = ::Multivariates<FF, num_polys>;
 
@@ -72,7 +73,18 @@ TEST(Sumcheck, Prover)
         q_c, sigma_1, sigma_2, sigma_3, id_1,         id_2, id_3, lagrange_1
     };
 
-    auto transcript = Transcript(transcript::Manifest());
+    std::vector<transcript::Manifest::RoundManifest> manifest_rounds;
+    for (size_t i = 0; i < multivariate_d; i++) {
+        auto label = std::to_string(multivariate_d - i);
+        manifest_rounds.emplace_back(
+            transcript::Manifest::RoundManifest({ { .name = "univariate_" + label,
+                                                    .num_bytes = fr_size * honk::StandardHonk::MAX_RELATION_LENGTH,
+                                                    .derived_by_verifier = false } },
+                                                /* challenge_name = */ "u_" + label,
+                                                /* num_challenges_in = */ 1));
+    }
+
+    auto transcript = Transcript(transcript::Manifest(manifest_rounds));
 
     auto multivariates = Multivariates(full_polynomials);
 

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
@@ -43,8 +43,9 @@ TEST(Sumcheck, Prover)
 {
     const size_t num_polys(proving_system::StandardArithmetization::NUM_POLYNOMIALS);
     const size_t multivariate_d(1);
-    const size_t multivariate_n(1 << multivariate_d);
-    const size_t max_relation_length = 4;
+    // const size_t multivariate_n(1 << multivariate_d);
+
+    // const size_t max_relation_length = 4;
     constexpr size_t fr_size = 32;
 
     using Multivariates = ::Multivariates<FF, num_polys>;
@@ -102,7 +103,7 @@ TEST(Sumcheck, Verifier)
 {
     const size_t num_polys(proving_system::StandardArithmetization::NUM_POLYNOMIALS);
     const size_t multivariate_d(1);
-    const size_t multivariate_n(1 << multivariate_d);
+    // const size_t multivariate_n(1 << multivariate_d);
     const size_t max_relation_length = 5;
 
     using Multivariates = ::Multivariates<FF, num_polys>;

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
@@ -208,7 +208,6 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
             accumulate_relation_univariates<>();
         }
 
-        FF running_challenge(1);
         auto result = batch_over_relations<Univariate<FF, MAX_RELATION_LENGTH>>(univariate_accumulators,
                                                                                 relation_separator_challenge);
 

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
@@ -26,7 +26,7 @@ TEST(SumcheckRound, ComputeUnivariateProver)
     const size_t max_relation_length = 5;
 
     using FF = barretenberg::fr;
-    using Multivariates = ::Multivariates<FF, num_polys, multivariate_d>;
+    using Multivariates = ::Multivariates<FF, num_polys>;
 
     std::array<FF, 2> w_l = { 1, 2 };
     std::array<FF, 2> w_r = { 1, 2 };
@@ -78,7 +78,7 @@ TEST(SumcheckRound, ComputeUnivariateVerifier)
     const size_t max_relation_length = 5;
 
     using FF = barretenberg::fr;
-    using Multivariates = ::Multivariates<FF, num_polys, multivariate_d>;
+    using Multivariates = ::Multivariates<FF, num_polys>;
 
     FF w_l = { 1 };
     FF w_r = { 2 };
@@ -131,7 +131,7 @@ TEST(SumcheckRound, ComputeUnivariateVerifier)
 //     using Fr = barretenberg::fr;
 //     using Edge = Edge<Fr>;
 //     using EdgeGroup = EdgeGroup<Fr, num_polys>;
-//     using Multivariates = Multivariates<Fr, num_polys, multivariate_d>;
+//     using Multivariates = Multivariates<Fr, num_polys>;
 //     using Univariate = Univariate<Fr, max_relation_length>;
 //     // TODO(Cody): move this out of round.
 //     EdgeGroup group0({ Edge({ 1, 2 }),

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
@@ -22,7 +22,7 @@ namespace test_sumcheck_round {
 TEST(SumcheckRound, ComputeUnivariateProver)
 {
     const size_t num_polys(proving_system::StandardArithmetization::NUM_POLYNOMIALS);
-    const size_t multivariate_d(1);
+    // const size_t multivariate_d(1);
     const size_t max_relation_length = 5;
 
     using FF = barretenberg::fr;
@@ -73,9 +73,9 @@ TEST(SumcheckRound, ComputeUnivariateProver)
 TEST(SumcheckRound, ComputeUnivariateVerifier)
 {
     const size_t num_polys(proving_system::StandardArithmetization::NUM_POLYNOMIALS);
-    const size_t multivariate_d(1);
-    const size_t multivariate_n(1 << multivariate_d);
-    const size_t max_relation_length = 5;
+    // const size_t multivariate_d(1);
+    // const size_t multivariate_n(1 << multivariate_d);
+    // const size_t max_rezlation_length = 5;
 
     using FF = barretenberg::fr;
     using Multivariates = ::Multivariates<FF, num_polys>;
@@ -104,7 +104,7 @@ TEST(SumcheckRound, ComputeUnivariateVerifier)
     std::vector<FF> purported_evaluations = { w_l, w_r,     w_o,     z_perm,  z_perm_shift, q_m,  q_l,  q_r,       q_o,
                                               q_c, sigma_1, sigma_2, sigma_3, id_1,         id_2, id_3, lagrange_1 };
 
-    size_t round_size = 1;
+    // size_t round_size = 1;
     auto relations = std::tuple(
         ArithmeticRelation<FF>(), GrandProductComputationRelation<FF>(), GrandProductInitializationRelation<FF>());
     auto round = SumcheckRound<FF,

--- a/cpp/src/aztec/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
+++ b/cpp/src/aztec/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
@@ -305,6 +305,9 @@ void KateCommitmentScheme<settings>::batch_verify(const transcript::StandardTran
             kate_g1_elements.insert({ label, element });
             break;
         }
+        case PolynomialSource::OTHER: {
+            break;
+        }
         }
 
         // We iterate over the polynomials in polynomial_manifest to add their commitments,

--- a/cpp/src/aztec/plonk/proof_system/constants.hpp
+++ b/cpp/src/aztec/plonk/proof_system/constants.hpp
@@ -7,6 +7,7 @@ enum ComposerType {
     STANDARD,
     TURBO,
     PLOOKUP,
+    STANDARD_HONK,
 };
 
 // This variable sets the composer (TURBO or ULTRA) of the entire stdlib and rollup modules.

--- a/cpp/src/aztec/plonk/proof_system/types/polynomial_manifest.hpp
+++ b/cpp/src/aztec/plonk/proof_system/types/polynomial_manifest.hpp
@@ -205,8 +205,8 @@ class PolynomialManifest {
     {
         switch (composer_type) {
         case ComposerType::STANDARD: {
-            std::copy(standard_honk_polynomial_manifest,
-                      standard_honk_polynomial_manifest + STANDARD_HONK_MANIFEST_SIZE,
+            std::copy(standard_polynomial_manifest,
+                      standard_polynomial_manifest + STANDARD_UNROLLED_MANIFEST_SIZE,
                       std::back_inserter(manifest));
             break;
         };
@@ -219,6 +219,12 @@ class PolynomialManifest {
         case ComposerType::PLOOKUP: {
             std::copy(ultra_polynomial_manifest,
                       ultra_polynomial_manifest + ULTRA_UNROLLED_MANIFEST_SIZE,
+                      std::back_inserter(manifest));
+            break;
+        };
+        case ComposerType::STANDARD_HONK: {
+            std::copy(standard_honk_polynomial_manifest,
+                      standard_honk_polynomial_manifest + STANDARD_HONK_MANIFEST_SIZE,
                       std::back_inserter(manifest));
             break;
         };

--- a/cpp/src/aztec/plonk/proof_system/types/polynomial_manifest.hpp
+++ b/cpp/src/aztec/plonk/proof_system/types/polynomial_manifest.hpp
@@ -6,7 +6,7 @@
 
 namespace waffle {
 
-enum PolynomialSource { WITNESS, SELECTOR, PERMUTATION };
+enum PolynomialSource { WITNESS, SELECTOR, PERMUTATION, OTHER };
 
 enum PolynomialRepresentation { MONOMIAL, COSET_FFT };
 
@@ -48,8 +48,8 @@ enum PolynomialIndex {
     S,
     Z,
     Z_LOOKUP,
-    // LAGRANGE_FIRST,
-    // LAGRANGE_LAST,
+    LAGRANGE_FIRST,
+    LAGRANGE_LAST,
     // SUBGROUP_GENERATOR,
     MAX_NUM_POLYNOMIALS,
 };
@@ -170,6 +170,29 @@ static constexpr PolynomialDescriptor ultra_polynomial_manifest[ULTRA_UNROLLED_M
     PolynomialDescriptor("ID_4", "id_4", false, false, PERMUTATION, ID_4),                      //
 };
 
+// TODO(Cody): Get this right; just using for now to extract names.
+static constexpr size_t STANDARD_HONK_MANIFEST_SIZE = 17;
+static constexpr PolynomialDescriptor standard_honk_polynomial_manifest[STANDARD_HONK_MANIFEST_SIZE]{
+    PolynomialDescriptor("W_1", "w_1_lagrange", false, false, WITNESS, W_1), //
+    PolynomialDescriptor("W_2", "w_2_lagrange", false, false, WITNESS, W_2), //
+    PolynomialDescriptor("W_3", "w_3_lagrange", false, false, WITNESS, W_3), //
+    PolynomialDescriptor("Z_PERM", "z_perm", true, true, WITNESS, Z),        //
+    // PolynomialDescriptor("Z_PERM_SHIFT", "z_perm_shift", true, true, WITNESS, Z_LOOKUP),                     //
+    PolynomialDescriptor("Q_M", "q_m_lagrange", true, false, SELECTOR, Q_M),                         //
+    PolynomialDescriptor("Q_1", "q_1_lagrange", true, false, SELECTOR, Q_1),                         //
+    PolynomialDescriptor("Q_2", "q_2_lagrange", true, false, SELECTOR, Q_2),                         //
+    PolynomialDescriptor("Q_3", "q_3_lagrange", true, false, SELECTOR, Q_3),                         //
+    PolynomialDescriptor("Q_C", "q_c_lagrange", true, false, SELECTOR, Q_C),                         //
+    PolynomialDescriptor("SIGMA_1", "sigma_1_lagrange", false, false, PERMUTATION, SIGMA_1),         //
+    PolynomialDescriptor("SIGMA_2", "sigma_2_lagrange", false, false, PERMUTATION, SIGMA_2),         //
+    PolynomialDescriptor("SIGMA_3", "sigma_3_lagrange", true, false, PERMUTATION, SIGMA_3),          //
+    PolynomialDescriptor("ID_1", "id_1_lagrange", false, false, PERMUTATION, ID_1),                  //
+    PolynomialDescriptor("ID_2", "id_2_lagrange", false, false, PERMUTATION, ID_2),                  //
+    PolynomialDescriptor("ID_3", "id_3_lagrange", true, false, PERMUTATION, ID_3),                   //
+    PolynomialDescriptor("LAGRANGE_FIRST", "L_first_lagrange", false, false, OTHER, LAGRANGE_FIRST), //
+    PolynomialDescriptor("LAGRANGE_LAST", "L_last_lagrange", false, false, OTHER, LAGRANGE_LAST)     //
+};
+
 // Simple class allowing for access to a polynomial manifest based on composer type
 class PolynomialManifest {
   private:
@@ -182,8 +205,8 @@ class PolynomialManifest {
     {
         switch (composer_type) {
         case ComposerType::STANDARD: {
-            std::copy(standard_polynomial_manifest,
-                      standard_polynomial_manifest + STANDARD_UNROLLED_MANIFEST_SIZE,
+            std::copy(standard_honk_polynomial_manifest,
+                      standard_honk_polynomial_manifest + STANDARD_HONK_MANIFEST_SIZE,
                       std::back_inserter(manifest));
             break;
         };
@@ -242,6 +265,8 @@ class PrecomputedPolyList {
                 precomputed_poly_ids.emplace_back(label);
                 precomputed_poly_ids.emplace_back(label + "_fft");
                 precomputed_poly_ids.emplace_back(label + "_lagrange");
+                break;
+            case PolynomialSource::OTHER:
                 break;
             }
         }

--- a/cpp/src/aztec/plonk/proof_system/utils/kate_verification.hpp
+++ b/cpp/src/aztec/plonk/proof_system/utils/kate_verification.hpp
@@ -88,6 +88,9 @@ void populate_kate_element_map(verification_key* key,
             kate_g1_elements.insert({ label, element });
             break;
         }
+        case PolynomialSource::OTHER: {
+            break;
+        }
         }
         Field kate_fr_scalar(0);
         if (item.requires_shifted_evaluation) {

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -101,20 +101,25 @@ struct StandardHonk {
         }
 
         // Rounds 4 + num_sumcheck_rounds
-        manifest_rounds.emplace_back(transcript::Manifest::RoundManifest(
+        manifest_rounds.emplace_back(transcript::Manifest::RoundManifest(       
             {
-              { .name = "w_1",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 0 },
-              { .name = "w_2",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 1 },
-              { .name = "w_3",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 2 },
-              { .name = "sigma_1",      .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 3 },
-              { .name = "sigma_2",      .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 4 },
-              { .name = "sigma_3",      .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 5 },
-              { .name = "q_1",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 6 },
-              { .name = "q_2",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 7 },
-              { .name = "q_3",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 8 },
-              { .name = "q_m",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 9 },
-              { .name = "q_c",          .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 10 },
-              { .name = "z_perm",       .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 11 },
+              { .name = "w_1",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 0 },
+              { .name = "w_2",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 1 },
+              { .name = "w_3",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 2 },
+              { .name = "z_perm",  .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 3 },
+              { .name = "q_m",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 4 },
+              { .name = "q_1",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 5 },
+              { .name = "q_2",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 6 },
+              { .name = "q_3",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 7 },
+              { .name = "q_c",     .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 8 },
+              { .name = "sigma_1", .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 9 },
+              { .name = "sigma_2", .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 10 },
+              { .name = "sigma_3", .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 11 },
+              { .name = "id_1",    .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 12 },
+              { .name = "id_2",    .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 13 },
+              { .name = "id_3",    .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 14 },
+              { .name = "L_first", .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 15 },
+              { .name = "L_last",  .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 16 },
             },
             /* challenge_name = */ "rho",
             /* num_challenges_in = */ 11, /* TODO(Cody): magic number! Where should this be specified? */

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -11,7 +11,7 @@ struct StandardArithmetization {
         W_R,
         W_O,
         Z_PERM,
-        Z_PERM_SHIFT,
+        Z_PERM_SHIFT, // TODO(Cody): Hid ethis.
         Q_M,
         Q_L,
         Q_R,
@@ -36,7 +36,8 @@ struct StandardHonk {
   public:
     using Arithmetization = proving_system::StandardArithmetization;
     using MULTIVARIATE = Arithmetization::POLYNOMIAL;
-    static constexpr size_t STANDARD_UNROLLED_MANIFEST_SIZE = 12; // cf waffle::STANDARD_UNROLLED_MANIFEST_SIZE
+    // TODO(Cody): Where to specify? is this polynomial manifest size?
+    static constexpr size_t STANDARD_HONK_MANIFEST_SIZE = 16;
     static constexpr size_t MAX_RELATION_LENGTH = 5; // TODO(Cody): increment after fixing add_edge_contribution; kill
                                                      // after moving barycentric class out of relations
 
@@ -116,7 +117,7 @@ struct StandardHonk {
               { .name = "z_perm",       .num_bytes = fr_size, .derived_by_verifier = false, .challenge_map_index = 11 },
             },
             /* challenge_name = */ "rho",
-            /* num_challenges_in = */ STANDARD_UNROLLED_MANIFEST_SIZE - 1, /* TODO(Cody): this is bad. */
+            /* num_challenges_in = */ 11, /* TODO(Cody): magic number! Where should this be specified? */
             /* map_challenges_in = */ true));
 
         // Rounds 5 + num_sumcheck_rounds

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -36,8 +36,8 @@ struct StandardHonk {
   public:
     using Arithmetization = proving_system::StandardArithmetization;
     using MULTIVARIATE = Arithmetization::POLYNOMIAL;
-    // TODO(Cody): Where to specify? is this polynomial manifest size?
-    static constexpr size_t STANDARD_HONK_MANIFEST_SIZE = 16;
+    // // TODO(Cody): Where to specify? is this polynomial manifest size?
+    // static constexpr size_t STANDARD_HONK_MANIFEST_SIZE = 16;
     static constexpr size_t MAX_RELATION_LENGTH = 5; // TODO(Cody): increment after fixing add_edge_contribution; kill
                                                      // after moving barycentric class out of relations
 

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
@@ -127,6 +127,7 @@ size_t get_cache_capacity(size_t num_gates, waffle::ComposerType composer_type)
         break;
     };
     default: {
+        // Will hit this with Standard Honk.
         throw_or_abort("Received invalid composer type");
     }
     };

--- a/cpp/src/aztec/proof_system/proving_key/proving_key.cpp
+++ b/cpp/src/aztec/proof_system/proving_key/proving_key.cpp
@@ -24,7 +24,7 @@ namespace waffle {
 proving_key::proving_key(const size_t num_gates,
                          const size_t num_inputs,
                          std::shared_ptr<ProverReferenceString> const& crs,
-                         waffle::ComposerType type = waffle::STANDARD)
+                         waffle::ComposerType type = waffle::STANDARD) // TODO(Cody): Don't use default for Honk
     : composer_type(type)
     , n(num_gates)
     , log_n(numeric::get_msb(num_gates))

--- a/cpp/src/aztec/stdlib/recursion/verifier/verifier.hpp
+++ b/cpp/src/aztec/stdlib/recursion/verifier/verifier.hpp
@@ -103,6 +103,9 @@ void populate_kate_element_map(typename Curve::Composer* ctx,
             kate_g1_elements.insert({ label, element });
             break;
         }
+        case waffle::PolynomialSource::OTHER: {
+            break;
+        }
         }
         if (item.requires_shifted_evaluation) {
             const auto challenge = transcript.get_challenge_field_element_from_map("nu", poly_label + "_omega");


### PR DESCRIPTION
This PR makes the Honk Prover class construct a sumcheck object and execute this. Some of the higher-level changes this necessitates.

- It may be desirable to pre-compute sumcheck classes for some expected sizes (values of `multivariate_d`, but at least for now I make this size a runtime parameter. This necessitates replacing some uses of `std::array` with `std::vector`.
- Since Standard Honk and Standard Plonk have different sets of polynomials, we cannot reuse the Standard Plonk polynomial manifest (or its size). The polynomial manifest is selected using the Composer type, so I added another composer type for Standard Honk.
- I add a constructor of a `Multivariates` object from a proving key (needed for prover to create the object) and from a transcript (Sumcheck class in verifier mode had previously not constructed multivariates).

I regret leaving the insertion of the sumcheck evaluations in a rough form in the prover. This is done for expediency.