### PR TITLE
Public input permutation

### DIFF
--- a/cpp/src/aztec/common/assert.hpp
+++ b/cpp/src/aztec/common/assert.hpp
@@ -10,8 +10,12 @@
         true ? static_cast<void>(0) : static_cast<void>((expression));                                                 \
     }
 
+// NOLINTBEGIN
+
 #if NDEBUG
 #define ASSERT(expression) DONT_EVALUATE((expression))
 #else
 #define ASSERT(expression) assert((expression))
 #endif // NDEBUG
+
+// NOLINTEND

--- a/cpp/src/aztec/honk/circuit_constructors/standard_circuit_constructor.cpp
+++ b/cpp/src/aztec/honk/circuit_constructors/standard_circuit_constructor.cpp
@@ -32,7 +32,7 @@ void StandardCircuitConstructor::create_add_gate(const add_triple& in)
     q_3.emplace_back(in.c_scaling);
     q_c.emplace_back(in.const_scaling);
 
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -85,7 +85,7 @@ void StandardCircuitConstructor::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(fr::neg_one());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 
     w_l.emplace_back(temp_idx);
     w_r.emplace_back(in.c);
@@ -96,7 +96,7 @@ void StandardCircuitConstructor::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(in.d_scaling);
     q_c.emplace_back(in.const_scaling);
 
-    ++n;
+    ++num_gates;
 
     // in.d must be between 0 and 3
     // i.e. in.d * (in.d - 1) * (in.d - 2) = 0
@@ -111,7 +111,7 @@ void StandardCircuitConstructor::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(fr::neg_one());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 
     constexpr fr neg_two = -fr(2);
     w_l.emplace_back(temp_2_idx);
@@ -123,7 +123,7 @@ void StandardCircuitConstructor::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(fr::zero());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 }
 
 void StandardCircuitConstructor::create_big_add_gate_with_bit_extraction(const add_quad& in)
@@ -201,7 +201,7 @@ void StandardCircuitConstructor::create_mul_gate(const mul_triple& in)
     q_3.emplace_back(in.c_scaling);
     q_c.emplace_back(in.const_scaling);
 
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -225,7 +225,7 @@ void StandardCircuitConstructor::create_bool_gate(const uint32_t variable_index)
     q_3.emplace_back(fr::neg_one());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -247,7 +247,7 @@ void StandardCircuitConstructor::create_poly_gate(const poly_triple& in)
     q_3.emplace_back(in.q_o);
     q_c.emplace_back(in.q_c);
 
-    ++n;
+    ++num_gates;
 }
 
 void StandardCircuitConstructor::create_fixed_group_add_gate_with_init(const fixed_group_add_quad& in,
@@ -687,7 +687,7 @@ void StandardCircuitConstructor::fix_witness(const uint32_t witness_index, const
     q_2.emplace_back(fr::zero());
     q_3.emplace_back(fr::zero());
     q_c.emplace_back(-witness_value);
-    ++n;
+    ++num_gates;
 }
 
 uint32_t StandardCircuitConstructor::put_constant_variable(const barretenberg::fr& variable)
@@ -738,7 +738,7 @@ bool StandardCircuitConstructor::check_circuit()
 
     fr gate_sum;
     fr left, right, output;
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < num_gates; i++) {
         gate_sum = fr::zero();
         left = get_variable(w_l[i]);
         right = get_variable(w_r[i]);

--- a/cpp/src/aztec/honk/circuit_constructors/standard_circuit_constructor.hpp
+++ b/cpp/src/aztec/honk/circuit_constructors/standard_circuit_constructor.hpp
@@ -19,6 +19,7 @@ class StandardCircuitConstructor : public CircuitConstructorBase<STANDARD_HONK_W
 
     // These are variables that we have used a gate on, to enforce that they are
     // equal to a defined value.
+    // TODO(Adrian): Why is this not in CircuitConstructorBase
     std::map<barretenberg::fr, uint32_t> constant_variable_indices;
 
     StandardCircuitConstructor(const size_t size_hint = 0)
@@ -29,12 +30,15 @@ class StandardCircuitConstructor : public CircuitConstructorBase<STANDARD_HONK_W
         w_o.reserve(size_hint);
         // To effieciently constrain wires to zero, we set the first value of w_1 to be 0, and use copy constraints for
         // all future zero values.
+        // TODO(Adrian): This should be done in a constant way, maybe by initializing the constant_variable_indices map
         zero_idx = put_constant_variable(barretenberg::fr::zero());
     };
 
+    StandardCircuitConstructor(const StandardCircuitConstructor& other) = delete;
     StandardCircuitConstructor(StandardCircuitConstructor&& other) = default;
+    StandardCircuitConstructor& operator=(const StandardCircuitConstructor& other) = delete;
     StandardCircuitConstructor& operator=(StandardCircuitConstructor&& other) = default;
-    ~StandardCircuitConstructor() {}
+    ~StandardCircuitConstructor() override = default;
 
     void assert_equal_constant(uint32_t const a_idx,
                                barretenberg::fr const& b,
@@ -54,6 +58,7 @@ class StandardCircuitConstructor : public CircuitConstructorBase<STANDARD_HONK_W
 
     fixed_group_add_quad previous_add_quad;
 
+    // TODO(Adrian): This should be a virtual overridable method in the base class.
     void fix_witness(const uint32_t witness_index, const barretenberg::fr& witness_value);
 
     std::vector<uint32_t> decompose_into_base4_accumulators(const uint32_t witness_index,
@@ -74,6 +79,7 @@ class StandardCircuitConstructor : public CircuitConstructorBase<STANDARD_HONK_W
     accumulator_triple create_and_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
     accumulator_triple create_xor_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
 
+    // TODO(Adrian): The 2 following methods should be virtual in the base class
     uint32_t put_constant_variable(const barretenberg::fr& variable);
 
     size_t get_num_constant_gates() const override { return 0; }

--- a/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
@@ -146,7 +146,9 @@ void ComposerHelper<CircuitConstructor>::compute_witness_base(const CircuitConst
     const size_t num_public_inputs = public_inputs.size();
 
     const size_t num_constraints = std::max(minimum_circuit_size, num_gates + num_public_inputs);
-    // TODO(Adrian): We should o
+    // TODO(Adrian): Not a fan of specifying NUM_RANDOMIZED_GATES everywhere,
+    // Each flavor of Honk should have a "fixed" number of random places to add randomness to.
+    // It should be taken care of in as few places possible.
     const size_t subgroup_size = circuit_constructor.get_circuit_subgroup_size(num_constraints + NUM_RANDOMIZED_GATES);
 
     // construct a view over all the wire's variable indices

--- a/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
@@ -1,9 +1,13 @@
 #include "composer_helper.hpp"
-#include "polynomials/polynomial.hpp"
-#include <cstddef>
+#include "permutation_helper.hpp"
+#include <polynomials/polynomial.hpp>
 #include <proof_system/flavor/flavor.hpp>
 #include <honk/pcs/commitment_key.hpp>
 #include <numeric/bitop/get_msb.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
 
 namespace honk {
 
@@ -23,53 +27,44 @@ namespace honk {
  * */
 template <typename CircuitConstructor>
 std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute_proving_key_base(
-    CircuitConstructor& constructor, const size_t minimum_circuit_size, const size_t num_reserved_gates)
+    const CircuitConstructor& constructor, const size_t minimum_circuit_size, const size_t num_randomized_gates)
 {
-    /*
-     * Map internal composer members for easier usage
-     */
+    const size_t num_gates = constructor.num_gates;
+    std::span<const uint32_t> public_inputs = constructor.public_inputs;
 
-    auto& n = constructor.n;
-    auto& public_inputs = constructor.public_inputs;
-    auto& selector_names = constructor.selector_names_;
-    auto& selectors = constructor.selectors;
-
-    const size_t num_filled_gates = n + public_inputs.size();
-    const size_t total_num_gates = std::max(minimum_circuit_size, num_filled_gates);
+    const size_t num_public_inputs = public_inputs.size();
+    const size_t num_constraints = num_gates + num_public_inputs;
+    const size_t total_num_constraints = std::max(minimum_circuit_size, num_constraints);
     const size_t subgroup_size =
-        constructor.get_circuit_subgroup_size(total_num_gates + num_reserved_gates); // next power of 2
+        constructor.get_circuit_subgroup_size(total_num_constraints + num_randomized_gates); // next power of 2
 
     auto crs = crs_factory_->get_prover_crs(subgroup_size + 1);
 
     // Initialize circuit_proving_key
     // TODO: replace composer types.
     circuit_proving_key = std::make_shared<waffle::proving_key>(
-        subgroup_size, public_inputs.size(), crs, waffle::ComposerType::STANDARD_HONK);
+        subgroup_size, num_public_inputs, crs, waffle::ComposerType::STANDARD_HONK);
 
-    for (size_t i = 0; i < constructor.num_selectors; ++i) {
-        std::vector<barretenberg::fr>& selector_values = selectors[i];
-        ASSERT(n == selector_values.size());
+    for (size_t j = 0; j < constructor.num_selectors; ++j) {
+        std::span<const barretenberg::fr> selector_values = constructor.selectors[j];
+        ASSERT(num_gates == selector_values.size());
 
-        // Fill unfilled gates' selector values with zeroes (stopping 1 short; the last value will be nonzero).
-        // TODO: (Do we want to copy the vectors and do it in a different place or do this iside the circuit itself?)
-        for (size_t j = num_filled_gates; j < subgroup_size - 1; ++j) {
-            selector_values.emplace_back(fr::zero());
+        // Compute selector vector, initialized to 0.
+        // Copy the selector values for all gates, keeping the rows at which we store public inputs as 0.
+        // Initializing the polynomials in this way automatically applies 0-padding to the selectors.
+        polynomial selector_poly_lagrange(subgroup_size, subgroup_size);
+        for (size_t i = 0; i < num_gates; ++i) {
+            selector_poly_lagrange[num_public_inputs + i] = selector_values[i];
         }
+        // TODO(Adrian): We may want to add a unique value (e.g. j+1) in the last position of each selector polynomial
+        // to guard against some edge cases that may occur during the MSM.
+        // If we do so, we should ensure that this does not clash with any other values we want to place at the end of
+        // of the witness vectors.
+        // In later iterations of the Sumcheck, we will be able to efficiently cancel out any checks in the last 2^k
+        // rows, so any randomness or unique values should be placed there.
 
-        // // TODO(Cody): We used to use a nonzero value to avoid the zero selector case.
-        // selector_values.emplace_back(i + 1);
-        selector_values.emplace_back(fr::zero());
-
-        // Compute selector vector
-        polynomial selector_poly_lagrange(subgroup_size);
-        for (size_t k = 0; k < public_inputs.size(); ++k) {
-            selector_poly_lagrange[k] = fr::zero();
-        }
-        for (size_t k = public_inputs.size(); k < subgroup_size; ++k) {
-            selector_poly_lagrange[k] = selector_values[k - public_inputs.size()];
-        }
-
-        circuit_proving_key->polynomial_cache.put(selector_names[i] + "_lagrange", std::move(selector_poly_lagrange));
+        circuit_proving_key->polynomial_cache.put(constructor.selector_names_[j] + "_lagrange",
+                                                  std::move(selector_poly_lagrange));
     }
 
     return circuit_proving_key;
@@ -140,69 +135,53 @@ std::shared_ptr<waffle::verification_key> ComposerHelper<CircuitConstructor>::co
  * */
 template <typename CircuitConstructor>
 template <size_t program_width>
-void ComposerHelper<CircuitConstructor>::compute_witness_base(CircuitConstructor& circuit_constructor,
+void ComposerHelper<CircuitConstructor>::compute_witness_base(const CircuitConstructor& circuit_constructor,
                                                               const size_t minimum_circuit_size)
 {
     if (computed_witness) {
         return;
     }
-    auto& n = circuit_constructor.n;
-    auto& public_inputs = circuit_constructor.public_inputs;
-    auto& w_l = circuit_constructor.w_l;
-    auto& w_r = circuit_constructor.w_r;
-    auto& w_o = circuit_constructor.w_o;
-    auto& w_4 = circuit_constructor.w_4;
-    auto zero_idx = circuit_constructor.zero_idx;
+    const size_t num_gates = circuit_constructor.num_gates;
+    std::span<const uint32_t> public_inputs = circuit_constructor.public_inputs;
+    const size_t num_public_inputs = public_inputs.size();
 
-    const size_t total_num_gates = std::max(minimum_circuit_size, n + public_inputs.size());
-    const size_t subgroup_size = circuit_constructor.get_circuit_subgroup_size(total_num_gates + NUM_RESERVED_GATES);
+    const size_t num_constraints = std::max(minimum_circuit_size, num_gates + num_public_inputs);
+    // TODO(Adrian): We should o
+    const size_t subgroup_size = circuit_constructor.get_circuit_subgroup_size(num_constraints + NUM_RANDOMIZED_GATES);
+
+    // construct a view over all the wire's variable indices
+    // w[j][i] is the index of the variable in the j-th wire, at gate i
+    // Each array should be of size `num_gates`
+    std::array<std::span<const uint32_t>, program_width> w;
+    w[0] = circuit_constructor.w_l;
+    w[1] = circuit_constructor.w_r;
+    w[2] = circuit_constructor.w_o;
+    if constexpr (program_width > 3) {
+        w[3] = circuit_constructor.w_4;
+    }
 
     // Note: randomness is added to 3 of the last 4 positions in plonk/proof_system/prover/prover.cpp
     // StandardProverBase::execute_preamble_round().
-    for (size_t i = total_num_gates; i < subgroup_size; ++i) {
-        w_l.emplace_back(zero_idx);
-        w_r.emplace_back(zero_idx);
-        w_o.emplace_back(zero_idx);
-    }
-    if (program_width > 3) {
-        for (size_t i = total_num_gates; i < subgroup_size; ++i) {
-            w_4.emplace_back(zero_idx);
+    for (size_t j = 0; j < program_width; ++j) {
+        // Initialize the polynomial with all the actual copies variable values
+        // Expect all values to be set to 0 initially
+        polynomial w_lagrange(subgroup_size, subgroup_size);
+
+        // Place all public inputs at the start of w_l and w_r.
+        // All selectors at these indices are set to 0 so these values are not constrained at all.
+        if ((j == 0) || (j == 1)) {
+            for (size_t i = 0; i < num_public_inputs; ++i) {
+                w_lagrange[i] = circuit_constructor.get_variable(public_inputs[i]);
+            }
         }
-    }
-    polynomial w_1_lagrange = polynomial(subgroup_size);
-    polynomial w_2_lagrange = polynomial(subgroup_size);
-    polynomial w_3_lagrange = polynomial(subgroup_size);
-    polynomial w_4_lagrange;
 
-    if (program_width > 3)
-        w_4_lagrange = polynomial(subgroup_size);
-
-    // Push the public inputs' values to the beginning of the wire witness polynomials.
-    // Note: each public input variable is assigned to both w_1 and w_2. See
-    // plonk/proof_system/public_inputs/public_inputs_impl.hpp for a giant comment explaining why.
-    for (size_t i = 0; i < public_inputs.size(); ++i) {
-        fr::__copy(circuit_constructor.get_variable(public_inputs[i]), w_1_lagrange[i]);
-        fr::__copy(circuit_constructor.get_variable(public_inputs[i]), w_2_lagrange[i]);
-        fr::__copy(fr::zero(), w_3_lagrange[i]);
-        if (program_width > 3)
-            fr::__copy(fr::zero(), w_4_lagrange[i]);
-    }
-
-    // Assign the variable values (which are pointed-to by the `w_` wires) to the wire witness polynomials `poly_w_`,
-    // shifted to make room for the public inputs at the beginning.
-    for (size_t i = public_inputs.size(); i < total_num_gates; ++i) {
-        fr::__copy(circuit_constructor.get_variable(w_l[i - public_inputs.size()]), w_1_lagrange.at(i));
-        fr::__copy(circuit_constructor.get_variable(w_r[i - public_inputs.size()]), w_2_lagrange.at(i));
-        fr::__copy(circuit_constructor.get_variable(w_o[i - public_inputs.size()]), w_3_lagrange.at(i));
-        if (program_width > 3)
-            fr::__copy(circuit_constructor.get_variable(w_4[i - public_inputs.size()]), w_4_lagrange.at(i));
-    }
-
-    circuit_proving_key->polynomial_cache.put("w_1_lagrange", std::move(w_1_lagrange));
-    circuit_proving_key->polynomial_cache.put("w_2_lagrange", std::move(w_2_lagrange));
-    circuit_proving_key->polynomial_cache.put("w_3_lagrange", std::move(w_3_lagrange));
-    if (program_width > 3) {
-        circuit_proving_key->polynomial_cache.put("w_4_lagrange", std::move(w_4_lagrange));
+        // Assign the variable values (which are pointed-to by the `w_` wires) to the wire witness polynomials
+        // `poly_w_`, shifted to make room for the public inputs at the beginning.
+        for (size_t i = 0; i < num_gates; ++i) {
+            w_lagrange[num_public_inputs + i] = circuit_constructor.get_variable(w[j][i]);
+        }
+        std::string index = std::to_string(j + 1);
+        circuit_proving_key->polynomial_cache.put("w_" + index + "_lagrange", std::move(w_lagrange));
     }
 
     computed_witness = true;
@@ -217,7 +196,7 @@ void ComposerHelper<CircuitConstructor>::compute_witness_base(CircuitConstructor
 
 template <typename CircuitConstructor>
 std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute_proving_key(
-    CircuitConstructor& circuit_constructor)
+    const CircuitConstructor& circuit_constructor)
 {
     if (circuit_proving_key) {
         return circuit_proving_key;
@@ -245,7 +224,7 @@ std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute
  * */
 template <typename CircuitConstructor>
 std::shared_ptr<waffle::verification_key> ComposerHelper<CircuitConstructor>::compute_verification_key(
-    CircuitConstructor& circuit_constructor)
+    const CircuitConstructor& circuit_constructor)
 {
     if (circuit_verification_key) {
         return circuit_verification_key;
@@ -268,7 +247,7 @@ std::shared_ptr<waffle::verification_key> ComposerHelper<CircuitConstructor>::co
  * @return The verifier.
  * */
 template <typename CircuitConstructor>
-StandardVerifier ComposerHelper<CircuitConstructor>::create_verifier(CircuitConstructor& circuit_constructor)
+StandardVerifier ComposerHelper<CircuitConstructor>::create_verifier(const CircuitConstructor& circuit_constructor)
 {
     auto verification_key = compute_verification_key(circuit_constructor);
     // TODO figure out types, actually
@@ -288,7 +267,7 @@ StandardVerifier ComposerHelper<CircuitConstructor>::create_verifier(CircuitCons
 
 template <typename CircuitConstructor>
 StandardUnrolledVerifier ComposerHelper<CircuitConstructor>::create_unrolled_verifier(
-    CircuitConstructor& circuit_constructor)
+    const CircuitConstructor& circuit_constructor)
 {
     compute_verification_key(circuit_constructor);
     StandardUnrolledVerifier output_state(
@@ -310,7 +289,7 @@ template <typename CircuitConstructor>
 template <typename Flavor>
 // TODO(Cody): this file should be generic with regard to flavor/arithmetization/whatever.
 StandardUnrolledProver ComposerHelper<CircuitConstructor>::create_unrolled_prover(
-    CircuitConstructor& circuit_constructor)
+    const CircuitConstructor& circuit_constructor)
 {
     compute_proving_key(circuit_constructor);
     compute_witness(circuit_constructor);
@@ -337,7 +316,7 @@ StandardUnrolledProver ComposerHelper<CircuitConstructor>::create_unrolled_prove
  * @return Initialized prover.
  * */
 template <typename CircuitConstructor>
-StandardProver ComposerHelper<CircuitConstructor>::create_prover(CircuitConstructor& circuit_constructor)
+StandardProver ComposerHelper<CircuitConstructor>::create_prover(const CircuitConstructor& circuit_constructor)
 {
     // Compute q_l, etc. and sigma polynomials.
     compute_proving_key(circuit_constructor);
@@ -369,5 +348,5 @@ StandardProver ComposerHelper<CircuitConstructor>::create_prover(CircuitConstruc
 
 template class ComposerHelper<StandardCircuitConstructor>;
 template StandardUnrolledProver ComposerHelper<StandardCircuitConstructor>::create_unrolled_prover<StandardHonk>(
-    StandardCircuitConstructor& circuit_constructor);
+    const StandardCircuitConstructor& circuit_constructor);
 } // namespace honk

--- a/cpp/src/aztec/honk/composer/composer_helper/composer_helper.hpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/composer_helper.hpp
@@ -1,18 +1,21 @@
+#pragma once
+
 #include <srs/reference_string/file_reference_string.hpp>
 #include <proof_system/proving_key/proving_key.hpp>
 #include <honk/proof_system/prover.hpp>
 #include <honk/proof_system/verifier.hpp>
+#include <honk/circuit_constructors/standard_circuit_constructor.hpp>
 #include <honk/pcs/commitment_key.hpp>
 #include <plonk/proof_system/verification_key/verification_key.hpp>
 #include <plonk/proof_system/verifier/verifier.hpp>
-#include "permutation_helper.hpp"
 
-#include <honk/circuit_constructors/standard_circuit_constructor.hpp>
+#include <utility>
+
 namespace honk {
 // TODO: change initializations to specify this parameter
 template <typename CircuitConstructor> class ComposerHelper {
   public:
-    static constexpr size_t NUM_RESERVED_GATES = 4; // this must be >= num_roots_cut_out_of_vanishing_polynomial
+    static constexpr size_t NUM_RANDOMIZED_GATES = 2; // equal to the number of multilinear evaluations leaked
     static constexpr size_t program_width = CircuitConstructor::program_width;
     std::shared_ptr<waffle::proving_key> circuit_proving_key;
     std::shared_ptr<waffle::verification_key> circuit_verification_key;
@@ -23,46 +26,53 @@ template <typename CircuitConstructor> class ComposerHelper {
         : ComposerHelper(std::shared_ptr<waffle::ReferenceStringFactory>(
               new waffle::FileReferenceStringFactory("../srs_db/ignition")))
     {}
-    ComposerHelper(std::shared_ptr<waffle::ReferenceStringFactory> const& crs_factory)
-        : crs_factory_(crs_factory)
+    ComposerHelper(std::shared_ptr<waffle::ReferenceStringFactory> crs_factory)
+        : crs_factory_(std::move(crs_factory))
     {}
 
     ComposerHelper(std::unique_ptr<waffle::ReferenceStringFactory>&& crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
-    ComposerHelper(std::shared_ptr<waffle::proving_key> const& p_key,
-                   std::shared_ptr<waffle::verification_key> const& v_key)
-        : circuit_proving_key(p_key)
-        , circuit_verification_key(v_key)
+    ComposerHelper(std::shared_ptr<waffle::proving_key> p_key, std::shared_ptr<waffle::verification_key> v_key)
+        : circuit_proving_key(std::move(p_key))
+        , circuit_verification_key(std::move(v_key))
     {}
-    ComposerHelper(ComposerHelper&& other) = default;
-    ComposerHelper& operator=(ComposerHelper&& other) = default;
-    ~ComposerHelper() {}
+    ComposerHelper(ComposerHelper&& other) noexcept = default;
+    ComposerHelper(const ComposerHelper& other) = delete;
+    ComposerHelper& operator=(ComposerHelper&& other) noexcept = default;
+    ComposerHelper& operator=(const ComposerHelper& other) = delete;
+    ~ComposerHelper() = default;
 
-    std::shared_ptr<waffle::proving_key> compute_proving_key(CircuitConstructor& circuit_constructor);
-    std::shared_ptr<waffle::verification_key> compute_verification_key(CircuitConstructor& circuit_constructor);
+    std::shared_ptr<waffle::proving_key> compute_proving_key(const CircuitConstructor& circuit_constructor);
+    std::shared_ptr<waffle::verification_key> compute_verification_key(const CircuitConstructor& circuit_constructor);
 
-    void compute_witness(CircuitConstructor& circuit_constructor)
+    void compute_witness(const CircuitConstructor& circuit_constructor)
     {
         compute_witness_base<program_width>(circuit_constructor);
     }
 
-    StandardVerifier create_verifier(CircuitConstructor& circuit_constructor);
+    StandardVerifier create_verifier(const CircuitConstructor& circuit_constructor);
     /**
      * Preprocess the circuit. Delegates to create_prover.
      *
      * @return A new initialized prover.
      */
-    StandardProver preprocess(CircuitConstructor& circuit_constructor) { return create_prover(circuit_constructor); };
-    StandardProver create_prover(CircuitConstructor& circuit_constructor);
+    StandardProver preprocess(const CircuitConstructor& circuit_constructor)
+    {
+        return create_prover(circuit_constructor);
+    };
+    StandardProver create_prover(const CircuitConstructor& circuit_constructor);
 
-    StandardUnrolledVerifier create_unrolled_verifier(CircuitConstructor& circuit_constructor);
+    StandardUnrolledVerifier create_unrolled_verifier(const CircuitConstructor& circuit_constructor);
 
-    template <typename Flavor> StandardUnrolledProver create_unrolled_prover(CircuitConstructor& circuit_constructor);
+    template <typename Flavor>
+    StandardUnrolledProver create_unrolled_prover(const CircuitConstructor& circuit_constructor);
 
-    std::shared_ptr<waffle::proving_key> compute_proving_key_base(CircuitConstructor& circuit_constructor,
-                                                                  const size_t minimum_ciricut_size = 0,
-                                                                  const size_t num_reserved_gates = NUM_RESERVED_GATES);
+    // TODO(Adrian): Seems error prone to provide the number of randomized gates
+    std::shared_ptr<waffle::proving_key> compute_proving_key_base(
+        const CircuitConstructor& circuit_constructor,
+        const size_t minimum_ciricut_size = 0,
+        const size_t num_randomized_gates = NUM_RANDOMIZED_GATES);
     // This needs to be static as it may be used only to compute the selector commitments.
 
     static std::shared_ptr<waffle::verification_key> compute_verification_key_base(
@@ -70,7 +80,7 @@ template <typename CircuitConstructor> class ComposerHelper {
         std::shared_ptr<waffle::VerifierReferenceString> const& vrs);
 
     template <size_t program_width>
-    void compute_witness_base(CircuitConstructor& circuit_constructor, const size_t minimum_circuit_size = 0);
+    void compute_witness_base(const CircuitConstructor& circuit_constructor, const size_t minimum_circuit_size = 0);
 };
 
 } // namespace honk

--- a/cpp/src/aztec/honk/composer/composer_helper/permutation_helper.hpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/permutation_helper.hpp
@@ -1,118 +1,89 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <vector>
+#pragma once
+
+#include <ecc/curves/bn254/fr.hpp>
+#include <polynomials/polynomial.hpp>
 #include <proof_system/proving_key/proving_key.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <initializer_list>
+#include <cstdint>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
 namespace honk {
-// Enum values spaced in increments of 30-bits (multiples of 2 ** 30).
-enum WireType { LEFT = 0U, RIGHT = (1U << 30U), OUTPUT = (1U << 31U), FOURTH = 0xc0000000 };
 
 /**
- * @brief cycle_node represents a particular witness at a particular gate. Used to collect permutation sets
- *
+ * @brief cycle_node represents the index of a value of the circuit.
+ * It will belong to a CyclicPermutation, such that all nodes in a CyclicPermutation
+ * must have the value.
+ * The total number of constaints is always <2^32 since that is the type used to represent variables, so we can save
+ * space by using a type smaller than size_t.
  */
 struct cycle_node {
+    uint32_t wire_index;
     uint32_t gate_index;
-    WireType wire_type;
-
-    cycle_node(const uint32_t a, const WireType b)
-        : gate_index(a)
-        , wire_type(b)
-    {}
-    cycle_node(const cycle_node& other)
-        : gate_index(other.gate_index)
-        , wire_type(other.wire_type)
-    {}
-    cycle_node(cycle_node&& other)
-        : gate_index(other.gate_index)
-        , wire_type(other.wire_type)
-    {}
-    cycle_node& operator=(const cycle_node& other)
-    {
-        gate_index = other.gate_index;
-        wire_type = other.wire_type;
-        return *this;
-    }
-    bool operator==(const cycle_node& other) const
-    {
-        return ((gate_index == other.gate_index) && (wire_type == other.wire_type));
-    }
 };
-typedef std::vector<std::vector<cycle_node>> CycleCollector;
+using CyclicPermutation = std::vector<cycle_node>;
 
 /**
- * Compute wire copy cycles
- *
- * First set all wire_copy_cycles corresponding to public_inputs to point to themselves.
- * Then go through all witnesses in w_l, w_r, w_o and w_4 (if program width is > 3) and
- * add them to cycles of their real indexes.
+ * Compute all CyclicPermutations of the circuit. Each CyclicPermutation represents the indices of the values in the
+ * witness wires that must have the same value.
  *
  * @tparam program_width Program width
  * */
 template <size_t program_width, typename CircuitConstructor>
-void compute_wire_copy_cycles(CircuitConstructor& circuit_constructor, CycleCollector& wire_copy_cycles)
+std::vector<CyclicPermutation> compute_wire_copy_cycles(const CircuitConstructor& circuit_constructor)
 {
     // Reference circuit constructor members
-    const std::vector<uint32_t>& real_variable_index = circuit_constructor.real_variable_index;
-    const std::vector<uint32_t>& public_inputs = circuit_constructor.public_inputs;
-
-    const std::vector<uint32_t>& w_l = circuit_constructor.w_l;
-    const std::vector<uint32_t>& w_r = circuit_constructor.w_r;
-    const std::vector<uint32_t>& w_o = circuit_constructor.w_o;
-    const size_t n = circuit_constructor.n;
-    const std::vector<uint32_t>& w_4 = circuit_constructor.w_4;
-
-    size_t number_of_cycles = 0;
-
+    const size_t num_gates = circuit_constructor.num_gates;
+    std::span<const uint32_t> public_inputs = circuit_constructor.public_inputs;
     const size_t num_public_inputs = public_inputs.size();
 
-    // Initialize wire_copy_cycles of public input variables to point to themselves ( we could actually ignore this step
-    // for HONK because of the way we construct the permutation)
-    for (size_t counter = 0; counter < num_public_inputs; ++counter) {
-        size_t i = num_public_inputs - 1 - counter;
-        cycle_node left{ static_cast<uint32_t>(i), WireType::LEFT };
-        cycle_node right{ static_cast<uint32_t>(i), WireType::RIGHT };
+    // Get references to the wires containing the index of the value inside constructor.variables
+    // These wires only contain the "real" gate constraints, and are not padded.
+    std::array<std::span<const uint32_t>, program_width> wire_indices;
+    wire_indices[0] = circuit_constructor.w_l;
+    wire_indices[1] = circuit_constructor.w_r;
+    wire_indices[2] = circuit_constructor.w_o;
+    if constexpr (program_width > 3) {
+        wire_indices[3] = circuit_constructor.w_4;
+    }
 
-        const auto public_input_index = real_variable_index[public_inputs[i]];
-        if (static_cast<size_t>(public_input_index) >= number_of_cycles) {
-            wire_copy_cycles.resize(public_input_index + 1);
-        }
-        std::vector<cycle_node>& cycle = wire_copy_cycles[static_cast<size_t>(public_input_index)];
+    // Each variable represents one cycle
+    const size_t number_of_cycles = circuit_constructor.variables.size();
+    std::vector<CyclicPermutation> copy_cycles(number_of_cycles);
+
+    // Represents the index of a variable in circuit_constructor.variables
+    std::span<const uint32_t> real_variable_index = circuit_constructor.real_variable_index;
+
+    // We use the permutation argument to enforce the public input variables to be equal to values provided by the
+    // verifier. The convension we use is to place the public input values as the first rows of witness vectors.
+    // All selectors are zero at these rows, so they are fully unconstrained.
+    // The "real" gates that follow can use references to these variables.
+    //
+    // The copy cycle for the i-th public variable looks like
+    //   (i) -> (n+i) -> (i') -> ... -> (i'')
+    // This loop initializes the i-th cycle with (i) -> (n+i), to whi
+    for (size_t i = 0; i < num_public_inputs; ++i) {
+        const uint32_t public_input_index = real_variable_index[public_inputs[i]];
+        const auto gate_index = static_cast<uint32_t>(i);
         // These two nodes must be in adjacent locations in the cycle for correct handling of public inputs
-        cycle.emplace_back(left);
-        cycle.emplace_back(right);
+        copy_cycles[public_input_index].emplace_back(cycle_node{ 0, gate_index });
+        copy_cycles[public_input_index].emplace_back(cycle_node{ 1, gate_index });
     }
 
-    // Go through all witnesses and add them to the wire_copy_cycles
-    for (size_t counter = 0; counter < n; ++counter) {
-        // Start from the back. This way we quickly get the maximum real variable index
-        size_t i = n - 1 - counter;
-        const uint32_t w_1_index = real_variable_index[w_l[i]];
-        const uint32_t w_2_index = real_variable_index[w_r[i]];
-        const uint32_t w_3_index = real_variable_index[w_o[i]];
-        // Check the maximum index of a variable. If it is more or equal to the cycle vector size, extend the vector
-        const uint32_t max_index = std::max({ w_1_index, w_2_index, w_3_index });
-        if (max_index >= number_of_cycles) {
-            wire_copy_cycles.resize(max_index + 1);
-            number_of_cycles = max_index + 1;
-        }
-        wire_copy_cycles[static_cast<size_t>(w_1_index)].emplace_back(static_cast<uint32_t>(i + num_public_inputs),
-                                                                      WireType::LEFT);
-        wire_copy_cycles[static_cast<size_t>(w_2_index)].emplace_back(static_cast<uint32_t>(i + num_public_inputs),
-                                                                      WireType::RIGHT);
-        wire_copy_cycles[static_cast<size_t>(w_3_index)].emplace_back(static_cast<uint32_t>(i + num_public_inputs),
-                                                                      WireType::OUTPUT);
-
-        // Handle width 4 separately
-        if constexpr (program_width > 3) {
-            static_assert(program_width == 4);
-            const auto w_4_index = real_variable_index[w_4[i]];
-            if (w_4_index >= number_of_cycles) {
-                wire_copy_cycles.resize(w_4_index + 1);
-            }
-            wire_copy_cycles[static_cast<size_t>(w_4_index)].emplace_back(static_cast<uint32_t>(i + num_public_inputs),
-                                                                          WireType::FOURTH);
+    // Iterate over all variables of the "real" gates, and add a corresponding node to the cycle for that variable
+    for (size_t j = 0; j < program_width; ++j) {
+        for (size_t i = 0; i < num_gates; ++i) {
+            const uint32_t var_index = circuit_constructor.real_variable_index[wire_indices[j][i]];
+            const auto wire_index = static_cast<uint32_t>(j);
+            const auto gate_index = static_cast<uint32_t>(i + num_public_inputs);
+            copy_cycles[var_index].emplace_back(cycle_node{ wire_index, gate_index });
         }
     }
+    return copy_cycles;
 }
 
 /**
@@ -131,47 +102,64 @@ template <size_t program_width, typename CircuitConstructor>
 void compute_standard_honk_sigma_permutations(CircuitConstructor& circuit_constructor, waffle::proving_key* key)
 {
     // Compute wire copy cycles for public and private variables
-    CycleCollector wire_copy_cycles;
-    compute_wire_copy_cycles<program_width>(circuit_constructor, wire_copy_cycles);
+    std::vector<CyclicPermutation> copy_cycles = compute_wire_copy_cycles<program_width>(circuit_constructor);
     const size_t n = key->n;
-    // Fill sigma polynomials with default values
-    std::vector<barretenberg::polynomial> sigma_polynomials_lagrange;
-    for (size_t i = 0; i < program_width; ++i) {
-        // Construct permutation polynomials in lagrange base
-        std::string index = std::to_string(i + 1);
-        sigma_polynomials_lagrange.push_back(barretenberg::polynomial(key->n));
-        barretenberg::polynomial& sigma_polynomial_lagrange = sigma_polynomials_lagrange[i];
-        for (size_t j = 0; j < key->n; j++) {
-            sigma_polynomial_lagrange[j] = (i * n + j);
+
+    // Initialize sigma[0], sigma[1], ..., as the identity permutation
+    // at the end of the loop, sigma[j][i] = j*n + i
+    std::array<barretenberg::polynomial, program_width> sigma;
+    for (size_t j = 0; j < program_width; ++j) {
+        sigma[j] = barretenberg::polynomial(n, n);
+        for (size_t i = 0; i < n; i++) {
+            sigma[j][i] = (j * n + i);
         }
     }
-    // Go through each cycle
-    for (auto& single_copy_cycle : wire_copy_cycles) {
+
+    // Each cycle is a partition of the indexes
+    for (auto& single_copy_cycle : copy_cycles) {
+        const size_t cycle_size = single_copy_cycle.size();
 
         // If we use assert equal, we lose a real variable index, which creates an empty cycle
-        if (single_copy_cycle.size() == 0) {
+        if (cycle_size == 0) {
             continue;
         }
-        size_t cycle_size = single_copy_cycle.size();
-        // Get the index value of the last element
-        cycle_node current_element = single_copy_cycle[cycle_size - 1];
-        auto last_index =
-            sigma_polynomials_lagrange[current_element.wire_type >> 30].data()[current_element.gate_index];
 
-        // Propagate indices through the cycle
-        for (size_t j = 0; j < cycle_size; j++) {
+        // next_index represents the index of the variable that the current node in the cycle should point to.
+        // We iterate over the cycle in reverse order, so the index of the last node should map to the index of the
+        // first one.
+        const auto [first_col, first_idx] = single_copy_cycle.front();
+        auto next_index = sigma[first_col][first_idx];
 
-            current_element = single_copy_cycle[j];
-            auto temp_index =
-                sigma_polynomials_lagrange[current_element.wire_type >> 30].data()[current_element.gate_index];
-            sigma_polynomials_lagrange[current_element.wire_type >> 30].data()[current_element.gate_index] = last_index;
-            last_index = temp_index;
+        // The index of variable reference by the j-th node should map to the index of the (j+1)-th node.
+        // The last one points to the first, and the index of the latter is stored in `next_index`.
+        // When we get to the second node in the list, we replace it with the index of the third node, and save the
+        // index it currently points to into `next_index`
+        for (size_t j = cycle_size - 1; j != 0; --j) {
+            const auto [current_col, current_idx] = single_copy_cycle[j];
+            next_index = std::exchange(sigma[current_col][current_idx], next_index);
         }
+        // After the loop ends, we make the first node point to the index of the second node,
+        // thereby completing the cycle.
+        sigma[first_col][first_idx] = next_index;
     }
+
+    // We intentionally want to break the cycles of the public input variables.
+    // During the witness generation, the left and right wire polynomials at index i contain the i-th public input.
+    // The CyclicPermutation created for these variables always start with (i) -> (n+i), followed by the indices of the
+    // variables in the "real" gates.
+    // We make i point to -(i+1), so that the only way of repairing the cycle is add the mapping
+    //  -(i+1) -> (n+i)
+    // These indices are chosen so they can easily be computed by the verifier. They can expect the running product
+    // to be equal to the "public input delta" that is computed in <honk/utils/public_inputs.hpp>
+    const auto num_public_inputs = static_cast<uint32_t>(circuit_constructor.public_inputs.size());
+    for (size_t i = 0; i < num_public_inputs; ++i) {
+        sigma[0][i] = -barretenberg::fr(i + 1);
+    }
+
     // Save to polynomial cache
-    for (size_t i = 0; i < program_width; i++) {
-        std::string index = std::to_string(i + 1);
-        key->polynomial_cache.put("sigma_" + index + "_lagrange", std::move(sigma_polynomials_lagrange[i]));
+    for (size_t j = 0; j < program_width; j++) {
+        std::string index = std::to_string(j + 1);
+        key->polynomial_cache.put("sigma_" + index + "_lagrange", std::move(sigma[j]));
     }
 }
 
@@ -190,20 +178,14 @@ void compute_standard_honk_id_polynomials(auto key) // proving_key* and share_pt
 {
     const size_t n = key->n;
     // Fill id polynomials with default values
-    std::vector<barretenberg::polynomial> id_polynomials_lagrange;
-    for (size_t i = 0; i < program_width; ++i) {
+    for (size_t j = 0; j < program_width; ++j) {
         // Construct permutation polynomials in lagrange base
-        std::string index = std::to_string(i + 1);
-        id_polynomials_lagrange.push_back(barretenberg::polynomial(key->n));
-        barretenberg::polynomial& id_polynomial_lagrange = id_polynomials_lagrange[i];
-        for (size_t j = 0; j < key->n; j++) {
-            id_polynomial_lagrange[j] = (i * n + j);
+        barretenberg::polynomial id_j(n, n);
+        for (size_t i = 0; i < key->n; ++i) {
+            id_j[i] = (j * n + i);
         }
-    }
-    // Save to polynomial cache
-    for (size_t i = 0; i < program_width; i++) {
-        std::string index = std::to_string(i + 1);
-        key->polynomial_cache.put("id_" + index + "_lagrange", std::move(id_polynomials_lagrange[i]));
+        std::string index = std::to_string(j + 1);
+        key->polynomial_cache.put("id_" + index + "_lagrange", std::move(id_j));
     }
 }
 

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.hpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.hpp
@@ -1,5 +1,7 @@
-#include "../circuit_constructors/standard_circuit_constructor.hpp"
+#pragma once
+
 #include "composer_helper/composer_helper.hpp"
+#include <honk/circuit_constructors/standard_circuit_constructor.hpp>
 #include <srs/reference_string/file_reference_string.hpp>
 #include <transcript/manifest.hpp>
 #include <proof_system/flavor/flavor.hpp>
@@ -56,9 +58,11 @@ class StandardHonkComposer {
         , composer_helper(p_key, v_key)
     {}
 
+    StandardHonkComposer(const StandardHonkComposer& other) = delete;
     StandardHonkComposer(StandardHonkComposer&& other) = default;
+    StandardHonkComposer& operator=(const StandardHonkComposer& other) = delete;
     StandardHonkComposer& operator=(StandardHonkComposer&& other) = default;
-    ~StandardHonkComposer() {}
+    ~StandardHonkComposer() = default;
 
     /**Methods related to circuit construction
      * They simply get proxied to the circuit constructor

--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -38,7 +38,7 @@ Prover<settings>::Prover(std::shared_ptr<waffle::proving_key> input_key, const t
     , transcript(input_manifest, settings::hash_type, settings::num_challenge_bytes)
     , proving_key(input_key)
     , commitment_key(nullptr) // TODO(Cody): Need better constructors for prover.
-    , queue(proving_key.get(), &transcript)
+// , queue(proving_key.get(), &transcript) // TODO(Adrian): explore whether it's needed 
 {}
 
 /**

--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -91,12 +91,11 @@ template <typename settings> void Prover<settings>::compute_wire_commitments()
  * Note: Step (4) utilizes Montgomery batch inversion to replace n-many inversions with
  * one batch inversion (at the expense of more multiplications)
  */
-template <typename settings> void Prover<settings>::compute_grand_product_polynomial(Fr beta)
+template <typename settings>
+void Prover<settings>::compute_grand_product_polynomial(barretenberg::fr beta, barretenberg::fr gamma)
 {
     using barretenberg::polynomial_arithmetic::copy_polynomial;
     static const size_t program_width = settings::program_width;
-
-    Fr gamma = beta * beta; // TODO(Cody): We already do this and it's kosher, right?
 
     // Allocate scratch space for accumulators
     Fr* numererator_accum[program_width];
@@ -261,8 +260,9 @@ template <typename settings> void Prover<settings>::execute_grand_product_comput
 
     transcript.apply_fiat_shamir("beta");
 
-    auto beta = transcript.get_challenge_field_element("beta");
-    compute_grand_product_polynomial(beta);
+    auto beta = transcript.get_challenge_field_element("beta", 0);
+    auto gamma = transcript.get_challenge_field_element("beta", 1);
+    compute_grand_product_polynomial(beta, gamma);
     std::span<Fr> z_perm = proving_key->polynomial_cache.get("z_perm_lagrange");
     auto commitment = commitment_key->commit(z_perm);
     transcript.add_element("Z_PERM", commitment.to_buffer());

--- a/cpp/src/aztec/honk/proof_system/prover.hpp
+++ b/cpp/src/aztec/honk/proof_system/prover.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <proof_system/proving_key/proving_key.hpp>
 #include <honk/pcs/commitment_key.hpp>
-#include "../../plonk/proof_system/types/plonk_proof.hpp"
-#include "../../plonk/proof_system/types/program_settings.hpp"
+#include <plonk/proof_system/types/plonk_proof.hpp>
+#include <plonk/proof_system/types/program_settings.hpp>
 #include <honk/pcs/gemini/gemini.hpp>
 #include <honk/pcs/shplonk/shplonk_single.hpp>
 #include <honk/pcs/kzg/kzg.hpp>
@@ -36,15 +36,6 @@ template <typename settings> class Prover {
 
     size_t get_circuit_size() const { return n; }
 
-    void flush_queued_work_items() { queue.flush_queue(); }
-
-    waffle::work_queue::work_item_info get_queued_work_item_info() const { return queue.get_queued_work_item_info(); }
-
-    size_t get_scalar_multiplication_size(const size_t work_item_number) const
-    {
-        return queue.get_scalar_multiplication_size(work_item_number);
-    }
-
     // TODO(luke): Eventually get rid of this but leave it for convenience for now
     const size_t n;
 
@@ -61,10 +52,19 @@ template <typename settings> class Prover {
 
     // Honk only needs a small portion of the functionality but may be fine to use existing work_queue
     // NOTE: this is not currently in use, but it may well be used in the future.
-    waffle::work_queue queue;
+    // TODO(Adrian): Uncomment when we need this again.
+    // waffle::work_queue queue;
+    // void flush_queued_work_items() { queue.flush_queue(); }
+    // waffle::work_queue::work_item_info get_queued_work_item_info() const {
+    //     return queue.get_queued_work_item_info();
+    // }
+    // size_t get_scalar_multiplication_size(const size_t work_item_number) const
+    // {
+    //     return queue.get_scalar_multiplication_size(work_item_number);
+    // }
 
     // This makes 'settings' accesible from Prover
-    typedef settings settings_;
+    using settings_ = settings;
 
     pcs::gemini::ProverOutput<pcs::kzg::Params> gemini_output;
     pcs::shplonk::ProverOutput<pcs::kzg::Params> shplonk_output;
@@ -76,7 +76,7 @@ template <typename settings> class Prover {
 // TODO(luke): need equivalent notion of settings for Honk
 extern template class Prover<waffle::standard_settings>;
 
-typedef Prover<waffle::standard_settings> StandardProver; // TODO(Cody): Delete?
-typedef Prover<waffle::standard_settings> StandardUnrolledProver;
+using StandardProver = Prover<waffle::standard_settings>; // TODO(Cody): Delete?
+using StandardUnrolledProver = Prover<waffle::standard_settings>;
 
 } // namespace honk

--- a/cpp/src/aztec/honk/proof_system/prover.hpp
+++ b/cpp/src/aztec/honk/proof_system/prover.hpp
@@ -28,8 +28,7 @@ template <typename settings> class Prover {
 
     void compute_wire_commitments();
 
-    void compute_grand_product_polynomial(
-        barretenberg::fr beta = 1); // TODO(Cody): get rid of dangerous default value here
+    void compute_grand_product_polynomial(barretenberg::fr beta, barretenberg::fr gamma);
 
     waffle::plonk_proof& export_proof();
     waffle::plonk_proof& construct_proof();

--- a/cpp/src/aztec/honk/proof_system/prover.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.test.cpp
@@ -1,6 +1,6 @@
-#include "../../srs/reference_string/file_reference_string.hpp"
-#include "./prover.hpp"
+#include "prover.hpp"
 
+#include <srs/reference_string/file_reference_string.hpp>
 #include <array>
 #include <vector>
 #include <cstddef>
@@ -80,8 +80,13 @@ template <class Fscalar> class ProverTests : public testing::Test {
         // Instantiate a Prover with pointer to the proving_key just constructed
         auto honk_prover = StandardProver(proving_key);
 
+        // Get random challenges
+        // (TODO(luke): set these up to come from a transcript. Must match actual implementation
+        Fscalar beta = Fscalar::one();
+        Fscalar gamma = Fscalar::one();
+
         // Method 1: Compute z_perm using 'compute_grand_product_polynomial' as the prover would in practice
-        honk_prover.compute_grand_product_polynomial();
+        honk_prover.compute_grand_product_polynomial(beta, gamma);
 
         // Method 2: Compute z_perm locally using the simplest non-optimized syntax possible. The comment below,
         // which describes the computation in 4 steps, is adapted from a similar comment in
@@ -111,11 +116,6 @@ template <class Fscalar> class ProverTests : public testing::Test {
         // Make scratch space for the numerator and denominator accumulators.
         std::array<std::array<Fscalar, num_gates>, program_width> numererator_accum;
         std::array<std::array<Fscalar, num_gates>, program_width> denominator_accum;
-
-        // Get random challenges
-        // (TODO(luke): set these up to come from a transcript. Must match actual implementation
-        Fscalar beta = Fscalar::one();
-        Fscalar gamma = Fscalar::one();
 
         // Step (1)
         for (size_t i = 0; i < proving_key->n; ++i) {

--- a/cpp/src/aztec/honk/proof_system/verifier.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.test.cpp
@@ -110,11 +110,11 @@ template <class FF> class VerifierTests : public testing::Test {
             w_o[2 * i] = w_o[2 * i] + w_l[2 * i];
             w_o[2 * i] = w_o[2 * i] + w_r[2 * i];
             w_o[2 * i] = w_o[2 * i] + fr::one();
-            fr::__copy(fr::one(), q_l.at(2 * i));
-            fr::__copy(fr::one(), q_r.at(2 * i));
-            fr::__copy(fr::neg_one(), q_o.at(2 * i));
-            fr::__copy(fr::one(), q_c.at(2 * i));
-            fr::__copy(fr::one(), q_m.at(2 * i));
+            q_l.at(2 * i) = fr::one();
+            q_r.at(2 * i) = fr::one();
+            q_o.at(2 * i) = fr::neg_one();
+            q_c.at(2 * i) = fr::one();
+            q_m.at(2 * i) = fr::one();
 
             w_l.at(2 * i + 1) = fr::random_element();
             w_r.at(2 * i + 1) = fr::random_element();

--- a/cpp/src/aztec/honk/sumcheck/relations/arithmetic_relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/arithmetic_relation.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <array>
 #include <tuple>
 

--- a/cpp/src/aztec/honk/sumcheck/relations/grand_product_computation_relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/grand_product_computation_relation.hpp
@@ -1,8 +1,7 @@
+#pragma once
 #include "relation.hpp"
 #include <proof_system/flavor/flavor.hpp>
-#include "../polynomials/multivariates.hpp" // TODO(Cody): don't need?
 #include "../polynomials/univariate.hpp"
-#include "../polynomials/barycentric_data.hpp"
 
 namespace honk::sumcheck {
 
@@ -16,6 +15,7 @@ template <typename FF> class GrandProductComputationRelation : public Relation<F
     // TODO(luke): make these real challenges once manifest is done
     const FF beta = FF::one();
     const FF gamma = FF::one();
+    const FF public_input_delta = FF::one();
 
     GrandProductComputationRelation() = default;
     explicit GrandProductComputationRelation(auto){}; // TODO(luke): should just be default?
@@ -27,9 +27,11 @@ template <typename FF> class GrandProductComputationRelation : public Relation<F
      * This file handles the relation that confirms faithful calculation of the grand
      * product polynomial Z_perm. (Initialization relation Z_perm(0) = 1 is handled elsewhere).
      *
-     *      z_perm(X)*P(X) - z_perm_shift(X)*Q(X), where
+     *      ( z_perm(X) + lagrange_first(X) )*P(X) - ( z_perm_shift(X) + delta * lagrange_last(X) )*Q(X),
+     *   where
      *      P(X) = Prod_{i=1:3} w_i(X) + β*(n*(i-1) + idx(X)) + γ
      *      Q(X) = Prod_{i=1:3} w_i(X) + β*σ_i(X) + γ
+     *      delta is the public input correction term
      *
      */
     void add_edge_contribution(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals)
@@ -45,15 +47,16 @@ template <typename FF> class GrandProductComputationRelation : public Relation<F
         auto id_3 = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::ID_1]);
         auto z_perm = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::Z_PERM]);
         auto z_perm_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::Z_PERM_SHIFT]);
-        // auto lagrange_1 = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::LAGRANGE_FIRST]);
+        auto lagrange_first = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::LAGRANGE_FIRST]);
+        auto lagrange_last = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::LAGRANGE_LAST]);
 
         // Contribution (1)
-        evals += z_perm;
+        evals += (z_perm + lagrange_first);
         evals *= w_1 + id_1 * beta + gamma;
         evals *= w_2 + id_2 * beta + gamma;
         evals *= w_3 + id_3 * beta + gamma;
-        evals -= z_perm_shift * (w_1 + sigma_1 * beta + gamma) * (w_2 + sigma_2 * beta + gamma) *
-                 (w_3 + sigma_3 * beta + gamma);
+        evals -= (z_perm_shift + lagrange_last * public_input_delta) * (w_1 + sigma_1 * beta + gamma) *
+                 (w_2 + sigma_2 * beta + gamma) * (w_3 + sigma_3 * beta + gamma);
     };
 
     void add_full_relation_value_contribution(auto& purported_evaluations, FF& full_honk_relation_value)
@@ -69,14 +72,16 @@ template <typename FF> class GrandProductComputationRelation : public Relation<F
         auto id_3 = purported_evaluations[MULTIVARIATE::ID_1];
         auto z_perm = purported_evaluations[MULTIVARIATE::Z_PERM];
         auto z_perm_shift = purported_evaluations[MULTIVARIATE::Z_PERM_SHIFT];
-        // auto lagrange_1 = purported_evaluations[MULTIVARIATE::LAGRANGE_FIRST];
+        auto lagrange_first = purported_evaluations[MULTIVARIATE::LAGRANGE_FIRST];
+        auto lagrange_last = purported_evaluations[MULTIVARIATE::LAGRANGE_LAST];
 
         // Contribution (1)
-        full_honk_relation_value += z_perm;
+        full_honk_relation_value += (z_perm + lagrange_first);
         full_honk_relation_value *= w_1 + beta * id_1 + gamma;
         full_honk_relation_value *= w_2 + beta * id_2 + gamma;
         full_honk_relation_value *= w_3 + beta * id_3 + gamma;
-        full_honk_relation_value -= z_perm_shift * (w_1 + beta * sigma_1 + gamma) * (w_2 + beta * sigma_2 + gamma) *
+        full_honk_relation_value -= (z_perm_shift + lagrange_last * public_input_delta) *
+                                    (w_1 + beta * sigma_1 + gamma) * (w_2 + beta * sigma_2 + gamma) *
                                     (w_3 + beta * sigma_3 + gamma);
     };
 };

--- a/cpp/src/aztec/honk/sumcheck/relations/grand_product_initialization_relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/grand_product_initialization_relation.hpp
@@ -1,8 +1,7 @@
+#pragma once
 #include "relation.hpp"
 #include <proof_system/flavor/flavor.hpp>
-#include "../polynomials/multivariates.hpp"
 #include "../polynomials/univariate.hpp"
-#include "../polynomials/barycentric_data.hpp"
 
 namespace honk::sumcheck {
 
@@ -19,26 +18,24 @@ template <typename FF> class GrandProductInitializationRelation : public Relatio
      * @brief Add contribution of the permutation relation for a given edge
      *
      * @detail There are 2 relations associated with enforcing the wire copy relations
-     * This file handles the relation Z_perm(0) = 1 via the relation:
+     * This file handles the relation Z_perm_shift(n_last) = 0 via the relation:
      *
-     *                      C(X) = L_1(X)(z_perm(X) - 1)
+     *                      C(X) = L_LAST(X) * Z_perm_shift(X)
      */
     void add_edge_contribution(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals)
     {
-        auto z_perm = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::Z_PERM]);
-        auto lagrange_1 = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::LAGRANGE_FIRST]);
-        auto one = FF(1);
+        auto z_perm_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::Z_PERM_SHIFT]);
+        auto lagrange_last = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::LAGRANGE_LAST]);
 
-        evals += lagrange_1 * (z_perm - one);
+        evals += lagrange_last * z_perm_shift;
     };
 
     void add_full_relation_value_contribution(auto& purported_evaluations, FF& full_honk_relation_value)
     {
-        auto z_perm = purported_evaluations[MULTIVARIATE::Z_PERM];
-        auto lagrange_1 = purported_evaluations[MULTIVARIATE::LAGRANGE_FIRST];
-        auto one = FF(1);
+        auto z_perm_shift = purported_evaluations[MULTIVARIATE::Z_PERM_SHIFT];
+        auto lagrange_last = purported_evaluations[MULTIVARIATE::LAGRANGE_LAST];
 
-        full_honk_relation_value += lagrange_1 * (z_perm - one);
+        full_honk_relation_value += lagrange_last * z_perm_shift;
     };
 };
 } // namespace honk::sumcheck

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.hpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "common/serialize.hpp"
 #include "plonk/proof_system/types/polynomial_manifest.hpp"
 #include "common/throw_or_abort.hpp"

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
@@ -125,8 +125,8 @@ TEST(Sumcheck, ProverAndVerifier)
     std::array<FF, 2> w_l = { 1, 2 };
     std::array<FF, 2> w_r = { 1, 2 };
     std::array<FF, 2> w_o = { 2, 4 };
-    std::array<FF, 2> z_perm = { 1, 0 };
-    std::array<FF, 2> z_perm_shift = { 0, 1 }; // NOTE: Not set up to be valid.
+    std::array<FF, 2> z_perm = { 0, 1 };
+    std::array<FF, 2> z_perm_shift = { 1, 0 }; // NOTE: Not set up to be valid.
     std::array<FF, 2> q_m = { 0, 1 };
     std::array<FF, 2> q_l = { 1, 0 };
     std::array<FF, 2> q_r = { 1, 0 };
@@ -139,7 +139,7 @@ TEST(Sumcheck, ProverAndVerifier)
     std::array<FF, 2> id_2 = { 1, 2 };    // NOTE: Not set up to be valid.
     std::array<FF, 2> id_3 = { 1, 2 };    // NOTE: Not set up to be valid.
     std::array<FF, 2> lagrange_first = { 1, 0 };
-    std::array<FF, 2> lagrange_last = { 1, 2 }; // NOTE: Not set up to be valid.
+    std::array<FF, 2> lagrange_last = { 0, 1 }; // NOTE: Not set up to be valid.
 
     // These will be owned outside the class, probably by the composer.
     std::array<std::span<FF>, Multivariates::num> full_polynomials = {

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <common/log.hpp>
 #include <array>
 #include <algorithm>

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
@@ -1,6 +1,5 @@
 #include <proof_system/flavor/flavor.hpp>
 #include "sumcheck_round.hpp"
-#include "relations/relation.hpp"
 #include "relations/arithmetic_relation.hpp"
 #include "relations/grand_product_computation_relation.hpp"
 #include "relations/grand_product_initialization_relation.hpp"

--- a/cpp/src/aztec/honk/utils/public_inputs.hpp
+++ b/cpp/src/aztec/honk/utils/public_inputs.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <span>
+namespace honk {
+
+/**
+ * @brief Compute the correction term for the permutation argument.
+ *
+ * @tparam Field
+ * @param public_inputs x₀, ..., xₘ₋₁ public inputs to the circuit
+ * @param beta random linear-combination term to combine both (wʲ, IDʲ) and (wʲ, σʲ)
+ * @param gamma Schwartz-Zippel random evaluation to ensure ∏ᵢ (γ + Sᵢ) = ∏ᵢ (γ + Tᵢ)
+ * @param domain_size Total number of rows required for the circuit (power of 2)
+ * @return Field Public input Δ
+ */
+template <typename Field>
+Field compute_public_input_delta(std::span<const Field> public_inputs,
+                                 const Field& beta,
+                                 const Field& gamma,
+                                 const size_t domain_size)
+{
+    Field numerator = Field::one();
+    Field denominator = Field::one();
+
+    // Let m be the number of public inputs x₀,…, xₘ₋₁.
+    // Recall that we broke the permutation σ⁰ by changing the mapping
+    //  (i) -> (n+i)   to   (i) -> (-(i+1))   i.e. σ⁰ᵢ = −(i+1)
+    //
+    // Therefore, the term in the numerator with ID¹ᵢ = n+i does not cancel out with any term in the denominator.
+    // Similarly, the denominator contains an extra σ⁰ᵢ = −(i+1) term that does not appear in the numerator.
+    // We expect the values of W⁰ᵢ and W¹ᵢ to be equal to xᵢ.
+    // The expected accumulated product would therefore be equal to
+
+    //   ∏ᵢ (γ + W¹ᵢ + β⋅ID¹ᵢ)        ∏ᵢ (γ + xᵢ + β⋅(n+i) )
+    //  -----------------------  =  ------------------------
+    //   ∏ᵢ (γ + W⁰ᵢ + β⋅σ⁰ᵢ )        ∏ᵢ (γ + xᵢ - β⋅(i+1) )
+
+    // At the start of the loop for each xᵢ where i = 0, 1, …, m-1,
+    // we have
+    //      numerator_acc   = γ + β⋅(n+i) = γ + β⋅n + β⋅i
+    //      denominator_acc = γ - β⋅(1+i) = γ - β   - β⋅i
+    // at the end of the loop, add and subtract β to each term respectively to
+    // set the expected value for the start of iteration i+1.
+    Field numerator_acc = gamma + (beta * Field(domain_size));
+    Field denominator_acc = gamma - beta;
+
+    for (const auto& x_i : public_inputs) {
+        numerator *= (numerator_acc + x_i);     // γ + xᵢ + β(n+i)
+        denominator *= (denominator_acc + x_i); // γ + xᵢ - β(1+i)
+
+        numerator_acc += beta;
+        denominator_acc -= beta;
+    }
+    return numerator / denominator;
+}
+
+} // namespace honk

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -41,8 +41,6 @@ template <typename Fr> class Polynomial {
     Polynomial& operator=(const Polynomial& other);
     ~Polynomial();
 
-    explicit constexpr operator std::span<Fr>() const noexcept { return std::span<Fr>(coefficients_, size()); };
-
     void clear()
     {
         free();

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -25,7 +25,7 @@ struct StandardArithmetization {
         ID_2,
         ID_3,
         LAGRANGE_FIRST,
-        LAGRANGE_LAST,
+        LAGRANGE_LAST, // = LAGRANGE_N-1 whithout ZK, but can be less
         COUNT
     };
 

--- a/cpp/src/aztec/transcript/manifest.hpp
+++ b/cpp/src/aztec/transcript/manifest.hpp
@@ -53,7 +53,7 @@ class Manifest {
          * */
         bool includes_element(const std::string& element_name)
         {
-            for (auto ele : elements) {
+            for (const auto& ele : elements) {
                 if (element_name == ele.name) {
                     return true;
                 }


### PR DESCRIPTION
Fixes #28, #22 

- comment-out work queue
- change sumcheck initialization round to check that the last element is 0 (not necessary now since we don't do ZK, but creates the least amount of change) 
- reinstore gamma challenge 

## Clang-tidy related

There are many changes that silence warnings from `clang-tidy`. 
- Initializing class members when possible 
- Explicitly deleting copy constructors/assignment operators for non-copyable classes
- Using `= default` for trivial destructors
- Adding `noexcept` to move constructors/assignment
- Using `auto` after `static_cast` to avoid duplication.
- Using `std::move` when copying an argument like a `string` or `vector` to help the compiler (references may alias, so passing by value tells the compiler that this value is really constant)
- Removing unused headers, and adding `#pragma once` to prevent import clashes. 
- Reorder some imports, and use the module-relative paths
- Replace some `typedef` with `using` 
- Use `const auto& element : container` to prevent unnecessary copies.


## Circuit Constructor

-  Replace `n` by `num_gates` to prevent clashes with `n` we use to refer to the `subgroup_size` 
- Added comments about things that seemed fishy, (all marked with `TODO(Adrian)` 
- Removed `NUM_RESERVED_GATES` and `WireType` since they are not used/duplicated
- Simplified `set_public_input`, though not sure if the removal of the `ASSERT` is correct. 

## Composer 

- Refactor `compute_proving_key_base`
  - Take the `CircuitConstructor` by `const` reference and modify the behavior so we only modify the `proving_key`. We no longer add any padding or dummy gates to the constructor, and instead do the padding entirely over the polynomials. 
  - Remove unnecessary zero-ing out of selector values by using the fact that polynomials are initialized to 0. 
  - Explicitly state where the public inputs are stored. 
- Refactor `compute_witness_base`
  - Use explicit types when referencing the `circuit_constructor` and ensure we only get objects that we don't modify. 
  - Create `array` of wires to handle the `program_width` more generally. 
  - No longer modify the `circuit_constructor` wires to add padding, and instead add 0-padding to the wire polynomials. 
  - Remove `fr::__copy` 
- Ensure all calls to `circuit_constructor` are `const` 
- PermutationHelper: Big refactor to clarify handling of public inputs. 
  - Simplify `cycle_node` behavior, and more generically handle different number of columns, and remove confusing `WireType` enum. 
  - Make `compute_wire_copy_cycles` return a vector of `CyclicPermutation` for clarity. 
  - Remove `resize` by noting that the number of cycles is equal to the number of `variables`
  - Reverse the order in which we were applying each `CyclicPermutation` to the `sigma` polynomials. Now, each `cycle_node` will map to the next one in the list. 
  - Add comments to explain what parts of the function are necessary for our public input handling. 
  - Changed the `composer_test` to also test for public inputs. 
    - Add many more tests to ensure the permutation polynomials that we create have the expected form. 
    - Compare results with the `public_input_delta`

## Prover & Verifier

- Comment-out the `work_queue` related members. 
- Restore `gamma` challenge that was removed due to a misunderstanding
- Remove default argument `beta = 1` for the `grand_product` computation.

## Sumcheck 

- Add `#pragma once` to headers
- Modify the `GrandProductComputationRelation` to work with `Z_perm` that has the first coefficient equal to 0. 
- Handle `public_input_delta` in `GrandProductComputationRelation` 
- Modify `GrandProductInitializationRelation` to instead check that the last "real" value of `Z_perm_shift` is 0. In the current ZK-less situation, this is not necessary since it will be guaranteed by Gemini shift opening. But leaving it here for later. 
- Renamed `LAGRANGE_1` to `LAGRANGE_FIRST` to be consistent with other parts of the code.

