### PR TITLE
join_split: Require same account flag for 'merge'

### DIFF
--- a/cpp/src/aztec/rollup/constants.hpp
+++ b/cpp/src/aztec/rollup/constants.hpp
@@ -35,7 +35,7 @@ constexpr bool is_circuit_change_expected = 0;
 /* The below constants are only used for regression testing; to identify accidental changes to circuit
  constraints. They need to be changed when there is a circuit change. */
 constexpr uint32_t ACCOUNT = 23967;
-constexpr uint32_t JOIN_SPLIT = 64043;
+constexpr uint32_t JOIN_SPLIT = 64047;
 constexpr uint32_t CLAIM = 22684;
 constexpr uint32_t ROLLUP = 1173221;
 constexpr uint32_t ROOT_ROLLUP = 5481327;
@@ -58,12 +58,13 @@ namespace circuit_vk_hash {
  constraints. They need to be changed when there is a circuit change. Note that they are written in the reverse order
  to comply with the from_buffer<>() method. */
 constexpr auto ACCOUNT = uint256_t(0xcd6d70c733eaf823, 0x6505d3402817ad3d, 0xbf9e2b6a262589cf, 0xafcc546b55cc45e3);
-constexpr auto JOIN_SPLIT = uint256_t(0x7f154a0f7899ffe5, 0xb131200661bf1911, 0x9a0c8cd44c9c087b, 0x1038d50b67f8a5b3);
+constexpr auto JOIN_SPLIT = uint256_t(0xb23c7772f47bc823, 0x5493625d4f08603c, 0x21ac50a5929576f9, 0xb7b3113c131460e5);
 constexpr auto CLAIM = uint256_t(0x878301ebba40ab60, 0x931466762c62d661, 0x40aad71ec3496905, 0x9f47aaa109759d0a);
-constexpr auto ROLLUP = uint256_t(0x10909f6022cbe853, 0x05540f4a6cdd597a, 0x89b7c29dfbfc50e2, 0xa3a335eed6b774d6);
-constexpr auto ROOT_ROLLUP = uint256_t(0x4d135bb2a2aa9ac1, 0xadf2e42748b53e53, 0x501463f9b3207d2b, 0xa0d8b0d4053698ba);
+constexpr auto ROLLUP = uint256_t(0x8712bcbeb11180c5, 0x598412e4f700c484, 0xfe50ad453c8e4288, 0xa7340fac5feb663f);
+constexpr auto ROOT_ROLLUP = uint256_t(0xcf2fee21f089b32f, 0x90c6187354cf70d4, 0x3a5a90b8c86d8c64, 0xd55af088ddc86db7);
+;
 constexpr auto ROOT_VERIFIER =
-    uint256_t(0x85521cebe5e98f46, 0x02141f667a54d17e, 0xd8d43be20eea9560, 0xade9412d8afbb6b9);
+    uint256_t(0xe91df73df393fb5f, 0x99a9fa13abfbb206, 0x2ffe8c891cbde8c2, 0xdcb051e8ca06df5e);
 }; // namespace circuit_vk_hash
 
 namespace ProofIds {

--- a/cpp/src/aztec/rollup/proofs/join_split/join_split_circuit.cpp
+++ b/cpp/src/aztec/rollup/proofs/join_split/join_split_circuit.cpp
@@ -269,12 +269,17 @@ join_split_outputs join_split_circuit_component(join_split_inputs const& inputs)
     const bool_ct is_same_owner =
         input_note_1.owner == output_note_1.owner && input_note_2.owner == output_note_2.owner;
     const bool_ct is_same_amount = total_in_value == total_out_value;
-    // is_merge_send: 
+    // is_same_account_flag:
+    //   we rely on input_note_1.account_required == input_note_2.account_required being checked already
+    const bool_ct is_same_account_flag = input_note_1.account_required == output_note_1.account_required &&
+                                         input_note_2.account_required == output_note_2.account_required;
+    // is_merge_send:
     //   if true, we can elide our signature as this is a same-owner, same-amount send
-    //   where one of the output notes has value 0
+    //   where one of the output notes has value 0. In addition, we shouldn't have output notes
+    //   that do not need an account if input notes needed an account, and vice versa
     //   Caveat: A signature of all 0's will still fail basic checks
-    const bool_ct is_merge_send =
-        is_send && (output_note_1_value == 0 || output_note_2_value == 0) && is_same_owner && is_same_amount;
+    const bool_ct is_merge_send = is_send && (output_note_1_value == 0 || output_note_2_value == 0) && is_same_owner &&
+                                  is_same_amount && is_same_account_flag;
     (verified || is_merge_send).assert_equal(true, "verify signature failed");
 
     return { nullifier1,      nullifier2, output_note_1_commitment, output_note_2.commitment,


### PR DESCRIPTION
# Description

See https://github.com/AztecProtocol/barretenberg/issues/66 for writeup
Modifies the definition of a "merge" (which, critically, is used when deciding to skip signature checks) to include checking the account flag

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
