### PR TITLE
Adding three additional manifest elements related to Gemini

### DIFF
--- a/cpp/src/aztec/honk/pcs/gemini/gemini.hpp
+++ b/cpp/src/aztec/honk/pcs/gemini/gemini.hpp
@@ -132,6 +132,7 @@ template <typename Params> class MultilinearReductionScheme {
 
     using Fr = typename Params::Fr;
     using Commitment = typename Params::Commitment;
+    using Commitment_affine = typename Params::C; // TODO(luke): find a better name
     using Polynomial = barretenberg::Polynomial<Fr>;
 
   public:
@@ -259,7 +260,7 @@ template <typename Params> class MultilinearReductionScheme {
          */
         for (size_t i = 0; i < commitments.size(); ++i) {
             std::string label = "FOLD_" + std::to_string(i + 1);
-            transcript->add_element(label, static_cast<barretenberg::g1::affine_element>(commitments[i]).to_buffer());
+            transcript->add_element(label, static_cast<Commitment_affine>(commitments[i]).to_buffer());
         }
         transcript->apply_fiat_shamir("r");
         const Fr r = Fr::serialize_from_buffer(transcript->get_challenge("r").begin());
@@ -325,6 +326,16 @@ template <typename Params> class MultilinearReductionScheme {
          */
         auto result_claims =
             compute_output_claim_from_proof(claims_f, claims_g, mle_opening_point, rhos, r_squares, proof);
+
+        // Add the following to transcript:
+        // - Evaluation \hat{a_0} = Fold_{r}^(0)(r) of the 0th Fold polynomial at +r
+        // - Commitments [Fold_{r}^(0)] and [Fold_{-r}^(0)] of the partially evaluated 0th Fold poly at +/-r
+        Fr a_0_pos = result_claims[0].eval;
+        Commitment_affine Fold_0_pos_commitment(result_claims[0].commitment);
+        Commitment_affine Fold_0_neg_commitment(result_claims[1].commitment);
+        transcript->add_element("a_0_pos", a_0_pos.to_buffer());
+        transcript->add_element("FOLD_0_pos", static_cast<Commitment_affine>(Fold_0_pos_commitment).to_buffer());
+        transcript->add_element("FOLD_0_neg", static_cast<Commitment_affine>(Fold_0_neg_commitment).to_buffer());
 
         return { result_claims, std::move(witness_polynomials), proof };
     };

--- a/cpp/src/aztec/honk/pcs/gemini/gemini.hpp
+++ b/cpp/src/aztec/honk/pcs/gemini/gemini.hpp
@@ -132,7 +132,7 @@ template <typename Params> class MultilinearReductionScheme {
 
     using Fr = typename Params::Fr;
     using Commitment = typename Params::Commitment;
-    using Commitment_affine = typename Params::C; // TODO(luke): find a better name
+    using CommitmentAffine = typename Params::C; // TODO(luke): find a better name
     using Polynomial = barretenberg::Polynomial<Fr>;
 
   public:
@@ -260,7 +260,7 @@ template <typename Params> class MultilinearReductionScheme {
          */
         for (size_t i = 0; i < commitments.size(); ++i) {
             std::string label = "FOLD_" + std::to_string(i + 1);
-            transcript->add_element(label, static_cast<Commitment_affine>(commitments[i]).to_buffer());
+            transcript->add_element(label, static_cast<CommitmentAffine>(commitments[i]).to_buffer());
         }
         transcript->apply_fiat_shamir("r");
         const Fr r = Fr::serialize_from_buffer(transcript->get_challenge("r").begin());
@@ -331,11 +331,11 @@ template <typename Params> class MultilinearReductionScheme {
         // - Evaluation \hat{a_0} = Fold_{r}^(0)(r) of the 0th Fold polynomial at +r
         // - Commitments [Fold_{r}^(0)] and [Fold_{-r}^(0)] of the partially evaluated 0th Fold poly at +/-r
         Fr a_0_pos = result_claims[0].eval;
-        Commitment_affine Fold_0_pos_commitment(result_claims[0].commitment);
-        Commitment_affine Fold_0_neg_commitment(result_claims[1].commitment);
+        CommitmentAffine Fold_0_pos_commitment(result_claims[0].commitment);
+        CommitmentAffine Fold_0_neg_commitment(result_claims[1].commitment);
         transcript->add_element("a_0_pos", a_0_pos.to_buffer());
-        transcript->add_element("FOLD_0_pos", static_cast<Commitment_affine>(Fold_0_pos_commitment).to_buffer());
-        transcript->add_element("FOLD_0_neg", static_cast<Commitment_affine>(Fold_0_neg_commitment).to_buffer());
+        transcript->add_element("FOLD_0_pos", static_cast<CommitmentAffine>(Fold_0_pos_commitment).to_buffer());
+        transcript->add_element("FOLD_0_neg", static_cast<CommitmentAffine>(Fold_0_neg_commitment).to_buffer());
 
         return { result_claims, std::move(witness_polynomials), proof };
     };

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -144,6 +144,13 @@ struct StandardHonk {
             gemini_evaluation_entries.emplace_back(transcript::Manifest::ManifestEntry(
             { .name = "a_" + std::to_string(i), .num_bytes = fr_size, .derived_by_verifier = false }));
         };
+        gemini_evaluation_entries.emplace_back(transcript::Manifest::ManifestEntry(
+            { .name = "a_0_pos", .num_bytes = fr_size, .derived_by_verifier = false }));
+        // Include two additional commitments that depend on challenge "r" from previous round
+        gemini_evaluation_entries.emplace_back(transcript::Manifest::ManifestEntry(
+              { .name = "FOLD_0_pos", .num_bytes = g1_size, .derived_by_verifier = false }));
+        gemini_evaluation_entries.emplace_back(transcript::Manifest::ManifestEntry(
+              { .name = "FOLD_0_neg", .num_bytes = g1_size, .derived_by_verifier = false }));
         manifest_rounds.emplace_back(transcript::Manifest::RoundManifest(
             gemini_evaluation_entries,
             /* challenge_name = */ "nu",

--- a/cpp/src/aztec/transcript/transcript.cpp
+++ b/cpp/src/aztec/transcript/transcript.cpp
@@ -15,14 +15,14 @@
 
 namespace transcript {
 
-// Set to 1 to enable debug logging.
+// Set to 1 to enable some logging.
 #if 0
-template <typename... Args> inline void debug(Args... args)
+template <typename... Args> inline void info_togglable(Args... args)
 {
     info("Transcript: ", args...);
 }
 #else
-template <typename... Args> inline void debug(Args...) {}
+template <typename... Args> inline void info_togglable(Args...) {}
 #endif
 
 std::array<uint8_t, Keccak256Hasher::PRNG_OUTPUT_SIZE> Keccak256Hasher::hash(std::vector<uint8_t> const& buffer)
@@ -154,7 +154,7 @@ void Transcript::mock_inputs_prior_to_challenge(const std::string& challenge_in,
 
 void Transcript::add_element(const std::string& element_name, const std::vector<uint8_t>& buffer)
 {
-    debug("add_element(): ", element_name, "\n");
+    info_togglable("add_element(): ", element_name, "\n");
     elements.insert({ element_name, buffer });
 }
 
@@ -164,7 +164,7 @@ void Transcript::add_element(const std::string& element_name, const std::vector<
  *
  * @param challenge_name Challenge name (needed to check if the challenge fits the current round).
  * */
-void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const bool debug*/)
+void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const bool info_togglable*/)
 {
     // For reference, see the relevant manifest, which is defined in
     // plonk/composer/[standard/turbo/ultra]_composer.hpp
@@ -172,9 +172,9 @@ void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const b
     // TODO(Cody): Coupling: this line insists that the challenges in the manifest
     // are encountered in the order that matches the order of the proof construction functions.
     // Future architecture should specify this data in a single place (?).
-    debug("apply_fiat_shamir(): challenge name match:");
-    debug("\t challenge_name in: ", challenge_name);
-    debug("\t challenge_name expected: ", manifest.get_round_manifest(current_round).challenge, "\n");
+    info_togglable("apply_fiat_shamir(): challenge name match:");
+    info_togglable("\t challenge_name in: ", challenge_name);
+    info_togglable("\t challenge_name expected: ", manifest.get_round_manifest(current_round).challenge, "\n");
     ASSERT(challenge_name == manifest.get_round_manifest(current_round).challenge);
 
     const size_t num_challenges = manifest.get_round_manifest(current_round).num_challenges;
@@ -191,9 +191,9 @@ void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const b
         buffer.insert(buffer.end(), current_challenge.data.begin(), current_challenge.data.end());
     }
     for (auto manifest_element : manifest.get_round_manifest(current_round).elements) {
-        debug("apply_fiat_shamir(): manifest element name match:");
-        debug("\t element name: ", manifest_element.name);
-        debug(
+        info_togglable("apply_fiat_shamir(): manifest element name match:");
+        info_togglable("\t element name: ", manifest_element.name);
+        info_togglable(
             "\t element exists and is unique: ", (elements.count(manifest_element.name) == 1) ? "true" : "false", "\n");
         ASSERT(elements.count(manifest_element.name) == 1);
 
@@ -309,7 +309,7 @@ void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const b
 std::array<uint8_t, Transcript::PRNG_OUTPUT_SIZE> Transcript::get_challenge(const std::string& challenge_name,
                                                                             const size_t idx) const
 {
-    debug("get_challenge(): ", challenge_name, "\n");
+    info_togglable("get_challenge(): ", challenge_name, "\n");
     ASSERT(challenges.count(challenge_name) == 1);
     return challenges.at(challenge_name)[idx].data;
 }

--- a/cpp/src/aztec/transcript/transcript.cpp
+++ b/cpp/src/aztec/transcript/transcript.cpp
@@ -15,6 +15,16 @@
 
 namespace transcript {
 
+// Set to 1 to enable debug logging.
+#if 0
+template <typename... Args> inline void debug(Args... args)
+{
+    info("Transcript: ", args...);
+}
+#else
+template <typename... Args> inline void debug(Args...) {}
+#endif
+
 std::array<uint8_t, Keccak256Hasher::PRNG_OUTPUT_SIZE> Keccak256Hasher::hash(std::vector<uint8_t> const& buffer)
 {
     keccak256 hash_result = ethash_keccak256(&buffer[0], buffer.size());
@@ -144,8 +154,7 @@ void Transcript::mock_inputs_prior_to_challenge(const std::string& challenge_in,
 
 void Transcript::add_element(const std::string& element_name, const std::vector<uint8_t>& buffer)
 {
-    // info("add_element");
-    // info("element_name = ", element_name);
+    debug("add_element(): ", element_name, "\n");
     elements.insert({ element_name, buffer });
 }
 
@@ -163,10 +172,9 @@ void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const b
     // TODO(Cody): Coupling: this line insists that the challenges in the manifest
     // are encountered in the order that matches the order of the proof construction functions.
     // Future architecture should specify this data in a single place (?).
-    // info("apply_fiat_shamir: challenge name match");
-    // info("challenge_name = ", challenge_name);
-    // info("manifest.get_round_manifest(current_round).challenge = ",
-    //      manifest.get_round_manifest(current_round).challenge);
+    debug("apply_fiat_shamir(): challenge name match:");
+    debug("\t challenge_name in: ", challenge_name);
+    debug("\t challenge_name expected: ", manifest.get_round_manifest(current_round).challenge, "\n");
     ASSERT(challenge_name == manifest.get_round_manifest(current_round).challenge);
 
     const size_t num_challenges = manifest.get_round_manifest(current_round).num_challenges;
@@ -183,9 +191,10 @@ void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const b
         buffer.insert(buffer.end(), current_challenge.data.begin(), current_challenge.data.end());
     }
     for (auto manifest_element : manifest.get_round_manifest(current_round).elements) {
-        // info("apply_fiat_shamir: manifest element name match");
-        // info("manifest_element.name = ", manifest_element.name);
-        // info("elements.count(manifest_element.name) = ", elements.count(manifest_element.name));
+        debug("apply_fiat_shamir(): manifest element name match:");
+        debug("\t element name: ", manifest_element.name);
+        debug(
+            "\t element exists and is unique: ", (elements.count(manifest_element.name) == 1) ? "true" : "false", "\n");
         ASSERT(elements.count(manifest_element.name) == 1);
 
         std::vector<uint8_t>& element_data = elements.at(manifest_element.name);
@@ -300,8 +309,7 @@ void Transcript::apply_fiat_shamir(const std::string& challenge_name /*, const b
 std::array<uint8_t, Transcript::PRNG_OUTPUT_SIZE> Transcript::get_challenge(const std::string& challenge_name,
                                                                             const size_t idx) const
 {
-    // info("get_challenge:");
-    // info("challenge_name = ", challenge_name);
+    debug("get_challenge(): ", challenge_name, "\n");
     ASSERT(challenges.count(challenge_name) == 1);
     return challenges.at(challenge_name)[idx].data;
 }


### PR DESCRIPTION
# Description

Add the following to Manifest/Transcript:
- Evaluation $\hat{a_0} = Fold_{r}^{(0)}(r)$
- Commitments to partially evaluated fold polynomials $[Fold_{r}^{(0)}]$ and $[Fold_{-r}^{(0)}]$

Also add togglable debug prints in transcript, similar to those in polynomial_cache.cpp.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
