### PR TITLE
Commit to Wires Using Lagrange SRS

### DIFF
--- a/cpp/bootstrap.sh
+++ b/cpp/bootstrap.sh
@@ -28,7 +28,7 @@ fi
 # Download ignition transcripts.
 cd ./srs_db
 ./download_ignition.sh 3
-./download_ignition_lagrange.sh 12
+./download_ignition_lagrange.sh 24
 cd ..
 
 # Pick native toolchain file.

--- a/cpp/scripts/run_tests
+++ b/cpp/scripts/run_tests
@@ -20,6 +20,6 @@ docker run --rm -t $IMAGE_URI /bin/sh -c "\
   set -e; \
   cd /usr/src/barretenberg/cpp/srs_db; \
   ./download_ignition.sh $NUM_TRANSCRIPTS; \
-  ./download_ignition_lagrange.sh 12; \
+  ./download_ignition_lagrange.sh 24; \
   cd /usr/src/barretenberg/cpp/build; \
   for BIN in $TESTS; do ./bin/\$BIN $@; done"

--- a/cpp/src/aztec/benchmark/pippenger_bench/main.cpp
+++ b/cpp/src/aztec/benchmark/pippenger_bench/main.cpp
@@ -65,8 +65,8 @@ int pippenger()
 {
     scalar_multiplication::pippenger_runtime_state state(NUM_POINTS);
     std::chrono::steady_clock::time_point time_start = std::chrono::steady_clock::now();
-    g1::element result =
-        scalar_multiplication::pippenger_unsafe(&scalars[0], reference_string->get_monomials(), NUM_POINTS, state);
+    g1::element result = scalar_multiplication::pippenger_unsafe(
+        &scalars[0], reference_string->get_monomial_points(), NUM_POINTS, state);
     std::chrono::steady_clock::time_point time_end = std::chrono::steady_clock::now();
     std::chrono::microseconds diff = std::chrono::duration_cast<std::chrono::microseconds>(time_end - time_start);
     std::cout << "run time: " << diff.count() << "us" << std::endl;

--- a/cpp/src/aztec/ecc/curves/bn254/scalar_multiplication/pippenger.cpp
+++ b/cpp/src/aztec/ecc/curves/bn254/scalar_multiplication/pippenger.cpp
@@ -11,7 +11,7 @@ Pippenger::Pippenger(g1::affine_element* points, size_t num_points)
     scalar_multiplication::generate_pippenger_point_table(monomials_, monomials_, num_points);
 }
 
-Pippenger::Pippenger(uint8_t const* points, size_t num_points, bool)
+Pippenger::Pippenger(uint8_t const* points, size_t num_points)
     : num_points_(num_points)
 {
     monomials_ = point_table_alloc<g1::affine_element>(num_points);

--- a/cpp/src/aztec/ecc/curves/bn254/scalar_multiplication/pippenger.hpp
+++ b/cpp/src/aztec/ecc/curves/bn254/scalar_multiplication/pippenger.hpp
@@ -41,7 +41,7 @@ class Pippenger {
      */
     Pippenger(g1::affine_element* points, size_t num_points);
 
-    Pippenger(uint8_t const* points, size_t num_points, bool is_lagrange = false);
+    Pippenger(uint8_t const* points, size_t num_points);
 
     Pippenger(std::string const& path, size_t num_points, bool is_lagrange = false);
 

--- a/cpp/src/aztec/honk/pcs/commitment_key.hpp
+++ b/cpp/src/aztec/honk/pcs/commitment_key.hpp
@@ -10,6 +10,7 @@
 #include <srs/reference_string/file_reference_string.hpp>
 #include <ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp>
 #include <ecc/curves/bn254/pairing.hpp>
+#include <numeric/bitop/pow.hpp>
 
 #include <string_view>
 #include <memory>
@@ -62,6 +63,21 @@ class CommitmentKey {
         ASSERT(degree <= srs.get_monomial_size());
         return barretenberg::scalar_multiplication::pippenger_unsafe(
             const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
+    };
+
+    /**
+     * @brief Uses the ProverSRS to create a commitment to p(X)
+     *
+     * @param polynomial a univariate polynomial in its evaluation form p(X) = ∑ᵢ p(ωⁱ)⋅Lᵢ(X)
+     * @return Commitment computed as C = [p(x)] = ∑ᵢ p(ωⁱ)⋅[Lᵢ(x)]₁
+     */
+    C commit_lagrange(std::span<const Fr> polynomial)
+    {
+        const size_t degree = polynomial.size();
+        ASSERT(degree == srs.get_lagrange_size());
+        ASSERT(numeric::is_power_of_two(degree));
+        return barretenberg::scalar_multiplication::pippenger_unsafe(
+            const_cast<Fr*>(polynomial.data()), srs.get_lagrange_points(), degree, pippenger_runtime_state);
     };
 
   private:

--- a/cpp/src/aztec/honk/pcs/commitment_key.hpp
+++ b/cpp/src/aztec/honk/pcs/commitment_key.hpp
@@ -59,9 +59,9 @@ class CommitmentKey {
     C commit(std::span<const Fr> polynomial)
     {
         const size_t degree = polynomial.size();
-        ASSERT(degree <= srs.get_size());
+        ASSERT(degree <= srs.get_monomial_size());
         return barretenberg::scalar_multiplication::pippenger_unsafe(
-            const_cast<Fr*>(polynomial.data()), srs.get_monomials(), degree, pippenger_runtime_state);
+            const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
     };
 
   private:

--- a/cpp/src/aztec/honk/proof_system/verifier.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.test.cpp
@@ -44,7 +44,7 @@ template <class FF> class VerifierTests : public testing::Test {
         for (size_t i = 0; i < 8; ++i) {
             commitments[i] = g1::affine_element(
                 scalar_multiplication::pippenger(poly_coefficients[i],
-                                                 circuit_proving_key->reference_string->get_monomials(),
+                                                 circuit_proving_key->reference_string->get_monomial_points(),
                                                  circuit_proving_key->circuit_size,
                                                  prover));
         }

--- a/cpp/src/aztec/join_split_example/proofs/join_split/c_bind.cpp
+++ b/cpp/src/aztec/join_split_example/proofs/join_split/c_bind.cpp
@@ -58,10 +58,12 @@ WASM_EXPORT uint32_t join_split__get_new_proving_key_data(uint8_t** output)
     return len;
 }
 
-WASM_EXPORT void join_split__init_verification_key(void* pippenger, uint8_t const* g2x)
+WASM_EXPORT void join_split__init_verification_key(void* pippenger, void* pippenger_lagrange, uint8_t const* g2x)
 {
     auto crs_factory = std::make_unique<waffle::PippengerReferenceStringFactory>(
-        reinterpret_cast<scalar_multiplication::Pippenger*>(pippenger), g2x);
+        reinterpret_cast<scalar_multiplication::Pippenger*>(pippenger),
+        reinterpret_cast<scalar_multiplication::Pippenger*>(pippenger_lagrange),
+        g2x);
     init_verification_key(std::move(crs_factory));
 }
 

--- a/cpp/src/aztec/lagrange_base_gen/lagrange_base_processor.cpp
+++ b/cpp/src/aztec/lagrange_base_gen/lagrange_base_processor.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
     auto reference_string = std::make_shared<waffle::FileReferenceString>(subgroup_size, srs_path);
     std::vector<barretenberg::g1::affine_element> monomial_srs(subgroup_size);
     for (size_t i = 0; i < subgroup_size; ++i) {
-        monomial_srs[i] = reference_string->get_monomials()[2 * i];
+        monomial_srs[i] = reference_string->get_monomial_points()[2 * i];
     }
 
     auto verifier_ref_string = std::make_shared<waffle::VerifierFileReferenceString>(srs_path);

--- a/cpp/src/aztec/numeric/bitop/pow.hpp
+++ b/cpp/src/aztec/numeric/bitop/pow.hpp
@@ -25,4 +25,9 @@ constexpr uint64_t pow64(const uint64_t input, const uint64_t exponent)
     return accumulator;
 }
 
+constexpr bool is_power_of_two(uint64_t x)
+{
+    return x && !(x & (x - 1));
+}
+
 } // namespace numeric

--- a/cpp/src/aztec/plonk/composer/composer_base.cpp
+++ b/cpp/src/aztec/plonk/composer/composer_base.cpp
@@ -327,11 +327,11 @@ std::shared_ptr<verification_key> ComposerBase::compute_verification_key_base(
             selector_poly_coefficients = proving_key->polynomial_cache.get(selector_poly_label).get_coefficients();
 
             // Commit to the constraint selector polynomial and insert the commitment in the verification key.
-            auto selector_poly_commitment =
-                g1::affine_element(scalar_multiplication::pippenger(selector_poly_coefficients,
-                                                                    proving_key->reference_string->get_monomials(),
-                                                                    proving_key->circuit_size,
-                                                                    proving_key->pippenger_runtime_state));
+            auto selector_poly_commitment = g1::affine_element(
+                scalar_multiplication::pippenger(selector_poly_coefficients,
+                                                 proving_key->reference_string->get_monomial_points(),
+                                                 proving_key->circuit_size,
+                                                 proving_key->pippenger_runtime_state));
 
             circuit_verification_key->commitments.insert({ selector_commitment_label, selector_poly_commitment });
         }

--- a/cpp/src/aztec/plonk/proof_system/prover/c_bind.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/c_bind.cpp
@@ -49,6 +49,11 @@ WASM_EXPORT void prover_get_work_queue_item_info(WasmProver* prover, uint8_t* re
     memcpy(result, &info, sizeof(info));
 }
 
+WASM_EXPORT bool prover_get_scalar_multiplication_type(WasmProver* prover, size_t work_item_number)
+{
+    return prover->get_scalar_multiplication_type(work_item_number);
+}
+
 WASM_EXPORT fr* prover_get_scalar_multiplication_data(WasmProver* prover, size_t work_item_number)
 {
     return prover->get_scalar_multiplication_data(work_item_number);

--- a/cpp/src/aztec/plonk/proof_system/prover/c_bind_unrolled.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/c_bind_unrolled.cpp
@@ -26,6 +26,11 @@ WASM_EXPORT void unrolled_prover_get_work_queue_item_info(WasmUnrolledProver* pr
     memcpy(result, &info, sizeof(info));
 }
 
+WASM_EXPORT bool unrolled_prover_get_scalar_multiplication_type(WasmUnrolledProver* prover, size_t work_item_number)
+{
+    return prover->get_scalar_multiplication_type(work_item_number);
+}
+
 WASM_EXPORT fr* unrolled_prover_get_scalar_multiplication_data(WasmUnrolledProver* prover, size_t work_item_number)
 {
     return prover->get_scalar_multiplication_data(work_item_number);

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.hpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.hpp
@@ -56,6 +56,11 @@ template <typename settings> class ProverBase {
         return queue.get_scalar_multiplication_size(work_item_number);
     }
 
+    bool get_scalar_multiplication_type(const size_t work_item_number) const
+    {
+        return queue.get_scalar_multiplication_type(work_item_number);
+    }
+
     barretenberg::fr* get_ifft_data(const size_t work_item_number) const
     {
         return queue.get_ifft_data(work_item_number);

--- a/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
@@ -68,11 +68,11 @@ waffle::Verifier generate_verifier(std::shared_ptr<proving_key> circuit_proving_
     commitments.resize(8);
 
     for (size_t i = 0; i < 8; ++i) {
-        commitments[i] =
-            g1::affine_element(scalar_multiplication::pippenger(poly_coefficients[i],
-                                                                circuit_proving_key->reference_string->get_monomials(),
-                                                                circuit_proving_key->circuit_size,
-                                                                state));
+        commitments[i] = g1::affine_element(
+            scalar_multiplication::pippenger(poly_coefficients[i],
+                                             circuit_proving_key->reference_string->get_monomial_points(),
+                                             circuit_proving_key->circuit_size,
+                                             state));
     }
 
     auto crs = std::make_shared<waffle::VerifierFileReferenceString>("../srs_db/ignition");

--- a/cpp/src/aztec/proof_system/proving_key/proving_key.hpp
+++ b/cpp/src/aztec/proof_system/proving_key/proving_key.hpp
@@ -60,8 +60,9 @@ struct proving_key {
     barretenberg::evaluation_domain small_domain;
     barretenberg::evaluation_domain large_domain;
 
-    // We are keeping only one reference string which would be monomial srs if we use the Kate based PLONK,
-    // and Lagrange srs if we use the SHPLONK based PLONK.
+    // The reference_string object contains monomial as well as lagrange SRS. We can access them using:
+    // Monomial SRS: reference_string->get_monomial_points()
+    // Lagrange SRS: reference_string->get_lagrange_points()
     std::shared_ptr<ProverReferenceString> reference_string;
 
     barretenberg::polynomial quotient_polynomial_parts[NUM_QUOTIENT_PARTS];

--- a/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
@@ -50,12 +50,26 @@ size_t work_queue::get_scalar_multiplication_size(const size_t work_item_number)
     for (const auto& item : work_item_queue) {
         if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
             if (count == work_item_number) {
-                return item.constant == MSMSize::N ? key->circuit_size : key->circuit_size + 1;
+                return (item.constant == MSMType::MONOMIAL_N_PLUS_ONE) ? key->circuit_size + 1 : key->circuit_size;
             }
             ++count;
         }
     }
     return 0;
+}
+
+bool work_queue::get_scalar_multiplication_type(const size_t work_item_number) const
+{
+    size_t count = 0;
+    for (const auto& item : work_item_queue) {
+        if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
+            if (count == work_item_number) {
+                return (item.constant == MSMType::LAGRANGE_N);
+            }
+            ++count;
+        }
+    }
+    return false;
 }
 
 barretenberg::fr* work_queue::get_ifft_data(const size_t work_item_number) const
@@ -198,32 +212,54 @@ void work_queue::process_queue()
             // We use the variable work_item::constant to set the size of the multi-scalar multiplication.
             // Note that a size (n+1) MSM is always needed to commit to the quotient polynomial parts t_1, t_2
             // and t_3 for Standard/Turbo/Ultra due to the addition of blinding factors
-            if (item.constant == MSMSize::N_PLUS_ONE) {
-                if (key->reference_string->get_size() < key->small_domain.size + 1) {
-                    info("Reference string too small for Pippenger.");
+            size_t msm_size = 0;
+            barretenberg::g1::affine_element* srs_points;
+            switch (static_cast<size_t>(uint256_t(item.constant))) {
+            case MSMType::MONOMIAL_N: {
+                if (key->reference_string->get_monomial_size() < key->small_domain.size) {
+                    info("MSM: Monomial reference string size: ",
+                         key->reference_string->get_monomial_size(),
+                         ", required size: ",
+                         key->small_domain.size);
                 }
-                auto runtime_state =
-                    barretenberg::scalar_multiplication::pippenger_runtime_state(key->small_domain.size + 1);
-                barretenberg::g1::affine_element result(
-                    barretenberg::scalar_multiplication::pippenger_unsafe(item.mul_scalars,
-                                                                          key->reference_string->get_monomials(),
-                                                                          key->small_domain.size + 1,
-                                                                          runtime_state));
-
-                transcript->add_element(item.tag, result.to_buffer());
-            } else {
-                ASSERT(item.constant == MSMSize::N);
-                if (key->reference_string->get_size() < key->small_domain.size) {
-                    info("Reference string too small for Pippenger.");
-                }
-                barretenberg::g1::affine_element result(
-                    barretenberg::scalar_multiplication::pippenger_unsafe(item.mul_scalars,
-                                                                          key->reference_string->get_monomials(),
-                                                                          key->small_domain.size,
-                                                                          key->pippenger_runtime_state));
-
-                transcript->add_element(item.tag, result.to_buffer());
+                msm_size = key->small_domain.size;
+                srs_points = key->reference_string->get_monomial_points();
+                break;
             }
+            case MSMType::MONOMIAL_N_PLUS_ONE: {
+                if (key->reference_string->get_monomial_size() < key->small_domain.size + 1) {
+                    info("MSM: Monomial reference string size: ",
+                         key->reference_string->get_monomial_size(),
+                         ", required size: ",
+                         key->small_domain.size + 1);
+                }
+                msm_size = key->small_domain.size + 1;
+                srs_points = key->reference_string->get_monomial_points();
+                break;
+            }
+            case MSMType::LAGRANGE_N: {
+                if (key->reference_string->get_lagrange_size() != key->small_domain.size) {
+                    info("MSM: Lagrange reference string size: ",
+                         key->reference_string->get_lagrange_size(),
+                         ", required size: ",
+                         key->small_domain.size);
+                }
+                msm_size = key->small_domain.size;
+                srs_points = key->reference_string->get_lagrange_points();
+                break;
+            }
+            default: {
+                info("Incorrect item constant value: ", static_cast<size_t>(uint256_t(item.constant)));
+                srs_points = key->reference_string->get_monomial_points();
+            }
+            }
+
+            // Run pippenger multi-scalar multiplication.
+            auto runtime_state = barretenberg::scalar_multiplication::pippenger_runtime_state(msm_size);
+            barretenberg::g1::affine_element result(barretenberg::scalar_multiplication::pippenger_unsafe(
+                item.mul_scalars, srs_points, msm_size, runtime_state));
+
+            transcript->add_element(item.tag, result.to_buffer());
 
             break;
         }

--- a/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
@@ -58,6 +58,11 @@ size_t work_queue::get_scalar_multiplication_size(const size_t work_item_number)
     return 0;
 }
 
+/**
+ * Returns a boolean that denotes if the scalar multiplication is to be done with the Monomial SRS or Lagrange SRS.
+ * 0: MSM with Monomial SRS (size n or n + 1)
+ * 1: MSM with Lagrange SRS (size n)
+ */
 bool work_queue::get_scalar_multiplication_type(const size_t work_item_number) const
 {
     size_t count = 0;

--- a/cpp/src/aztec/proof_system/work_queue/work_queue.hpp
+++ b/cpp/src/aztec/proof_system/work_queue/work_queue.hpp
@@ -8,7 +8,7 @@ class work_queue {
 
   public:
     enum WorkType { FFT, SMALL_FFT, IFFT, SCALAR_MULTIPLICATION };
-    enum MSMSize { N, N_PLUS_ONE };
+    enum MSMType { MONOMIAL_N, MONOMIAL_N_PLUS_ONE, LAGRANGE_N };
 
     struct work_item_info {
         uint32_t num_scalar_multiplications;
@@ -41,6 +41,8 @@ class work_queue {
     barretenberg::fr* get_scalar_multiplication_data(const size_t work_item_number) const;
 
     size_t get_scalar_multiplication_size(const size_t work_item_number) const;
+
+    bool get_scalar_multiplication_type(const size_t work_item_number) const;
 
     barretenberg::fr* get_ifft_data(const size_t work_item_number) const;
 

--- a/cpp/src/aztec/srs/reference_string/file_reference_string.cpp
+++ b/cpp/src/aztec/srs/reference_string/file_reference_string.cpp
@@ -5,12 +5,12 @@
 
 namespace waffle {
 
-VerifierFileReferenceString::VerifierFileReferenceString(std::string const& path, bool is_lagrange)
+VerifierFileReferenceString::VerifierFileReferenceString(std::string const& path)
     : precomputed_g2_lines(
           (barretenberg::pairing::miller_lines*)(aligned_alloc(64, sizeof(barretenberg::pairing::miller_lines) * 2)))
 {
 
-    barretenberg::io::read_transcript_g2(g2_x, path, is_lagrange);
+    barretenberg::io::read_transcript_g2(g2_x, path);
     barretenberg::pairing::precompute_miller_lines(barretenberg::g2::one, precomputed_g2_lines[0]);
     barretenberg::pairing::precompute_miller_lines(g2_x, precomputed_g2_lines[1]);
 }

--- a/cpp/src/aztec/srs/reference_string/reference_string.hpp
+++ b/cpp/src/aztec/srs/reference_string/reference_string.hpp
@@ -27,8 +27,10 @@ class ProverReferenceString {
     virtual ~ProverReferenceString() = default;
     ;
 
-    virtual barretenberg::g1::affine_element* get_monomials() = 0;
-    virtual size_t get_size() const = 0;
+    virtual barretenberg::g1::affine_element* get_monomial_points() = 0;
+    virtual barretenberg::g1::affine_element* get_lagrange_points() = 0;
+    virtual size_t get_monomial_size() const = 0;
+    virtual size_t get_lagrange_size() const = 0;
 };
 
 class ReferenceStringFactory {


### PR DESCRIPTION

# **Copied from PR https://github.com/AztecProtocol/barretenberg/pull/39**
   - **Original author: @suyash67**
   - This copy uses branches with git history restored

---

Committing to the wire polynomials with Lagrange srs is expected to improve the proof construction time. This is because the wire values are very small in magnitude as compared to the field size, and the resulting MSM while computing the commitments to the wire polynomials is faster.

This is going to be very useful if/when we start using the new lookup argument for doing permutation check ([paper](https://eprint.iacr.org/2022/1530.pdf)).
---

# Comments from original PR

## **Copied from comment (https://github.com/AztecProtocol/barretenberg/pull/39#issuecomment-1375487455) by author @suyash67**

Note: we need to merge #36 before this one.
