### PR TITLE
Skip some recursion tests.

### DIFF
--- a/cpp/src/aztec/stdlib/recursion/verifier/verifier.test.cpp
+++ b/cpp/src/aztec/stdlib/recursion/verifier/verifier.test.cpp
@@ -1,5 +1,6 @@
 #include "verifier.hpp"
 #include <common/test.hpp>
+#include <gtest/internal/gtest-internal.h>
 #include <transcript/transcript.hpp>
 #include <proof_system/proving_key/serialize.hpp>
 #include <stdlib/primitives/curves/bn254.hpp>
@@ -634,17 +635,20 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
     }
 };
 
-typedef testing::Types<waffle::StandardComposer, waffle::TurboComposer, waffle::UltraComposer> OuterComposerTypes;
+typedef testing::Types<waffle::StandardComposer, /* waffle::TurboComposer,  */ waffle::UltraComposer>
+    OuterComposerTypes;
 
 TYPED_TEST_SUITE(stdlib_verifier, OuterComposerTypes);
 
 HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition();
 };
 
 HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_ultra_no_tables)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition_ultra_no_tables();
 };
 
@@ -661,16 +665,19 @@ HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_with_variable_veri
 
 HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_with_variable_verification_key_b)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition_with_variable_verification_key_b();
 }
 
 HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_var_verif_key_fail)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition_with_variable_verification_key_failure_case();
 }
 
 HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_const_verif_key)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition_with_constant_verification_key();
 }
 

--- a/cpp/src/aztec/stdlib/recursion/verifier/verifier.test.cpp
+++ b/cpp/src/aztec/stdlib/recursion/verifier/verifier.test.cpp
@@ -642,7 +642,6 @@ TYPED_TEST_SUITE(stdlib_verifier, OuterComposerTypes);
 
 HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition)
 {
-    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition();
 };
 

--- a/cpp/src/aztec/stdlib/recursion/verifier/verifier_turbo.test.cpp
+++ b/cpp/src/aztec/stdlib/recursion/verifier/verifier_turbo.test.cpp
@@ -474,11 +474,13 @@ TYPED_TEST_SUITE(stdlib_verifier_turbo, OuterComposerTypes);
 
 HEAVY_TYPED_TEST(stdlib_verifier_turbo, recursive_proof_composition)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition();
 };
 
 HEAVY_TYPED_TEST(stdlib_verifier_turbo, double_verification)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_double_verification();
 };
 
@@ -489,16 +491,19 @@ HEAVY_TYPED_TEST(stdlib_verifier_turbo, recursive_proof_composition_with_variabl
 
 HEAVY_TYPED_TEST(stdlib_verifier_turbo, recursive_proof_composition_with_variable_verification_key_b)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition_with_variable_verification_key_b();
 }
 
 HEAVY_TYPED_TEST(stdlib_verifier_turbo, recursive_proof_composition_var_verif_key_fail)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition_with_variable_verification_key_failure_case();
 }
 
 HEAVY_TYPED_TEST(stdlib_verifier_turbo, recursive_proof_composition_const_verif_key)
 {
+    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition_with_constant_verification_key();
 }
 

--- a/cpp/src/aztec/stdlib/recursion/verifier/verifier_turbo.test.cpp
+++ b/cpp/src/aztec/stdlib/recursion/verifier/verifier_turbo.test.cpp
@@ -474,7 +474,6 @@ TYPED_TEST_SUITE(stdlib_verifier_turbo, OuterComposerTypes);
 
 HEAVY_TYPED_TEST(stdlib_verifier_turbo, recursive_proof_composition)
 {
-    GTEST_SKIP_("Skipping to reduce CI time.");
     TestFixture::test_recursive_proof_composition();
 };
 


### PR DESCRIPTION

# **Copied from PR https://github.com/AztecProtocol/barretenberg/pull/60**
   - **Original author: @codygunton**
   - This copy uses branches with git history restored

---

The set of stdlib recursion tests seems to be overkill, given that we are going to significantly change recursion before it's ever put into production again. Reducing that set of tests to speed up CI time.
---
