### PR TITLE
Fixed stdlib ecdsa issue and added benchmarking to the test

### DIFF
--- a/cpp/src/aztec/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/cpp/src/aztec/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -47,6 +47,7 @@ TEST(stdlib_ecdsa, verify_signature)
     EXPECT_EQ(signature_result.get_value(), true);
 
     std::cerr << "composer gates = " << composer.get_num_gates() << std::endl;
+    benchmark_info("UltraComposer", "ECDSA", "Signature Verification Test", "Gate Count", composer.get_num_gates());
     auto prover = composer.create_prover();
     auto verifier = composer.create_verifier();
     auto proof = prover.construct_proof();

--- a/cpp/src/aztec/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/cpp/src/aztec/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -244,7 +244,7 @@ bigfield<C, T> bigfield<C, T>::create_from_u512_as_witness(C* ctx,
 
 template <typename C, typename T> bigfield<C, T>::bigfield(const byte_array<C>& bytes)
 {
-
+    ASSERT(bytes.size() == 32); // we treat input as a 256-bit big integer
     const auto split_byte_into_nibbles = [](C* ctx, const field_t<C>& split_byte) {
         const uint64_t byte_val = uint256_t(split_byte.get_value()).data[0];
         const uint64_t lo_nibble_val = byte_val & 15ULL;
@@ -285,6 +285,8 @@ template <typename C, typename T> bigfield<C, T>::bigfield(const byte_array<C>& 
 
     const auto res = bigfield(limb0, limb1, limb2, limb3, true);
 
+    const auto num_last_limb_bits = 256 - (NUM_LIMB_BITS * 3);
+    res.binary_basis_limbs[3].maximum_value = (uint64_t(1) << num_last_limb_bits);
     *this = res;
 }
 


### PR DESCRIPTION

# **Copied from PR https://github.com/AztecProtocol/barretenberg/pull/80**
   - **Original author: @Rumata888**
   - This copy uses branches with git history restored

---

# Description

Fixed stdlib ecdsa issue and added benchmarking to the test
# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.

---
