### PR TITLE
Simplifying the commitment maps in vkey

### DIFF
--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -302,9 +302,8 @@ TEST(standard_honk_composer, test_verification_key_creation)
     // There is nothing we can really check apart from the fact that constraint selectors and permutation selectors were
     // committed to, we simply check that the verification key now contains the appropriate number of constraint and
     // permutation selector commitments. This method should work with any future arithemtization.
-    // Note(luke): permutation_selectors contains 2*program_width perm/id commitments + 2 lagrange poly commitments.
-    EXPECT_EQ(verification_key->constraint_selectors.size(), composer.circuit_constructor.selectors.size());
-    EXPECT_EQ(verification_key->permutation_selectors.size(), composer.program_width * 2 + 2);
+    EXPECT_EQ(verification_key->commitments.size(),
+              composer.circuit_constructor.selectors.size() + composer.program_width * 2 + 2);
 }
 
 /**

--- a/cpp/src/aztec/honk/proof_system/verifier.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.cpp
@@ -180,15 +180,10 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
             commitment = transcript.get_group_element(commitment_label);
             break;
         }
-        case waffle::SELECTOR: {
-            commitment = key->constraint_selectors[commitment_label];
-            break;
-        }
-        // Note(luke): polys with label PERMUTATION and OTHER are both stored in 'permutation_selectors'. See
-        // 'compute_verification_key_base'.
+        case waffle::SELECTOR:
         case waffle::PERMUTATION:
         case waffle::OTHER: {
-            commitment = key->permutation_selectors[commitment_label];
+            commitment = key->commitments[commitment_label];
             break;
         }
         }

--- a/cpp/src/aztec/honk/proof_system/verifier.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.test.cpp
@@ -53,15 +53,15 @@ template <class FF> class VerifierTests : public testing::Test {
         auto circuit_verification_key = std::make_shared<waffle::verification_key>(
             circuit_proving_key->n, circuit_proving_key->num_public_inputs, crs, circuit_proving_key->composer_type);
 
-        circuit_verification_key->constraint_selectors.insert({ "Q_1", commitments[0] });
-        circuit_verification_key->constraint_selectors.insert({ "Q_2", commitments[1] });
-        circuit_verification_key->constraint_selectors.insert({ "Q_3", commitments[2] });
-        circuit_verification_key->constraint_selectors.insert({ "Q_M", commitments[3] });
-        circuit_verification_key->constraint_selectors.insert({ "Q_C", commitments[4] });
+        circuit_verification_key->commitments.insert({ "Q_1", commitments[0] });
+        circuit_verification_key->commitments.insert({ "Q_2", commitments[1] });
+        circuit_verification_key->commitments.insert({ "Q_3", commitments[2] });
+        circuit_verification_key->commitments.insert({ "Q_M", commitments[3] });
+        circuit_verification_key->commitments.insert({ "Q_C", commitments[4] });
 
-        circuit_verification_key->permutation_selectors.insert({ "SIGMA_1", commitments[5] });
-        circuit_verification_key->permutation_selectors.insert({ "SIGMA_2", commitments[6] });
-        circuit_verification_key->permutation_selectors.insert({ "SIGMA_3", commitments[7] });
+        circuit_verification_key->commitments.insert({ "SIGMA_1", commitments[5] });
+        circuit_verification_key->commitments.insert({ "SIGMA_2", commitments[6] });
+        circuit_verification_key->commitments.insert({ "SIGMA_3", commitments[7] });
 
         StandardVerifier verifier(circuit_verification_key, create_manifest(0, circuit_proving_key->log_n));
 

--- a/cpp/src/aztec/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
+++ b/cpp/src/aztec/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
@@ -284,23 +284,14 @@ void KateCommitmentScheme<settings>::batch_verify(const transcript::StandardTran
             kate_g1_elements.insert({ label, element });
             break;
         }
-        case PolynomialSource::SELECTOR: {
-            // add [qL]_1, [qR]_1, [qM]_1, [qC]_1, [qO]_1 to the group elements' vector
-            const auto element = input_key->constraint_selectors.at(label);
+        case PolynomialSource::SELECTOR:
+        case PolynomialSource::PERMUTATION: {
+            // add [qL]_1, [qR]_1, [qM]_1, [qC]_1, [qO]_1, [\sigma_1]_1, [\sigma_2]_1, [\sigma_3]_1 to the commitments
+            // map.
+            const auto element = input_key->commitments.at(label);
             // selectors can be all zeros so infinity point is valid
             if (!element.on_curve()) {
                 throw_or_abort("polynomial commitment to selector is not a valid point.");
-            }
-            kate_g1_elements.insert({ label, element });
-            break;
-        }
-        case PolynomialSource::PERMUTATION: {
-
-            // add [\sigma_1]_1, [\sigma_2]_1, [\sigma_3]_1 to the group elements' vector
-            const auto element = input_key->permutation_selectors.at(label);
-            // selectors can be all zeros so infinity point is valid
-            if (!element.on_curve()) {
-                throw_or_abort("polynomial commitment to permutation selector is not a valid point.");
             }
             kate_g1_elements.insert({ label, element });
             break;

--- a/cpp/src/aztec/plonk/proof_system/utils/kate_verification.hpp
+++ b/cpp/src/aztec/plonk/proof_system/utils/kate_verification.hpp
@@ -77,13 +77,9 @@ void populate_kate_element_map(verification_key* key,
             kate_g1_elements.insert({ label, element });
             break;
         }
-        case PolynomialSource::SELECTOR: {
-            const auto element = key->constraint_selectors.at(label);
-            kate_g1_elements.insert({ label, element });
-            break;
-        }
+        case PolynomialSource::SELECTOR:
         case PolynomialSource::PERMUTATION: {
-            const auto element = key->permutation_selectors.at(label);
+            const auto element = key->commitments.at(label);
             kate_g1_elements.insert({ label, element });
             break;
         }
@@ -140,21 +136,21 @@ inline void print_turbo_verification_key(verification_key* key)
     print_fr("work_root", key->domain.root);
     print_fr("domain_inverse", key->domain.domain_inverse);
     print_fr("work_root_inverse", key->domain.root_inverse);
-    print_g1("Q1", key->constraint_selectors.at("Q_1"));
-    print_g1("Q2", key->constraint_selectors.at("Q_2"));
-    print_g1("Q3", key->constraint_selectors.at("Q_3"));
-    print_g1("Q4", key->constraint_selectors.at("Q_4"));
-    print_g1("Q5", key->constraint_selectors.at("Q_5"));
-    print_g1("QM", key->constraint_selectors.at("Q_M"));
-    print_g1("QC", key->constraint_selectors.at("Q_C"));
-    print_g1("QARITH", key->constraint_selectors.at("Q_ARITHMETIC"));
-    print_g1("QFIXEDBASE", key->constraint_selectors.at("Q_FIXED_BASE"));
-    print_g1("QRANGE", key->constraint_selectors.at("Q_RANGE"));
-    print_g1("QLOGIC", key->constraint_selectors.at("Q_LOGIC"));
-    print_g1("sigma_commitments[0]", key->permutation_selectors.at("SIGMA_1"));
-    print_g1("sigma_commitments[1]", key->permutation_selectors.at("SIGMA_2"));
-    print_g1("sigma_commitments[2]", key->permutation_selectors.at("SIGMA_3"));
-    print_g1("sigma_commitments[3]", key->permutation_selectors.at("SIGMA_4"));
+    print_g1("Q1", key->commitments.at("Q_1"));
+    print_g1("Q2", key->commitments.at("Q_2"));
+    print_g1("Q3", key->commitments.at("Q_3"));
+    print_g1("Q4", key->commitments.at("Q_4"));
+    print_g1("Q5", key->commitments.at("Q_5"));
+    print_g1("QM", key->commitments.at("Q_M"));
+    print_g1("QC", key->commitments.at("Q_C"));
+    print_g1("QARITH", key->commitments.at("Q_ARITHMETIC"));
+    print_g1("QFIXEDBASE", key->commitments.at("Q_FIXED_BASE"));
+    print_g1("QRANGE", key->commitments.at("Q_RANGE"));
+    print_g1("QLOGIC", key->commitments.at("Q_LOGIC"));
+    print_g1("sigma_commitments[0]", key->commitments.at("SIGMA_1"));
+    print_g1("sigma_commitments[1]", key->commitments.at("SIGMA_2"));
+    print_g1("sigma_commitments[2]", key->commitments.at("SIGMA_3"));
+    print_g1("sigma_commitments[3]", key->commitments.at("SIGMA_4"));
     print_fr("permutation_non_residues[0]", 5);
     print_fr("permutation_non_residues[1]", 6);
     print_fr("permutation_non_residues[2]", 7);

--- a/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
@@ -79,15 +79,15 @@ waffle::Verifier generate_verifier(std::shared_ptr<proving_key> circuit_proving_
     std::shared_ptr<verification_key> circuit_verification_key = std::make_shared<verification_key>(
         circuit_proving_key->n, circuit_proving_key->num_public_inputs, crs, circuit_proving_key->composer_type);
 
-    circuit_verification_key->constraint_selectors.insert({ "Q_1", commitments[0] });
-    circuit_verification_key->constraint_selectors.insert({ "Q_2", commitments[1] });
-    circuit_verification_key->constraint_selectors.insert({ "Q_3", commitments[2] });
-    circuit_verification_key->constraint_selectors.insert({ "Q_M", commitments[3] });
-    circuit_verification_key->constraint_selectors.insert({ "Q_C", commitments[4] });
+    circuit_verification_key->commitments.insert({ "Q_1", commitments[0] });
+    circuit_verification_key->commitments.insert({ "Q_2", commitments[1] });
+    circuit_verification_key->commitments.insert({ "Q_3", commitments[2] });
+    circuit_verification_key->commitments.insert({ "Q_M", commitments[3] });
+    circuit_verification_key->commitments.insert({ "Q_C", commitments[4] });
 
-    circuit_verification_key->permutation_selectors.insert({ "SIGMA_1", commitments[5] });
-    circuit_verification_key->permutation_selectors.insert({ "SIGMA_2", commitments[6] });
-    circuit_verification_key->permutation_selectors.insert({ "SIGMA_3", commitments[7] });
+    circuit_verification_key->commitments.insert({ "SIGMA_1", commitments[5] });
+    circuit_verification_key->commitments.insert({ "SIGMA_2", commitments[6] });
+    circuit_verification_key->commitments.insert({ "SIGMA_3", commitments[7] });
 
     Verifier verifier(circuit_verification_key, create_manifest());
 

--- a/cpp/src/aztec/proof_system/verification_key/sol_gen.hpp
+++ b/cpp/src/aztec/proof_system/verification_key/sol_gen.hpp
@@ -35,14 +35,14 @@ inline void output_vk_sol(std::ostream& os, std::shared_ptr<verification_key> co
     print_u256("0x20", key->num_public_inputs, "vk.num_inputs");
     print_u256("0x40", key->domain.root, "vk.work_root");
     print_u256("0x60", key->domain.domain_inverse, "vk.domain_inverse");
-    print_g1("0x80", "0xa0", key->constraint_selectors.at("Q_1"), "vk.Q1");
-    print_g1("0xc0", "0xe0", key->constraint_selectors.at("Q_2"), "vk.Q2");
-    print_g1("0x100", "0x120", key->constraint_selectors.at("Q_3"), "vk.Q3");
-    print_g1("0x140", "0x160", key->constraint_selectors.at("Q_M"), "vk.QM");
-    print_g1("0x180", "0x1a0", key->constraint_selectors.at("Q_C"), "vk.QC");
-    print_g1("0x1c0", "0x1e0", key->permutation_selectors.at("SIGMA_1"), "vk.SIGMA1");
-    print_g1("0x200", "0x220", key->permutation_selectors.at("SIGMA_2"), "vk.SIGMA2");
-    print_g1("0x240", "0x260", key->permutation_selectors.at("SIGMA_3"), "vk.SIGMA3");
+    print_g1("0x80", "0xa0", key->commitments.at("Q_1"), "vk.Q1");
+    print_g1("0xc0", "0xe0", key->commitments.at("Q_2"), "vk.Q2");
+    print_g1("0x100", "0x120", key->commitments.at("Q_3"), "vk.Q3");
+    print_g1("0x140", "0x160", key->commitments.at("Q_M"), "vk.QM");
+    print_g1("0x180", "0x1a0", key->commitments.at("Q_C"), "vk.QC");
+    print_g1("0x1c0", "0x1e0", key->commitments.at("SIGMA_1"), "vk.SIGMA1");
+    print_g1("0x200", "0x220", key->commitments.at("SIGMA_2"), "vk.SIGMA2");
+    print_g1("0x240", "0x260", key->commitments.at("SIGMA_3"), "vk.SIGMA3");
     os <<
         "            mstore(add(_vk, 0x280), " << (key->contains_recursive_proof ? "0x01" : "0x00") << ") // vk.contains_recursive_proof\n"
         "            mstore(add(_vk, 0x2a0), " << (key->contains_recursive_proof ? key->recursive_proof_public_input_indices[0] : 0) << ") // vk.recursive_proof_public_input_indices\n"

--- a/cpp/src/aztec/proof_system/verification_key/verification_key.cpp
+++ b/cpp/src/aztec/proof_system/verification_key/verification_key.cpp
@@ -24,8 +24,7 @@ verification_key::verification_key(verification_key_data&& data, std::shared_ptr
     , num_public_inputs(data.num_public_inputs)
     , domain(n)
     , reference_string(crs)
-    , constraint_selectors(std::move(data.constraint_selectors))
-    , permutation_selectors(std::move(data.permutation_selectors))
+    , commitments(std::move(data.commitments))
     , polynomial_manifest(data.composer_type)
     , contains_recursive_proof(data.contains_recursive_proof)
     , recursive_proof_public_input_indices(std::move(data.recursive_proof_public_input_indices))
@@ -38,8 +37,7 @@ verification_key::verification_key(const verification_key& other)
     , num_public_inputs(other.num_public_inputs)
     , domain(other.domain)
     , reference_string(other.reference_string)
-    , constraint_selectors(other.constraint_selectors)
-    , permutation_selectors(other.permutation_selectors)
+    , commitments(other.commitments)
     , polynomial_manifest(other.polynomial_manifest)
     , contains_recursive_proof(other.contains_recursive_proof)
     , recursive_proof_public_input_indices(other.recursive_proof_public_input_indices)
@@ -52,8 +50,7 @@ verification_key::verification_key(verification_key&& other)
     , num_public_inputs(other.num_public_inputs)
     , domain(other.domain)
     , reference_string(other.reference_string)
-    , constraint_selectors(other.constraint_selectors)
-    , permutation_selectors(other.permutation_selectors)
+    , commitments(other.commitments)
     , polynomial_manifest(other.polynomial_manifest)
     , contains_recursive_proof(other.contains_recursive_proof)
     , recursive_proof_public_input_indices(other.recursive_proof_public_input_indices)
@@ -66,8 +63,7 @@ verification_key& verification_key::operator=(verification_key&& other)
     log_n = numeric::get_msb(other.n);
     num_public_inputs = other.num_public_inputs;
     reference_string = std::move(other.reference_string);
-    constraint_selectors = std::move(other.constraint_selectors);
-    permutation_selectors = std::move(other.permutation_selectors);
+    commitments = std::move(other.commitments);
     polynomial_manifest = std::move(other.polynomial_manifest);
     domain = std::move(other.domain);
     contains_recursive_proof = (other.contains_recursive_proof);
@@ -80,11 +76,7 @@ sha256::hash verification_key::sha256_hash()
     std::vector<uint256_t> vk_data;
     vk_data.emplace_back(n);
     vk_data.emplace_back(num_public_inputs);
-    for (auto& commitment_entry : constraint_selectors) {
-        vk_data.emplace_back(commitment_entry.second.x);
-        vk_data.emplace_back(commitment_entry.second.y);
-    }
-    for (auto& commitment_entry : permutation_selectors) {
+    for (auto& commitment_entry : commitments) {
         vk_data.emplace_back(commitment_entry.second.x);
         vk_data.emplace_back(commitment_entry.second.y);
     }

--- a/cpp/src/aztec/proof_system/verification_key/verification_key.hpp
+++ b/cpp/src/aztec/proof_system/verification_key/verification_key.hpp
@@ -11,8 +11,7 @@ struct verification_key_data {
     uint32_t composer_type;
     uint32_t n;
     uint32_t num_public_inputs;
-    std::map<std::string, barretenberg::g1::affine_element> constraint_selectors;
-    std::map<std::string, barretenberg::g1::affine_element> permutation_selectors;
+    std::map<std::string, barretenberg::g1::affine_element> commitments;
     bool contains_recursive_proof = false;
     std::vector<uint32_t> recursive_proof_public_input_indices;
 };
@@ -23,8 +22,7 @@ template <typename B> inline void read(B& buf, verification_key_data& key)
     read(buf, key.composer_type);
     read(buf, key.n);
     read(buf, key.num_public_inputs);
-    read(buf, key.constraint_selectors);
-    read(buf, key.permutation_selectors);
+    read(buf, key.commitments);
     read(buf, key.contains_recursive_proof);
     read(buf, key.recursive_proof_public_input_indices);
 }
@@ -35,8 +33,7 @@ template <typename B> inline void write(B& buf, verification_key_data const& key
     write(buf, key.composer_type);
     write(buf, key.n);
     write(buf, key.num_public_inputs);
-    write(buf, key.constraint_selectors);
-    write(buf, key.permutation_selectors);
+    write(buf, key.commitments);
     write(buf, key.contains_recursive_proof);
     write(buf, key.recursive_proof_public_input_indices);
 }
@@ -44,8 +41,7 @@ template <typename B> inline void write(B& buf, verification_key_data const& key
 inline bool operator==(verification_key_data const& lhs, verification_key_data const& rhs)
 {
     return lhs.composer_type == rhs.composer_type && lhs.n == rhs.n && lhs.num_public_inputs == rhs.num_public_inputs &&
-           lhs.constraint_selectors == rhs.constraint_selectors &&
-           lhs.permutation_selectors == rhs.permutation_selectors;
+           lhs.commitments == rhs.commitments;
 }
 
 struct verification_key {
@@ -71,9 +67,7 @@ struct verification_key {
 
     std::shared_ptr<VerifierReferenceString> reference_string;
 
-    std::map<std::string, barretenberg::g1::affine_element> constraint_selectors;
-
-    std::map<std::string, barretenberg::g1::affine_element> permutation_selectors;
+    std::map<std::string, barretenberg::g1::affine_element> commitments;
 
     PolynomialManifest polynomial_manifest;
 
@@ -92,8 +86,7 @@ template <typename B> inline void write(B& buf, verification_key const& key)
     write(buf, key.composer_type);
     write(buf, static_cast<uint32_t>(key.n));
     write(buf, static_cast<uint32_t>(key.num_public_inputs));
-    write(buf, key.constraint_selectors);
-    write(buf, key.permutation_selectors);
+    write(buf, key.commitments);
     write(buf, key.contains_recursive_proof);
     write(buf, key.recursive_proof_public_input_indices);
 }

--- a/cpp/src/aztec/proof_system/verification_key/verification_key.test.cpp
+++ b/cpp/src/aztec/proof_system/verification_key/verification_key.test.cpp
@@ -11,10 +11,10 @@ TEST(verification_key, buffer_serialization)
     key.composer_type = static_cast<uint32_t>(ComposerType::STANDARD);
     key.n = 1234;
     key.num_public_inputs = 10;
-    key.constraint_selectors["test1"] = g1::element::random_element();
-    key.constraint_selectors["test2"] = g1::element::random_element();
-    key.permutation_selectors["foo1"] = g1::element::random_element();
-    key.permutation_selectors["foo2"] = g1::element::random_element();
+    key.commitments["test1"] = g1::element::random_element();
+    key.commitments["test2"] = g1::element::random_element();
+    key.commitments["foo1"] = g1::element::random_element();
+    key.commitments["foo2"] = g1::element::random_element();
 
     auto buf = to_buffer(key);
     auto result = from_buffer<verification_key_data>(buf);
@@ -28,10 +28,10 @@ TEST(verification_key, stream_serialization)
     key.composer_type = static_cast<uint32_t>(ComposerType::STANDARD);
     key.n = 1234;
     key.num_public_inputs = 10;
-    key.constraint_selectors["test1"] = g1::element::random_element();
-    key.constraint_selectors["test2"] = g1::element::random_element();
-    key.permutation_selectors["foo1"] = g1::element::random_element();
-    key.permutation_selectors["foo2"] = g1::element::random_element();
+    key.commitments["test1"] = g1::element::random_element();
+    key.commitments["test2"] = g1::element::random_element();
+    key.commitments["foo1"] = g1::element::random_element();
+    key.commitments["foo2"] = g1::element::random_element();
 
     std::stringstream s;
     write(s, key);

--- a/cpp/src/aztec/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/aztec/stdlib/recursion/verification_key/verification_key.hpp
@@ -123,12 +123,8 @@ template <typename Curve> struct verification_key {
         key->num_public_inputs = witness_t<Composer>(ctx, input_key->num_public_inputs);
         key->domain = evaluation_domain<Composer>::from_witness(ctx, input_key->domain);
 
-        for (const auto& [tag, value] : input_key->constraint_selectors) {
-            key->constraint_selectors.insert({ tag, Curve::g1_ct::from_witness(ctx, value) });
-        }
-
-        for (const auto& [tag, value] : input_key->permutation_selectors) {
-            key->permutation_selectors.insert({ tag, Curve::g1_ct::from_witness(ctx, value) });
+        for (const auto& [tag, value] : input_key->commitments) {
+            key->commitments.insert({ tag, Curve::g1_ct::from_witness(ctx, value) });
         }
 
         return key;
@@ -147,12 +143,10 @@ template <typename Curve> struct verification_key {
 
         key->reference_string = input_key->reference_string;
 
-        for (const auto& [tag, value] : input_key->constraint_selectors) {
-            key->constraint_selectors.insert({ tag, typename Curve::g1_ct(value) });
+        for (const auto& [tag, value] : input_key->commitments) {
+            key->commitments.insert({ tag, typename Curve::g1_ct(value) });
         }
-        for (const auto& [tag, value] : input_key->permutation_selectors) {
-            key->permutation_selectors.insert({ tag, typename Curve::g1_ct(value) });
-        }
+
         key->polynomial_manifest = input_key->polynomial_manifest;
 
         return key;
@@ -201,17 +195,7 @@ template <typename Curve> struct verification_key {
         std::vector<field_t<Composer>> key_witnesses;
         key_witnesses.push_back(compressed_domain);
         key_witnesses.push_back(num_public_inputs);
-        for (const auto& [tag, selector] : constraint_selectors) {
-            key_witnesses.push_back(selector.x.binary_basis_limbs[0].element);
-            key_witnesses.push_back(selector.x.binary_basis_limbs[1].element);
-            key_witnesses.push_back(selector.x.binary_basis_limbs[2].element);
-            key_witnesses.push_back(selector.x.binary_basis_limbs[3].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[0].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[1].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[2].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[3].element);
-        }
-        for (const auto& [tag, selector] : permutation_selectors) {
+        for (const auto& [tag, selector] : commitments) {
             key_witnesses.push_back(selector.x.binary_basis_limbs[0].element);
             key_witnesses.push_back(selector.x.binary_basis_limbs[1].element);
             key_witnesses.push_back(selector.x.binary_basis_limbs[2].element);
@@ -248,21 +232,7 @@ template <typename Curve> struct verification_key {
         std::vector<barretenberg::fr> key_witnesses;
         key_witnesses.push_back(compressed_domain);
         key_witnesses.push_back(key->num_public_inputs);
-        for (const auto& [tag, selector] : key->constraint_selectors) {
-            const auto x_limbs = split_bigfield_limbs(selector.x);
-            const auto y_limbs = split_bigfield_limbs(selector.y);
-
-            key_witnesses.push_back(x_limbs[0]);
-            key_witnesses.push_back(x_limbs[1]);
-            key_witnesses.push_back(x_limbs[2]);
-            key_witnesses.push_back(x_limbs[3]);
-
-            key_witnesses.push_back(y_limbs[0]);
-            key_witnesses.push_back(y_limbs[1]);
-            key_witnesses.push_back(y_limbs[2]);
-            key_witnesses.push_back(y_limbs[3]);
-        }
-        for (const auto& [tag, selector] : key->permutation_selectors) {
+        for (const auto& [tag, selector] : key->commitments) {
             const auto x_limbs = split_bigfield_limbs(selector.x);
             const auto y_limbs = split_bigfield_limbs(selector.y);
 
@@ -293,8 +263,7 @@ template <typename Curve> struct verification_key {
 
     evaluation_domain<Composer> domain;
 
-    std::map<std::string, typename Curve::g1_ct> constraint_selectors;
-    std::map<std::string, typename Curve::g1_ct> permutation_selectors;
+    std::map<std::string, typename Curve::g1_ct> commitments;
 
     // Native data:
 

--- a/cpp/src/aztec/stdlib/recursion/verifier/verifier.hpp
+++ b/cpp/src/aztec/stdlib/recursion/verifier/verifier.hpp
@@ -74,30 +74,17 @@ void populate_kate_element_map(typename Curve::Composer* ctx,
             kate_g1_elements.insert({ label, g1_ct::from_witness(ctx, element) });
             break;
         }
-        case waffle::PolynomialSource::SELECTOR: {
-            const auto element = key->constraint_selectors.at(label);
-            // TODO: with user-defined circuits, we will need verify that the point
-            // lies on the curve with constraints
-            if (!element.get_value().on_curve()) {
-                std::cerr << label << " constraint selector not on curve!" << std::endl;
-            }
-            if (element.get_value().is_point_at_infinity()) {
-                std::cerr << label << " constraint selector is point at infinity! Error!" << std::endl;
-                ctx->failure("constraint selector " + label + " is point at infinity");
-            }
-            kate_g1_elements.insert({ label, element });
-            break;
-        }
+        case waffle::PolynomialSource::SELECTOR:
         case waffle::PolynomialSource::PERMUTATION: {
-            const auto element = key->permutation_selectors.at(label);
+            const auto element = key->commitments.at(label);
             // TODO: with user-defined circuits, we will need verify that the point
             // lies on the curve with constraints
             if (!element.get_value().on_curve()) {
-                std::cerr << label << " permutation selector not on curve!" << std::endl;
+                std::cerr << label << " commitment not on curve!" << std::endl;
             }
             if (element.get_value().is_point_at_infinity()) {
-                std::cerr << label << " permutation selector is point at infinity! Error!" << std::endl;
-                ctx->failure("permutation selector " + label + " is point at infinity");
+                std::cerr << label << " commitment is point at infinity! Error!" << std::endl;
+                ctx->failure("commitment " + label + " is point at infinity");
             }
             kate_g1_elements.insert({ label, element });
             break;


### PR DESCRIPTION

# **Copied from PR https://github.com/AztecProtocol/barretenberg/pull/82**
   - **Original author: @ledwards2225**
   - This copy uses branches with git history restored

---

# Description

Replacing std::maps called `permutation_selectors` and `constraint_selectors` in verification key with a single map called `commitments`. It holds all the commitments..

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.

---
