### PR TITLE
Added dynamic array abstraction into standard library

### DIFF
--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -7,5 +7,6 @@ srs_db/ignition/transcript*
 srs_db/lagrange
 srs_db/coset_lagrange
 srs_db/modified_lagrange
+.vscode/settings.json
 # to be unignored when we agree on clang-tidy rules
 .clangd

--- a/cpp/src/aztec/plonk/composer/ultra_composer.cpp
+++ b/cpp/src/aztec/plonk/composer/ultra_composer.cpp
@@ -1258,8 +1258,15 @@ std::vector<uint32_t> UltraComposer::decompose_into_default_range(const uint32_t
     return sublimb_indices;
 }
 
-void UltraComposer::create_new_range_constraint(const uint32_t variable_index, const uint64_t target_range)
+void UltraComposer::create_new_range_constraint(const uint32_t variable_index,
+                                                const uint64_t target_range,
+                                                std::string const msg)
 {
+    if (uint256_t(get_variable(variable_index)).data[0] > target_range) {
+        if (!failed()) {
+            failure(msg);
+        }
+    }
     if (range_lists.count(target_range) == 0) {
         range_lists.insert({ target_range, create_range_list(target_range) });
     }

--- a/cpp/src/aztec/plonk/composer/ultra_composer.hpp
+++ b/cpp/src/aztec/plonk/composer/ultra_composer.hpp
@@ -189,13 +189,15 @@ class UltraComposer : public ComposerBase {
         }
     }
 
-    void create_new_range_constraint(const uint32_t variable_index, const uint64_t target_range);
-    void create_range_constraint(const uint32_t variable_index, const size_t num_bits, std::string const&)
+    void create_new_range_constraint(const uint32_t variable_index,
+                                     const uint64_t target_range,
+                                     std::string const msg = "create_new_range_constraint");
+    void create_range_constraint(const uint32_t variable_index, const size_t num_bits, std::string const& msg)
     {
         if (num_bits <= DEFAULT_PLOOKUP_RANGE_BITNUM) {
-            create_new_range_constraint(variable_index, 1ULL << num_bits);
+            create_new_range_constraint(variable_index, 1ULL << num_bits, msg);
         } else {
-            decompose_into_default_range(variable_index, num_bits);
+            decompose_into_default_range(variable_index, num_bits, DEFAULT_PLOOKUP_RANGE_BITNUM, msg);
         }
     }
 

--- a/cpp/src/aztec/stdlib/primitives/memory/dynamic_array.cpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/dynamic_array.cpp
@@ -1,0 +1,277 @@
+#include "dynamic_array.hpp"
+
+#include "../composers/composers.hpp"
+#include "../bool/bool.hpp"
+
+namespace plonk {
+namespace stdlib {
+
+/**
+ * @brief Construct a new Dynamic Array< Composer>:: Dynamic Array object
+ *
+ * @details Dynamic arrays require a maximum size when created, that cannot be exceeded.
+ *          Read and write operations cost 3.25 UltraPlonk gates.
+ *          Each dynamic array requires an additional 3.25 * maximum_size number of gates
+ *
+ * @tparam Composer
+ * @param composer
+ * @param maximum_size The maximum size of the array
+ */
+template <typename Composer>
+DynamicArray<Composer>::DynamicArray(Composer* composer, const size_t maximum_size)
+    : _context(composer)
+    , _max_size(maximum_size)
+    , _length(0)
+{
+    static_assert(Composer::type == waffle::ComposerType::PLOOKUP);
+    ASSERT(_context != nullptr);
+    _inner_table = ram_table(_context, maximum_size);
+    // Initialize the ram table with all zeroes
+    for (size_t i = 0; i < maximum_size; ++i) {
+        _inner_table.write(i, 0);
+    }
+}
+
+/**
+ * @brief Construct a new Dynamic Array< Composer>:: Dynamic Array object
+ *
+ * @tparam Composer
+ * @param other
+ */
+template <typename Composer>
+DynamicArray<Composer>::DynamicArray(const DynamicArray& other)
+    : _context(other._context)
+    , _max_size(other._max_size)
+    , _length(other._length)
+    , _inner_table(other._inner_table)
+{}
+
+/**
+ * @brief Construct a new Dynamic Array< Composer>:: Dynamic Array object
+ *
+ * @tparam Composer
+ * @param other
+ */
+template <typename Composer>
+DynamicArray<Composer>::DynamicArray(DynamicArray&& other)
+    : _context(other._context)
+    , _max_size(other._max_size)
+    , _length(other._length)
+    , _inner_table(other._inner_table)
+{}
+
+/**
+ * @brief Assignment Operator
+ *
+ * @tparam Composer
+ * @param other
+ * @return DynamicArray<Composer>&
+ */
+template <typename Composer> DynamicArray<Composer>& DynamicArray<Composer>::operator=(const DynamicArray& other)
+{
+    _context = other._context;
+    _max_size = other._max_size;
+    _length = other._length;
+    _inner_table = other._inner_table;
+    return *this;
+}
+
+/**
+ * @brief Move Assignment Operator
+ *
+ * @tparam Composer
+ * @param other
+ * @return DynamicArray<Composer>&
+ */
+template <typename Composer> DynamicArray<Composer>& DynamicArray<Composer>::operator=(DynamicArray&& other)
+{
+    _context = other._context;
+    _max_size = other._max_size;
+    _length = other._length;
+    _inner_table = other._inner_table;
+    return *this;
+}
+
+/**
+ * @brief Resize array. Current method v. inefficient!
+ *
+ * @tparam Composer
+ * @param new_length
+ */
+template <typename Composer>
+void DynamicArray<Composer>::resize(const field_pt& new_length, const field_pt default_value)
+{
+    // 1: assert new_length < max_size
+    field_pt max_bounds_check = (field_pt(_max_size) - new_length - 1);
+    if (max_bounds_check.is_constant()) {
+        ASSERT(uint256_t(new_length.get_value()) <= _max_size);
+    } else {
+        _context->create_new_range_constraint(max_bounds_check.normalize().get_witness_index(), _max_size);
+    }
+
+    /**
+     * Iterate over max array size
+     * if i is currently >= length but will be < new_length, write `default_value` into ram table
+     */
+    for (size_t i = 0; i < _max_size; ++i) {
+        bool_pt index_valid = bool_pt(witness_pt(_context, (uint256_t)(new_length.get_value()) > i));
+        {
+            // index_delta will be between 0 and length - 1 if index valid
+            // i.e. will pass check that index_delta < _max_size
+            field_pt index_delta = (new_length - i - 1);
+
+            // reverse_delta will be between 0 and (_max_size - length) if *invalid*
+            // i.e. will pass check that reverse_delta < _max_size
+            field_pt reverse_delta = (-new_length + i);
+
+            field_pt bounds_check = field_pt::conditional_assign(index_valid, index_delta, reverse_delta);
+
+            // this should do the same for only 2 gates, but hard to read
+            // field_pt t1 = new_length - i;
+            // field_pt t2 = field_pt(index_valid);
+            // field_pt bounds_check = (t2 + t2).madd(t1 - 1, -t1);
+
+            _context->create_new_range_constraint(bounds_check.normalize().get_witness_index(), _max_size);
+        }
+
+        bool_pt index_currently_invalid = bool_pt(witness_pt(_context, i >= native_size()));
+        {
+            // index_delta will be between 0 and length - 1 if index valid
+            // i.e. will pass check that index_delta < _max_size
+            field_pt index_delta = (_length - i - 1);
+
+            // reverse_delta will be between 0 and (_max_size - length) if *invalid*
+            // i.e. will pass check that reverse_delta < _max_size
+            field_pt reverse_delta = (-_length + i);
+
+            field_pt bounds_check = field_pt::conditional_assign(index_currently_invalid, reverse_delta, index_delta);
+
+            _context->create_new_range_constraint(bounds_check.normalize().get_witness_index(), _max_size);
+        }
+
+        field_pt old_value = _inner_table.read(i);
+        field_pt new_value =
+            field_pt::conditional_assign(index_currently_invalid && index_valid, default_value, old_value);
+        _inner_table.write(i, new_value);
+    }
+
+    _length = new_length;
+}
+
+/**
+ * @brief Read a field element from the dynamic array at an index value
+ *
+ * @tparam Composer
+ * @param index
+ * @return field_t<Composer>
+ */
+template <typename Composer> field_t<Composer> DynamicArray<Composer>::read(const field_pt& index) const
+{
+    const field_pt index_delta = (_length - index - 1);
+
+    if (index_delta.is_constant()) {
+        bool valid = (uint256_t(index_delta.get_value()) < _max_size);
+        if (!valid) {
+            _context->failure("DynamicArray::read access out of bounds");
+        }
+    } else {
+        _context->create_new_range_constraint(
+            index_delta.normalize().get_witness_index(), _max_size, "DynamicArray::read access out of bounds");
+    }
+
+    return _inner_table.read(index);
+}
+
+/**
+ * @brief Write a field element into the dynamic array at an index value
+ *
+ * @tparam Composer
+ * @param index
+ * @param value
+ */
+template <typename Composer> void DynamicArray<Composer>::write(const field_pt& index, const field_pt& value)
+{
+    const field_pt index_delta = (_length - index - 1);
+
+    if (index_delta.is_constant()) {
+        bool valid = (uint256_t(index_delta.get_value()) < _max_size);
+        if (!valid) {
+            _context->failure("DynamicArray::read access out of bounds");
+        }
+    } else {
+        _context->create_new_range_constraint(
+            index_delta.normalize().get_witness_index(), _max_size, "DynamicArray::read access out of bounds");
+    }
+
+    _inner_table.write(index, value);
+}
+
+/**
+ * @brief Push a field element onto the dynamic array
+ *
+ * @tparam Composer
+ * @param value
+ */
+template <typename Composer> void DynamicArray<Composer>::push(const field_pt& value)
+{
+    if (native_size() >= _max_size) {
+        _context->failure("DynamicArray::push array is already at its maximum size");
+    }
+
+    _inner_table.write(_length, value);
+    _length += 1;
+}
+
+/**
+ * @brief Pop a field element off of the dynamic array
+ *
+ * @tparam Composer
+ */
+template <typename Composer> void DynamicArray<Composer>::pop()
+{
+    if (native_size() == 0) {
+        _context->failure("DynamicArray::pop array is already empty");
+    }
+
+    _length.assert_is_not_zero();
+    _length -= 1;
+}
+
+/**
+ * @brief Conditionally push a field element onto the dynamic array
+ *
+ * @tparam Composer
+ * @param predicate
+ * @param value
+ */
+template <typename Composer>
+void DynamicArray<Composer>::conditional_push(const bool_pt& predicate, const field_pt& value)
+{
+    if (native_size() >= _max_size) {
+        _context->failure("DynamicArray::push array is already at its maximum size");
+    }
+
+    _inner_table.write(_length, value);
+    _length += predicate;
+}
+
+/**
+ * @brief Conditionallhy pop a field element off of the dynamic array
+ *
+ * @tparam Composer
+ * @param predicate
+ */
+template <typename Composer> void DynamicArray<Composer>::conditional_pop(const bool_pt& predicate)
+{
+    if (native_size() == 0) {
+        _context->failure("DynamicArray::pop array is already empty");
+    }
+
+    field_pt length_check = field_pt::conditional_assign(predicate, _length, 1);
+    length_check.assert_is_not_zero();
+    _length -= predicate;
+}
+
+INSTANTIATE_STDLIB_ULTRA_TYPE(DynamicArray);
+} // namespace stdlib
+} // namespace plonk

--- a/cpp/src/aztec/stdlib/primitives/memory/dynamic_array.hpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/dynamic_array.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#include "ram_table.hpp"
+
+namespace plonk {
+namespace stdlib {
+
+/**
+ * @brief A dynamic array of field elements
+ *
+ * @tparam Composer (must support plookup)
+ */
+template <typename Composer> class DynamicArray {
+  private:
+    typedef field_t<Composer> field_pt;
+    typedef bool_t<Composer> bool_pt;
+    typedef witness_t<Composer> witness_pt;
+
+  public:
+    DynamicArray(Composer* composer, const size_t maximum_size);
+
+    DynamicArray(const DynamicArray& other);
+    DynamicArray(DynamicArray&& other);
+
+    DynamicArray& operator=(const DynamicArray& other);
+    DynamicArray& operator=(DynamicArray&& other);
+
+    void resize(const field_pt& new_length, const field_pt default_value = 0);
+
+    field_pt read(const field_pt& index) const;
+    void write(const field_pt& index, const field_pt& value);
+
+    void push(const field_pt& index);
+    void pop();
+
+    void conditional_push(const bool_pt& predicate, const field_pt& index);
+    void conditional_pop(const bool_pt& predicate);
+
+    field_pt size() const { return _length; }
+    size_t native_size() const { return static_cast<size_t>(static_cast<uint256_t>(_length.get_value())); }
+    size_t max_size() const { return _max_size; }
+
+    Composer* get_context() const { return _context; }
+
+  private:
+    Composer* _context = nullptr;
+    size_t _max_size;
+    field_pt _length = 0;
+    mutable ram_table<Composer> _inner_table;
+};
+
+EXTERN_STDLIB_ULTRA_TYPE(DynamicArray);
+
+} // namespace stdlib
+} // namespace plonk

--- a/cpp/src/aztec/stdlib/primitives/memory/dynamic_array.test.cpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/dynamic_array.test.cpp
@@ -1,0 +1,72 @@
+#include "dynamic_array.hpp"
+
+#include <gtest/gtest.h>
+
+#include <numeric/random/engine.hpp>
+
+#include <plonk/composer/ultra_composer.hpp>
+
+#include "../bool/bool.hpp"
+
+namespace test_stdlib_dynamic_array {
+using namespace barretenberg;
+using namespace plonk;
+
+namespace {
+auto& engine = numeric::random::get_debug_engine();
+}
+
+// Defining ultra-specific types for local testing.
+using Composer = waffle::UltraComposer;
+using bool_ct = stdlib::bool_t<waffle::UltraComposer>;
+using field_ct = stdlib::field_t<Composer>;
+using witness_ct = stdlib::witness_t<Composer>;
+using DynamicArray_ct = stdlib::DynamicArray<Composer>;
+
+TEST(DynamicArray, DynamicArrayReadWriteConsistency)
+{
+
+    Composer composer;
+    const size_t max_size = 10;
+
+    DynamicArray_ct array(&composer, max_size);
+
+    for (size_t i = 0; i < max_size; ++i) {
+        array.push(field_ct::from_witness(&composer, i));
+        EXPECT_EQ(array.read(i).get_value(), i);
+    }
+
+    EXPECT_EQ(array.native_size(), max_size);
+    for (size_t i = 0; i < max_size; ++i) {
+        array.pop();
+    }
+    EXPECT_EQ(array.native_size(), 0);
+
+    array.resize(max_size - 1, 7);
+
+    EXPECT_EQ(array.native_size(), max_size - 1);
+    for (size_t i = 0; i < max_size - 1; ++i) {
+        EXPECT_EQ(array.read(i).get_value(), 7);
+    }
+
+    array.conditional_push(false, 100);
+    EXPECT_EQ(array.native_size(), max_size - 1);
+
+    array.conditional_push(true, 100);
+    EXPECT_EQ(array.native_size(), max_size);
+    EXPECT_EQ(array.read(max_size - 1).get_value(), 100);
+
+    array.conditional_pop(false);
+    EXPECT_EQ(array.native_size(), max_size);
+
+    array.conditional_pop(true);
+    EXPECT_EQ(array.native_size(), max_size - 1);
+
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    auto proof = prover.construct_proof();
+    bool verified = verifier.verify_proof(proof);
+    EXPECT_EQ(verified, true);
+}
+
+} // namespace test_stdlib_dynamic_array

--- a/cpp/src/aztec/stdlib/primitives/memory/ram_table.cpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/ram_table.cpp
@@ -1,0 +1,256 @@
+#include "ram_table.hpp"
+
+#include "../composers/composers.hpp"
+
+namespace plonk {
+namespace stdlib {
+
+/**
+ * @brief Construct a new ram table<Composer>::ram table object. It's dynamic memory!
+ *
+ * @tparam Composer
+ * @param table_entries vector of field elements that will initialize the RAM table
+ */
+template <typename Composer> ram_table<Composer>::ram_table(Composer* composer, const size_t table_size)
+{
+    static_assert(Composer::type == waffle::ComposerType::PLOOKUP);
+    _context = composer;
+    _length = table_size;
+    _index_initialized.resize(table_size);
+    for (size_t i = 0; i < _index_initialized.size(); ++i) {
+        _index_initialized[i] = false;
+    }
+
+    // do not initialize the table yet. The input entries might all be constant,
+    // if this is the case we might not have a valid pointer to a Composer
+    // We get around this, by initializing the table when `read` or `write` operator is called
+    // with a non-const field element.
+}
+
+/**
+ * @brief Construct a new ram table<Composer>::ram table object. It's dynamic memory!
+ *
+ * @tparam Composer
+ * @param table_entries vector of field elements that will initialize the RAM table
+ */
+template <typename Composer> ram_table<Composer>::ram_table(const std::vector<field_pt>& table_entries)
+{
+    static_assert(Composer::type == waffle::ComposerType::PLOOKUP);
+    // get the composer _context
+    for (const auto& entry : table_entries) {
+        if (entry.get_context() != nullptr) {
+            _context = entry.get_context();
+            break;
+        }
+    }
+    _raw_entries = table_entries;
+    _length = _raw_entries.size();
+    _index_initialized.resize(_length);
+    for (size_t i = 0; i < _index_initialized.size(); ++i) {
+        _index_initialized[i] = false;
+    }
+    // do not initialize the table yet. The input entries might all be constant,
+    // if this is the case we might not have a valid pointer to a Composer
+    // We get around this, by initializing the table when `read` or `write` operator is called
+    // with a non-const field element.
+}
+
+/**
+ * @brief internal method, is used to call Composer methods that will generate RAM table.
+ *
+ * @details initialize the table once we perform a read. This ensures we always have a pointer to a Composer.
+ * (if both the table entries and the index are constant, we don't need a composer as we
+ * can directly extract the desired value fram `_raw_entries`)
+ *
+ * @tparam Composer
+ */
+template <typename Composer> void ram_table<Composer>::initialize_table() const
+{
+    if (_ram_table_generated_in_composer) {
+        return;
+    }
+    ASSERT(_context != nullptr);
+
+    _ram_id = _context->create_RAM_array(_length);
+
+    if (_raw_entries.size() > 0) {
+        for (size_t i = 0; i < _length; ++i) {
+            if (!_index_initialized[i]) {
+                field_pt entry;
+                if (_raw_entries[i].is_constant()) {
+                    entry = field_pt::from_witness_index(_context,
+                                                         _context->put_constant_variable(_raw_entries[i].get_value()));
+                } else {
+                    entry = _raw_entries[i].normalize();
+                }
+                _context->init_RAM_element(_ram_id, i, entry.get_witness_index());
+                _index_initialized[i] = true;
+            }
+        }
+    }
+
+    _ram_table_generated_in_composer = true;
+}
+
+/**
+ * @brief Construct a new ram table<Composer>::ram table object
+ *
+ * @tparam Composer
+ * @param other
+ */
+template <typename Composer>
+ram_table<Composer>::ram_table(const ram_table& other)
+    : _raw_entries(other._raw_entries)
+    , _index_initialized(other._index_initialized)
+    , _length(other._length)
+    , _ram_id(other._ram_id)
+    , _ram_table_generated_in_composer(other._ram_table_generated_in_composer)
+    , _all_entries_written_to_with_constant_index(other._all_entries_written_to_with_constant_index)
+    , _context(other._context)
+{}
+
+/**
+ * @brief Construct a new ram table<Composer>::ram table object
+ *
+ * @tparam Composer
+ * @param other
+ */
+template <typename Composer>
+ram_table<Composer>::ram_table(ram_table&& other)
+    : _raw_entries(other._raw_entries)
+    , _index_initialized(other._index_initialized)
+    , _length(other._length)
+    , _ram_id(other._ram_id)
+    , _ram_table_generated_in_composer(other._ram_table_generated_in_composer)
+    , _all_entries_written_to_with_constant_index(other._all_entries_written_to_with_constant_index)
+    , _context(other._context)
+{}
+
+/**
+ * @brief Copy assignment operator
+ *
+ * @tparam Composer
+ * @param other
+ * @return ram_table<Composer>&
+ */
+template <typename Composer> ram_table<Composer>& ram_table<Composer>::operator=(const ram_table& other)
+{
+    _raw_entries = other._raw_entries;
+    _length = other._length;
+    _ram_id = other._ram_id;
+    _index_initialized = other._index_initialized;
+    _ram_table_generated_in_composer = other._ram_table_generated_in_composer;
+    _all_entries_written_to_with_constant_index = other._all_entries_written_to_with_constant_index;
+
+    _context = other._context;
+    return *this;
+}
+
+/**
+ * @brief Move assignment operator
+ *
+ * @tparam Composer
+ * @param other
+ * @return ram_table<Composer>&
+ */
+template <typename Composer> ram_table<Composer>& ram_table<Composer>::operator=(ram_table&& other)
+{
+    _raw_entries = other._raw_entries;
+    _length = other._length;
+    _ram_id = other._ram_id;
+    _index_initialized = other._index_initialized;
+    _ram_table_generated_in_composer = other._ram_table_generated_in_composer;
+    _all_entries_written_to_with_constant_index = other._all_entries_written_to_with_constant_index;
+    _context = other._context;
+    return *this;
+}
+
+/**
+ * @brief Read a field element from the RAM table at an index value
+ *
+ * @tparam Composer
+ * @param index
+ * @return field_t<Composer>
+ */
+template <typename Composer> field_t<Composer> ram_table<Composer>::read(const field_pt& index) const
+{
+    if (_context == nullptr) {
+        _context = index.get_context();
+    }
+
+    if (uint256_t(index.get_value()) >= _length) {
+        // TODO: what's best practise here? We are assuming that this action will generate failing constraints,
+        // and we set failure message here so that it better describes the point of failure.
+        // However, we are not *ensuring* that failing constraints are generated at the point that `failure()` is
+        // called. Is this ok?
+        _context->failure("ram_table: RAM array access out of bounds");
+    }
+
+    initialize_table();
+
+    if (!check_indices_initialized()) {
+        _context->failure("ram_table: must write to every RAM entry at least once (with constant index value) before "
+                          "table can be read");
+    }
+
+    field_pt index_wire = index;
+    if (index.is_constant()) {
+        index_wire = field_pt::from_witness_index(_context, _context->put_constant_variable(index.get_value()));
+    }
+
+    uint32_t output_idx = _context->read_RAM_array(_ram_id, index_wire.normalize().get_witness_index());
+    return field_pt::from_witness_index(_context, output_idx);
+}
+
+/**
+ * @brief Write a field element from the RAM table at an index value
+ *
+ * @tparam Composer
+ * @param index
+ * @param value
+ */
+template <typename Composer> void ram_table<Composer>::write(const field_pt& index, const field_pt& value)
+{
+    if (_context == nullptr) {
+        _context = index.get_context();
+    }
+
+    if (uint256_t(index.get_value()) >= _length) {
+        // TODO: what's best practise here? We are assuming that this action will generate failing constraints,
+        // and we set failure message here so that it better describes the point of failure.
+        // However, we are not *ensuring* that failing constraints are generated at the point that `failure()` is
+        // called. Is this ok?
+        _context->failure("ram_table: RAM array access out of bounds");
+    }
+
+    initialize_table();
+    field_pt index_wire = index;
+    auto native_index = index.get_value();
+    if (index.is_constant()) {
+        // need to write every array element at a constant index before doing reads/writes at prover-defined indices
+        index_wire = field_pt::from_witness_index(_context, _context->put_constant_variable(native_index));
+    } else {
+        if (!check_indices_initialized()) {
+            _context->failure("ram_table: must write to every RAM entry at least once (with constant index value) "
+                              "before table can be written to at an unknown index");
+        }
+    }
+
+    field_pt value_wire = value;
+    auto native_value = value.get_value();
+    if (value.is_constant()) {
+        value_wire = field_pt::from_witness_index(_context, _context->put_constant_variable(native_value));
+    }
+
+    if (index.is_constant() && _index_initialized[static_cast<size_t>(native_index)] == false) {
+        _context->init_RAM_element(_ram_id, static_cast<size_t>(native_index), value_wire.get_witness_index());
+
+        _index_initialized[static_cast<size_t>(native_index)] = true;
+    } else {
+        _context->write_RAM_array(_ram_id, index_wire.normalize().get_witness_index(), value_wire.get_witness_index());
+    }
+}
+
+INSTANTIATE_STDLIB_ULTRA_TYPE(ram_table);
+} // namespace stdlib
+} // namespace plonk

--- a/cpp/src/aztec/stdlib/primitives/memory/ram_table.cpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/ram_table.cpp
@@ -242,10 +242,11 @@ template <typename Composer> void ram_table<Composer>::write(const field_pt& ind
         value_wire = field_pt::from_witness_index(_context, _context->put_constant_variable(native_value));
     }
 
-    if (index.is_constant() && _index_initialized[static_cast<size_t>(native_index)] == false) {
-        _context->init_RAM_element(_ram_id, static_cast<size_t>(native_index), value_wire.get_witness_index());
+    const size_t array_index = static_cast<size_t>(static_cast<uint64_t>(native_index));
+    if (index.is_constant() && _index_initialized[array_index] == false) {
+        _context->init_RAM_element(_ram_id, array_index, value_wire.get_witness_index());
 
-        _index_initialized[static_cast<size_t>(native_index)] = true;
+        _index_initialized[array_index] = true;
     } else {
         _context->write_RAM_array(_ram_id, index_wire.normalize().get_witness_index(), value_wire.get_witness_index());
     }

--- a/cpp/src/aztec/stdlib/primitives/memory/ram_table.hpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/ram_table.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include "../composers/composers_fwd.hpp"
+#include "../field/field.hpp"
+
+namespace plonk {
+namespace stdlib {
+
+// A runtime-defined read-only memory table. Table entries must be initialized in the constructor.
+// N.B. Only works with the UltraComposer at the moment!
+template <typename Composer> class ram_table {
+  private:
+    typedef field_t<Composer> field_pt;
+
+  public:
+    ram_table() {}
+    ram_table(Composer* composer, const size_t table_size);
+    ram_table(const std::vector<field_pt>& table_entries);
+    ram_table(const ram_table& other);
+    ram_table(ram_table&& other);
+
+    void initialize_table() const;
+
+    ram_table& operator=(const ram_table& other);
+    ram_table& operator=(ram_table&& other);
+
+    field_pt read(const field_pt& index) const;
+
+    void write(const field_pt& index, const field_pt& value);
+
+    size_t size() const { return _length; }
+
+    Composer* get_context() const { return _context; }
+
+    bool check_indices_initialized() const
+    {
+        if (_all_entries_written_to_with_constant_index) {
+            return true;
+        }
+        if (_length == 0) {
+            return false;
+        }
+        bool init = true;
+        for (auto i : _index_initialized) {
+            init = init && i;
+        }
+        _all_entries_written_to_with_constant_index = init;
+        return _all_entries_written_to_with_constant_index;
+    }
+
+  private:
+    std::vector<field_pt> _raw_entries;
+    mutable std::vector<bool> _index_initialized;
+    size_t _length = 0;
+    mutable size_t _ram_id = 0; // Composer identifier for this ROM table
+    mutable bool _ram_table_generated_in_composer = false;
+    mutable bool _all_entries_written_to_with_constant_index = false;
+    mutable Composer* _context = nullptr;
+};
+
+EXTERN_STDLIB_ULTRA_TYPE(ram_table);
+
+} // namespace stdlib
+} // namespace plonk

--- a/cpp/src/aztec/stdlib/primitives/memory/ram_table.test.cpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/ram_table.test.cpp
@@ -1,0 +1,111 @@
+#include "ram_table.hpp"
+
+#include <gtest/gtest.h>
+
+#include <numeric/random/engine.hpp>
+
+#include <plonk/composer/ultra_composer.hpp>
+
+namespace test_stdlib_ram_table {
+using namespace plonk;
+
+// Defining ultra-specific types for local testing.
+using Composer = waffle::UltraComposer;
+using field_ct = stdlib::field_t<Composer>;
+using witness_ct = stdlib::witness_t<Composer>;
+using ram_table_ct = stdlib::ram_table<Composer>;
+
+namespace {
+auto& engine = numeric::random::get_debug_engine();
+}
+
+TEST(ram_table, ram_table_init_read_consistency)
+{
+    Composer composer;
+
+    std::vector<field_ct> table_values;
+    const size_t table_size = 10;
+    for (size_t i = 0; i < table_size; ++i) {
+        table_values.emplace_back(witness_ct(&composer, fr::random_element()));
+    }
+
+    ram_table_ct table(table_values);
+
+    field_ct result(0);
+    fr expected(0);
+
+    for (size_t i = 0; i < 10; ++i) {
+        field_ct index(witness_ct(&composer, (uint64_t)i));
+
+        if (i % 2 == 0) {
+            const auto to_add = table.read(index);
+            result += to_add; // variable lookup
+        } else {
+            const auto to_add = table.read(i); // constant lookup
+            result += to_add;
+        }
+        expected += table_values[i].get_value();
+    }
+
+    EXPECT_EQ(result.get_value(), expected);
+
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    auto proof = prover.construct_proof();
+    bool verified = verifier.verify_proof(proof);
+    EXPECT_EQ(verified, true);
+}
+
+TEST(ram_table, ram_table_read_write_consistency)
+{
+    Composer composer;
+    const size_t table_size = 10;
+
+    std::vector<fr> table_values(table_size);
+
+    ram_table_ct table(&composer, table_size);
+
+    for (size_t i = 0; i < table_size; ++i) {
+        table.write(i, 0);
+    }
+    field_ct result(0);
+    fr expected(0);
+
+    const auto update = [&]() {
+        for (size_t i = 0; i < table_size / 2; ++i) {
+            table_values[2 * i] = fr::random_element();
+            table_values[2 * i + 1] = fr::random_element();
+
+            // init with both constant and variable values
+            table.write(2 * i, table_values[2 * i]);
+            table.write(2 * i + 1, witness_ct(&composer, table_values[2 * i + 1]));
+        }
+    };
+
+    const auto read = [&]() {
+        for (size_t i = 0; i < table_size / 2; ++i) {
+            const size_t index = table_size - 2 - (i * 2); // access in something other than basic incremental order
+
+            result += table.read(witness_ct(&composer, index));
+            result += table.read(index + 1);
+
+            expected += table_values[index];
+            expected += table_values[index + 1];
+        }
+    };
+
+    update();
+    read();
+    update();
+    read();
+    update();
+
+    EXPECT_EQ(result.get_value(), expected);
+
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    auto proof = prover.construct_proof();
+    bool verified = verifier.verify_proof(proof);
+    EXPECT_EQ(verified, true);
+}
+} // namespace test_stdlib_ram_table

--- a/cpp/src/aztec/stdlib/types/types.hpp
+++ b/cpp/src/aztec/stdlib/types/types.hpp
@@ -20,6 +20,9 @@
 #include <stdlib/primitives/curves/secp256k1.hpp>
 #include <stdlib/primitives/memory/rom_table.hpp>
 #include <stdlib/recursion/verifier/program_settings.hpp>
+#include <stdlib/primitives/memory/ram_table.hpp>
+#include <stdlib/primitives/memory/rom_table.hpp>
+#include <stdlib/primitives/memory/dynamic_array.hpp>
 
 namespace plonk::stdlib::types {
 
@@ -86,7 +89,9 @@ typedef stdlib::schnorr::signature_bits<Composer> signature_bits;
 } // namespace schnorr
 
 // Ultra-composer specific types
+typedef stdlib::ram_table<waffle::UltraComposer> ram_table_ct;
 typedef stdlib::rom_table<waffle::UltraComposer> rom_table_ct;
+typedef stdlib::DynamicArray<waffle::UltraComposer> DynamicArray_ct;
 
 typedef std::conditional_t<SYSTEM_COMPOSER == waffle::TURBO,
                            recursion::recursive_turbo_verifier_settings<bn254>,


### PR DESCRIPTION
Co-authored-by: Maddiaa <cheethas@users.noreply.github.com>

# Description

Added classes to the stdlib that leverage the new ram gates

stdlib::ram_table is a fixed-size table of field elements that can be read from/written to at indexes not known at circuit-compile time

stdlib::dynamic_array emulates a variable-sized array using stdlib::ram_table. A maximum potential size must be defined that affects the number of constraints required to initialise/resize the array.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [x ] Every change is related to the PR description.
- [x ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x ] If existing code has been modified, such documentation has been added or updated.
