### PR TITLE
Polynomial cleanup

### DIFF
--- a/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/composer_helper.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<waffle::proving_key> ComposerHelper<CircuitConstructor>::compute
         // Compute selector vector, initialized to 0.
         // Copy the selector values for all gates, keeping the rows at which we store public inputs as 0.
         // Initializing the polynomials in this way automatically applies 0-padding to the selectors.
-        polynomial selector_poly_lagrange(subgroup_size, subgroup_size);
+        polynomial selector_poly_lagrange(subgroup_size);
         for (size_t i = 0; i < num_gates; ++i) {
             selector_poly_lagrange[num_public_inputs + i] = selector_values[i];
         }
@@ -156,7 +156,7 @@ void ComposerHelper<CircuitConstructor>::compute_witness_base(const CircuitConst
     for (size_t j = 0; j < program_width; ++j) {
         // Initialize the polynomial with all the actual copies variable values
         // Expect all values to be set to 0 initially
-        polynomial w_lagrange(subgroup_size, subgroup_size);
+        polynomial w_lagrange(subgroup_size);
 
         // Place all public inputs at the start of w_l and w_r.
         // All selectors at these indices are set to 0 so these values are not constrained at all.

--- a/cpp/src/aztec/honk/composer/composer_helper/permutation_helper.hpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/permutation_helper.hpp
@@ -118,7 +118,7 @@ void compute_standard_honk_sigma_permutations(CircuitConstructor& circuit_constr
     // at the end of the loop, sigma[j][i] = j*n + i
     std::array<barretenberg::polynomial, program_width> sigma;
     for (size_t j = 0; j < program_width; ++j) {
-        sigma[j] = barretenberg::polynomial(n, n);
+        sigma[j] = barretenberg::polynomial(n);
         for (size_t i = 0; i < n; i++) {
             sigma[j][i] = (j * n + i);
         }
@@ -189,7 +189,7 @@ void compute_standard_honk_id_polynomials(auto key) // proving_key* and share_pt
     // Fill id polynomials with default values
     for (size_t j = 0; j < program_width; ++j) {
         // Construct permutation polynomials in lagrange base
-        barretenberg::polynomial id_j(n, n);
+        barretenberg::polynomial id_j(n);
         for (size_t i = 0; i < key->circuit_size; ++i) {
             id_j[i] = (j * n + i);
         }
@@ -207,8 +207,8 @@ inline void compute_first_and_last_lagrange_polynomials(auto key) // proving_key
 {
     const size_t n = key->circuit_size;
     // info("Computing Lagrange basis polys, the  value of n is: ",/s n);
-    barretenberg::polynomial lagrange_polynomial_0(n, n);
-    barretenberg::polynomial lagrange_polynomial_n_min_1(n, n);
+    barretenberg::polynomial lagrange_polynomial_0(n);
+    barretenberg::polynomial lagrange_polynomial_n_min_1(n);
     lagrange_polynomial_0[0] = 1;
     lagrange_polynomial_n_min_1[n - 1] = 1;
     key->polynomial_cache.put("L_first_lagrange", std::move(lagrange_polynomial_0));

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -154,8 +154,7 @@ TEST(standard_honk_composer, test_lagrange_polynomial_correctness)
     // Generate proving key
     auto proving_key = composer.compute_proving_key();
     // Generate a random polynomial
-    barretenberg::polynomial random_polynomial =
-        barretenberg::polynomial(proving_key->circuit_size, proving_key->circuit_size);
+    barretenberg::polynomial random_polynomial = barretenberg::polynomial(proving_key->circuit_size);
     for (size_t i = 0; i < proving_key->circuit_size; i++) {
         random_polynomial[i] = barretenberg::fr::random_element();
     }

--- a/cpp/src/aztec/honk/pcs/commitment_key.test.hpp
+++ b/cpp/src/aztec/honk/pcs/commitment_key.test.hpp
@@ -72,7 +72,7 @@ template <typename Params> class CommitmentTest : public ::testing::Test {
 
     Polynomial random_polynomial(const size_t n)
     {
-        Polynomial p(n, n);
+        Polynomial p(n);
         for (size_t i = 0; i < n; ++i) {
             p[i] = Fr::random_element(engine);
         }

--- a/cpp/src/aztec/honk/pcs/gemini/gemini.hpp
+++ b/cpp/src/aztec/honk/pcs/gemini/gemini.hpp
@@ -201,7 +201,7 @@ template <typename Params> class MultilinearReductionScheme {
         // such that A₀(X) = F(X) + G↺(X) = F(X) + G(X)/X.
 
         //  F(X) = ∑ⱼ ρʲ fⱼ(X)
-        Polynomial& batched_F = witness_polynomials.emplace_back(Polynomial(n, n));
+        Polynomial& batched_F = witness_polynomials.emplace_back(Polynomial(n));
         for (size_t j = 0; j < num_polys_f; ++j) {
             const size_t n_j = polys_f[j]->size();
             ASSERT(n_j <= n);
@@ -210,7 +210,7 @@ template <typename Params> class MultilinearReductionScheme {
         }
 
         //  G(X) = ∑ⱼ ρʲ gⱼ(X)
-        Polynomial& batched_G = witness_polynomials.emplace_back(Polynomial(n, n));
+        Polynomial& batched_G = witness_polynomials.emplace_back(Polynomial(n));
         for (size_t j = 0; j < num_polys_g; ++j) {
             const size_t n_j = polys_g[j]->size();
             ASSERT(n_j <= n);
@@ -235,7 +235,7 @@ template <typename Params> class MultilinearReductionScheme {
             const size_t n_l = 1 << (num_variables - l - 1);
 
             // A_l_fold = Aₗ₊₁(X) = (1-uₗ)⋅even(Aₗ)(X) + uₗ⋅odd(Aₗ)(X)
-            Fr* A_l_fold = witness_polynomials.emplace_back(Polynomial(n_l, n_l)).get_coefficients();
+            Fr* A_l_fold = witness_polynomials.emplace_back(Polynomial(n_l)).get_coefficients();
 
             // fold the previous polynomial with odd and even parts
             for (size_t i = 0; i < n_l; ++i) {

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk.test.cpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk.test.cpp
@@ -171,10 +171,16 @@ TYPED_TEST(ShplonkTest, Gemini)
 
     EXPECT_EQ(gemini_prover_claim, gemini_verifier_claim);
 
+    info("\n\n Shplonk Prover. \n\n");
+
     const auto [prover_claim, witness, proof] =
         Shplonk::reduce_prove(this->ck(), gemini_prover_claim, gemini_witness, transcript);
 
+    info("\n\n Verifiy claim. \n\n");
+
     this->verify_opening_claim(prover_claim, witness);
+
+    info("\n\n Shplonk Verifier. \n\n");
 
     const auto verifier_claim = Shplonk::reduce_verify(gemini_prover_claim, proof, transcript);
     EXPECT_EQ(prover_claim, verifier_claim);

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk.test.cpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk.test.cpp
@@ -171,16 +171,10 @@ TYPED_TEST(ShplonkTest, Gemini)
 
     EXPECT_EQ(gemini_prover_claim, gemini_verifier_claim);
 
-    info("\n\n Shplonk Prover. \n\n");
-
     const auto [prover_claim, witness, proof] =
         Shplonk::reduce_prove(this->ck(), gemini_prover_claim, gemini_witness, transcript);
 
-    info("\n\n Verifiy claim. \n\n");
-
     this->verify_opening_claim(prover_claim, witness);
-
-    info("\n\n Shplonk Verifier. \n\n");
 
     const auto verifier_claim = Shplonk::reduce_verify(gemini_prover_claim, proof, transcript);
     EXPECT_EQ(prover_claim, verifier_claim);

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
@@ -109,9 +109,10 @@ template <typename Params> class MultiBatchOpeningScheme {
 
         // initialize Q(X) = 0
         Polynomial Q(max_poly_size);
+        Polynomial tmp(max_poly_size);
         for (size_t k = 0; k < num_multi_claims; ++k) {
             // Bₖ(X) into temp_poly
-            Polynomial tmp = merged_polynomials[k];
+            tmp = merged_polynomials[k];
             // subtract Bₖ(X) - Tₖ(X) in-place
             tmp -= interpolated_polynomials[k];
 

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
@@ -82,7 +82,7 @@ template <typename Params> class MultiBatchOpeningScheme {
             // - Cₖ = ∑ⱼ ρʲ⋅Cⱼ
             // - Yₖ = {yᵏ₁, …, yᵏₘₖ}, where yᵏᵢ = ∑ⱼ ρʲ⋅yʲᵢ
             // create an empty polynomial in which we merge all polynomials openened at the same claim
-            auto& B_k = merged_polynomials.emplace_back(merged_poly_size, merged_poly_size);
+            auto& B_k = merged_polynomials.emplace_back(merged_poly_size);
             auto& C_k = merged_commitments.emplace_back(Commitment::zero());
             std::vector<Fr> evals_k(num_queries_k, Fr::zero());
 
@@ -108,7 +108,7 @@ template <typename Params> class MultiBatchOpeningScheme {
         }
 
         // initialize Q(X) = 0
-        Polynomial Q(max_poly_size, max_poly_size);
+        Polynomial Q(max_poly_size);
         for (size_t k = 0; k < num_multi_claims; ++k) {
             // Bₖ(X) into temp_poly
             Polynomial tmp = merged_polynomials[k];

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
@@ -109,13 +109,8 @@ template <typename Params> class MultiBatchOpeningScheme {
 
         // initialize Q(X) = 0
         Polynomial Q(max_poly_size, max_poly_size);
-        // Polynomial tmp(size_t(0), max_poly_size);
         for (size_t k = 0; k < num_multi_claims; ++k) {
             // Bₖ(X) into temp_poly
-            // info("k = ", k);
-            // info("tmp.get_max_size() = ", tmp.get_max_size());
-            // info("merged_polynomials[j].get_max_size() = ", merged_polynomials[k].get_max_size());
-            // info("interpolated_polynomials[j].get_max_size() = ", interpolated_polynomials[k].get_max_size());
             Polynomial tmp = merged_polynomials[k];
             // subtract Bₖ(X) - Tₖ(X) in-place
             tmp -= interpolated_polynomials[k];

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
@@ -82,7 +82,7 @@ template <typename Params> class MultiBatchOpeningScheme {
             // - Cₖ = ∑ⱼ ρʲ⋅Cⱼ
             // - Yₖ = {yᵏ₁, …, yᵏₘₖ}, where yᵏᵢ = ∑ⱼ ρʲ⋅yʲᵢ
             // create an empty polynomial in which we merge all polynomials openened at the same claim
-            auto& B_k = merged_polynomials.emplace_back(Polynomial(size_t(0), merged_poly_size));
+            auto& B_k = merged_polynomials.emplace_back(merged_poly_size, merged_poly_size);
             auto& C_k = merged_commitments.emplace_back(Commitment::zero());
             std::vector<Fr> evals_k(num_queries_k, Fr::zero());
 
@@ -108,7 +108,7 @@ template <typename Params> class MultiBatchOpeningScheme {
         }
 
         // initialize Q(X) = 0
-        Polynomial Q(size_t(0), max_poly_size);
+        Polynomial Q(max_poly_size, max_poly_size);
         // Polynomial tmp(size_t(0), max_poly_size);
         for (size_t k = 0; k < num_multi_claims; ++k) {
             // Bₖ(X) into temp_poly

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_multi.hpp
@@ -109,10 +109,14 @@ template <typename Params> class MultiBatchOpeningScheme {
 
         // initialize Q(X) = 0
         Polynomial Q(size_t(0), max_poly_size);
-        Polynomial tmp(size_t(0), max_poly_size);
+        // Polynomial tmp(size_t(0), max_poly_size);
         for (size_t k = 0; k < num_multi_claims; ++k) {
             // Bₖ(X) into temp_poly
-            tmp = merged_polynomials[k];
+            // info("k = ", k);
+            // info("tmp.get_max_size() = ", tmp.get_max_size());
+            // info("merged_polynomials[j].get_max_size() = ", merged_polynomials[k].get_max_size());
+            // info("interpolated_polynomials[j].get_max_size() = ", interpolated_polynomials[k].get_max_size());
+            Polynomial tmp = merged_polynomials[k];
             // subtract Bₖ(X) - Tₖ(X) in-place
             tmp -= interpolated_polynomials[k];
 

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_single.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_single.hpp
@@ -45,6 +45,7 @@ template <typename Params> class SingleBatchOpeningScheme {
         }
         // Q(X) = ∑ⱼ ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( X − xⱼ )
         Polynomial Q(max_poly_size);
+        Polynomial tmp(max_poly_size);
 
         Fr current_nu = Fr::one();
         for (size_t j = 0; j < num_claims; ++j) {
@@ -52,7 +53,7 @@ template <typename Params> class SingleBatchOpeningScheme {
             const auto& [commitment_j, opening_j, eval_j] = claims[j];
 
             // tmp = ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( X − xⱼ )
-            Polynomial tmp = witness_polynomials[j];
+            tmp = witness_polynomials[j];
             tmp[0] -= eval_j;
             tmp.factor_roots(opening_j);
 
@@ -93,7 +94,7 @@ template <typename Params> class SingleBatchOpeningScheme {
             const auto& [commitment_j, opening_j, eval_j] = claims[j];
 
             // tmp = ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( r − xⱼ )
-            Polynomial tmp = witness_polynomials[j];
+            tmp = witness_polynomials[j];
             tmp[0] -= eval_j;
             Fr scaling_factor = current_nu * inverse_vanishing_evals[j]; // = ρʲ / ( r − xⱼ )
 

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_single.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_single.hpp
@@ -44,7 +44,7 @@ template <typename Params> class SingleBatchOpeningScheme {
             max_poly_size = std::max(max_poly_size, poly.size());
         }
         // Q(X) = ∑ⱼ ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( X − xⱼ )
-        Polynomial Q(max_poly_size, max_poly_size);
+        Polynomial Q(max_poly_size);
 
         Fr current_nu = Fr::one();
         for (size_t j = 0; j < num_claims; ++j) {

--- a/cpp/src/aztec/honk/pcs/shplonk/shplonk_single.hpp
+++ b/cpp/src/aztec/honk/pcs/shplonk/shplonk_single.hpp
@@ -45,7 +45,6 @@ template <typename Params> class SingleBatchOpeningScheme {
         }
         // Q(X) = ∑ⱼ ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( X − xⱼ )
         Polynomial Q(max_poly_size, max_poly_size);
-        Polynomial tmp(max_poly_size, max_poly_size);
 
         Fr current_nu = Fr::one();
         for (size_t j = 0; j < num_claims; ++j) {
@@ -53,7 +52,7 @@ template <typename Params> class SingleBatchOpeningScheme {
             const auto& [commitment_j, opening_j, eval_j] = claims[j];
 
             // tmp = ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( X − xⱼ )
-            tmp = witness_polynomials[j];
+            Polynomial tmp = witness_polynomials[j];
             tmp[0] -= eval_j;
             tmp.factor_roots(opening_j);
 
@@ -94,7 +93,7 @@ template <typename Params> class SingleBatchOpeningScheme {
             const auto& [commitment_j, opening_j, eval_j] = claims[j];
 
             // tmp = ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( r − xⱼ )
-            tmp = witness_polynomials[j];
+            Polynomial tmp = witness_polynomials[j];
             tmp[0] -= eval_j;
             Fr scaling_factor = current_nu * inverse_vanishing_evals[j]; // = ρʲ / ( r − xⱼ )
 

--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -165,7 +165,7 @@ void Prover<settings>::compute_grand_product_polynomial(barretenberg::fr beta, b
 
     // Construct permutation polynomial 'z_perm' in lagrange form as:
     // z_perm = [0 numerator_accumulator[0][0] numerator_accumulator[0][1] ... numerator_accumulator[0][n-2] 0]
-    Polynomial z_perm(key->circuit_size, key->circuit_size);
+    Polynomial z_perm(key->circuit_size);
     // We'll need to shift this polynomial to the left by dividing it by X in gemini, so the the 0-th coefficient should
     // stay zero
     copy_polynomial(numerator_accumulator[0], &z_perm[1], key->circuit_size - 1, key->circuit_size - 1);

--- a/cpp/src/aztec/honk/proof_system/prover.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.test.cpp
@@ -60,8 +60,8 @@ template <class Fscalar> class ProverTests : public testing::Test {
         std::vector<polynomial> wires;
         std::vector<polynomial> sigmas;
         for (size_t i = 0; i < program_width; ++i) {
-            polynomial wire_poly(proving_key->circuit_size, proving_key->circuit_size);
-            polynomial sigma_poly(proving_key->circuit_size, proving_key->circuit_size);
+            polynomial wire_poly(proving_key->circuit_size);
+            polynomial sigma_poly(proving_key->circuit_size);
             for (size_t j = 0; j < proving_key->circuit_size; ++j) {
                 wire_poly[j] = Fscalar::random_element();
                 sigma_poly[j] = Fscalar::random_element();
@@ -143,7 +143,7 @@ template <class Fscalar> class ProverTests : public testing::Test {
         }
 
         // Step (4)
-        polynomial z_perm(proving_key->circuit_size, proving_key->circuit_size);
+        polynomial z_perm(proving_key->circuit_size);
         z_perm[0] = Fscalar::zero(); // Z_0 = 1
         // Note: in practice, we replace this expensive element-wise division with Montgomery batch inversion
         for (size_t i = 0; i < proving_key->circuit_size - 1; ++i) {

--- a/cpp/src/aztec/honk/proof_system/verifier.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.test.cpp
@@ -87,14 +87,14 @@ template <class FF> class VerifierTests : public testing::Test {
         std::shared_ptr<waffle::proving_key> proving_key =
             std::make_shared<waffle::proving_key>(n, 0, crs, waffle::STANDARD_HONK);
 
-        polynomial w_l(n, n);
-        polynomial w_r(n, n);
-        polynomial w_o(n, n);
-        polynomial q_l(n, n);
-        polynomial q_r(n, n);
-        polynomial q_o(n, n);
-        polynomial q_c(n, n);
-        polynomial q_m(n, n);
+        polynomial w_l(n);
+        polynomial w_r(n);
+        polynomial w_o(n);
+        polynomial q_l(n);
+        polynomial q_r(n);
+        polynomial q_o(n);
+        polynomial q_c(n);
+        polynomial q_m(n);
 
         fr T0;
         for (size_t i = 0; i < n / 4; ++i) {

--- a/cpp/src/aztec/honk/proof_system/verifier.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.test.cpp
@@ -87,23 +87,15 @@ template <class FF> class VerifierTests : public testing::Test {
         std::shared_ptr<waffle::proving_key> proving_key =
             std::make_shared<waffle::proving_key>(n, 0, crs, waffle::STANDARD_HONK);
 
-        polynomial w_l;
-        polynomial w_r;
-        polynomial w_o;
-        polynomial q_l;
-        polynomial q_r;
-        polynomial q_o;
-        polynomial q_c;
-        polynomial q_m;
+        polynomial w_l(n, n);
+        polynomial w_r(n, n);
+        polynomial w_o(n, n);
+        polynomial q_l(n, n);
+        polynomial q_r(n, n);
+        polynomial q_o(n, n);
+        polynomial q_c(n, n);
+        polynomial q_m(n, n);
 
-        w_l.resize(n);
-        w_r.resize(n);
-        w_o.resize(n);
-        q_l.resize(n);
-        q_r.resize(n);
-        q_o.resize(n);
-        q_m.resize(n);
-        q_c.resize(n);
         fr T0;
         for (size_t i = 0; i < n / 4; ++i) {
             w_l.at(2 * i) = fr::random_element();

--- a/cpp/src/aztec/honk/utils/power_polynomial.hpp
+++ b/cpp/src/aztec/honk/utils/power_polynomial.hpp
@@ -19,7 +19,7 @@ namespace power_polynomial {
 template <typename Fr> barretenberg::Polynomial<Fr> generate_vector(Fr zeta, size_t vector_size)
 {
     // We know the size from the start, so we can allocate exactly the right amount of memory
-    barretenberg::Polynomial<Fr> pow_vector(vector_size, vector_size);
+    barretenberg::Polynomial<Fr> pow_vector(vector_size);
 
     constexpr size_t usefulness_margin = 4;
     size_t num_threads = max_threads::compute_num_threads();

--- a/cpp/src/aztec/plonk/composer/ultra_composer.cpp
+++ b/cpp/src/aztec/plonk/composer/ultra_composer.cpp
@@ -689,8 +689,8 @@ std::shared_ptr<proving_key> UltraComposer::compute_proving_key()
 
     // Instantiate z_lookup and s polynomials in the proving key (no values assigned yet).
     // Note: might be better to add these polys to cache only after they've been computed, as is convention
-    polynomial z_lookup_fft(subgroup_size * 4, subgroup_size * 4);
-    polynomial s_fft(subgroup_size * 4, subgroup_size * 4);
+    polynomial z_lookup_fft(subgroup_size * 4);
+    polynomial s_fft(subgroup_size * 4);
     circuit_proving_key->polynomial_cache.put("z_lookup_fft", std::move(z_lookup_fft));
     circuit_proving_key->polynomial_cache.put("s_fft", std::move(s_fft));
 

--- a/cpp/src/aztec/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
+++ b/cpp/src/aztec/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
@@ -175,8 +175,8 @@ void KateCommitmentScheme<settings>::batch_open(const transcript::StandardTransc
 
     // Note: the opening poly W_\frak{z} is always size (n + 1) due to blinding
     // of the quotient polynomial
-    polynomial opening_poly(input_key->circuit_size + 1, input_key->circuit_size + 1);
-    polynomial shifted_opening_poly(input_key->circuit_size, input_key->circuit_size);
+    polynomial opening_poly(input_key->circuit_size + 1);
+    polynomial shifted_opening_poly(input_key->circuit_size);
 
     const polynomial& linear_poly = input_key->polynomial_cache.get("linear_poly");
 

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.cpp
@@ -495,7 +495,7 @@ template <typename settings> void ProverBase<settings>::compute_linearisation_co
 
     fr zeta = fr::serialize_from_buffer(transcript.get_challenge("z").begin());
 
-    polynomial linear_poly(key->circuit_size + 1, key->circuit_size + 1);
+    polynomial linear_poly(key->circuit_size + 1);
 
     commitment_scheme->add_opening_evaluations_to_transcript(transcript, key, false);
     if constexpr (settings::use_linearisation) {

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.cpp
@@ -597,17 +597,12 @@ template <typename settings> void ProverBase<settings>::add_blinding_to_quotient
 // Compute FFT of lagrange polynomial L_1 needed in random widgets only
 template <typename settings> void ProverBase<settings>::compute_lagrange_1_fft()
 {
-    polynomial lagrange_1_fft(4 * circuit_size, 4 * circuit_size + 8);
+    polynomial lagrange_1_fft(4 * circuit_size + 8);
     polynomial_arithmetic::compute_lagrange_polynomial_fft(
         lagrange_1_fft.get_coefficients(), key->small_domain, key->large_domain);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[0]);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[1]);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[2]);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[3]);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[4]);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[5]);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[6]);
-    lagrange_1_fft.add_lagrange_base_coefficient(lagrange_1_fft[7]);
+    for (size_t i = 0; i < 8; i++) {
+        lagrange_1_fft[4 * circuit_size + i] = lagrange_1_fft[i];
+    }
     key->polynomial_cache.put("lagrange_1_fft", std::move(lagrange_1_fft));
 }
 

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
@@ -243,11 +243,11 @@ waffle::Prover generate_test_data(const size_t n)
     q_m.ifft(key->small_domain);
     q_c.ifft(key->small_domain);
 
-    polynomial q_1_fft(q_l, n * 2);
-    polynomial q_2_fft(q_r, n * 2);
-    polynomial q_3_fft(q_o, n * 2);
-    polynomial q_m_fft(q_m, n * 2);
-    polynomial q_c_fft(q_c, n * 2);
+    polynomial q_1_fft(q_l, n * 4);
+    polynomial q_2_fft(q_r, n * 4);
+    polynomial q_3_fft(q_o, n * 4);
+    polynomial q_m_fft(q_m, n * 4);
+    polynomial q_c_fft(q_c, n * 4);
 
     q_1_fft.coset_fft(key->large_domain);
     q_2_fft.coset_fft(key->large_domain);

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
@@ -115,14 +115,14 @@ waffle::Prover generate_test_data(const size_t n)
     auto reference_string = std::make_shared<waffle::FileReferenceString>(n + 1, "../srs_db/ignition");
     std::shared_ptr<proving_key> key = std::make_shared<proving_key>(n, 0, reference_string, waffle::STANDARD);
 
-    polynomial w_l(n, n);
-    polynomial w_r(n, n);
-    polynomial w_o(n, n);
-    polynomial q_l(n, n);
-    polynomial q_r(n, n);
-    polynomial q_o(n, n);
-    polynomial q_c(n, n);
-    polynomial q_m(n, n);
+    polynomial w_l(n);
+    polynomial w_r(n);
+    polynomial w_o(n);
+    polynomial q_l(n);
+    polynomial q_r(n);
+    polynomial q_o(n);
+    polynomial q_c(n);
+    polynomial q_m(n);
 
     for (size_t i = 0; i < n / 4; ++i) {
         w_l.at(2 * i) = fr::random_element();

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
@@ -115,23 +115,14 @@ waffle::Prover generate_test_data(const size_t n)
     auto reference_string = std::make_shared<waffle::FileReferenceString>(n + 1, "../srs_db/ignition");
     std::shared_ptr<proving_key> key = std::make_shared<proving_key>(n, 0, reference_string, waffle::STANDARD);
 
-    polynomial w_l;
-    polynomial w_r;
-    polynomial w_o;
-    polynomial q_l;
-    polynomial q_r;
-    polynomial q_o;
-    polynomial q_c;
-    polynomial q_m;
-
-    w_l.resize(n);
-    w_r.resize(n);
-    w_o.resize(n);
-    q_l.resize(n);
-    q_r.resize(n);
-    q_o.resize(n);
-    q_m.resize(n);
-    q_c.resize(n);
+    polynomial w_l(n, n);
+    polynomial w_r(n, n);
+    polynomial w_o(n, n);
+    polynomial q_l(n, n);
+    polynomial q_r(n, n);
+    polynomial q_o(n, n);
+    polynomial q_c(n, n);
+    polynomial q_m(n, n);
 
     for (size_t i = 0; i < n / 4; ++i) {
         w_l.at(2 * i) = fr::random_element();

--- a/cpp/src/aztec/plonk/proof_system/utils/generalized_permutation.hpp
+++ b/cpp/src/aztec/plonk/proof_system/utils/generalized_permutation.hpp
@@ -10,7 +10,7 @@ inline void compute_gen_permutation_lagrange_base_single(barretenberg::polynomia
                                                          const barretenberg::evaluation_domain& small_domain)
 {
     if (output.get_size() < permutation.size()) {
-        output.resize_unsafe(permutation.size());
+        throw_or_abort("Permutation polynomial size is insufficient to store permutations.");
     }
     // permutation encoding:
     // low 28 bits defines the location in witness polynomial

--- a/cpp/src/aztec/plonk/proof_system/utils/generalized_permutation.hpp
+++ b/cpp/src/aztec/plonk/proof_system/utils/generalized_permutation.hpp
@@ -9,7 +9,7 @@ inline void compute_gen_permutation_lagrange_base_single(barretenberg::polynomia
                                                          const std::vector<uint32_t>& permutation,
                                                          const barretenberg::evaluation_domain& small_domain)
 {
-    if (output.get_size() < permutation.size()) {
+    if (output.size() < permutation.size()) {
         throw_or_abort("Permutation polynomial size is insufficient to store permutations.");
     }
     // permutation encoding:

--- a/cpp/src/aztec/plonk/proof_system/utils/permutation.hpp
+++ b/cpp/src/aztec/plonk/proof_system/utils/permutation.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "common/throw_or_abort.hpp"
 #include <numeric/bitop/get_msb.hpp>
 #include <polynomials/iterate_over_domain.hpp>
 #include <polynomials/polynomial.hpp>
@@ -45,7 +46,7 @@ inline void compute_permutation_lagrange_base_single(barretenberg::polynomial& o
                                                      const barretenberg::evaluation_domain& small_domain)
 {
     if (output.get_size() < permutation.size()) {
-        output.resize_unsafe(permutation.size());
+        throw_or_abort("Permutation polynomial size is insufficient to store permutations.");
     }
     // permutation encoding:
     // low 28 bits defines the location in witness polynomial

--- a/cpp/src/aztec/plonk/proof_system/utils/permutation.hpp
+++ b/cpp/src/aztec/plonk/proof_system/utils/permutation.hpp
@@ -45,7 +45,7 @@ inline void compute_permutation_lagrange_base_single(barretenberg::polynomial& o
                                                      const std::vector<permutation_subgroup_element>& permutation,
                                                      const barretenberg::evaluation_domain& small_domain)
 {
-    if (output.get_size() < permutation.size()) {
+    if (output.size() < permutation.size()) {
         throw_or_abort("Permutation polynomial size is insufficient to store permutations.");
     }
     // permutation encoding:

--- a/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
@@ -114,14 +114,14 @@ waffle::Prover generate_test_data(const size_t n)
     auto crs = std::make_shared<waffle::FileReferenceString>(n + 1, "../srs_db/ignition");
     std::shared_ptr<proving_key> key = std::make_shared<proving_key>(n, 0, crs, waffle::STANDARD);
 
-    polynomial w_l(n, n);
-    polynomial w_r(n, n);
-    polynomial w_o(n, n);
-    polynomial q_l(n, n);
-    polynomial q_r(n, n);
-    polynomial q_o(n, n);
-    polynomial q_c(n, n);
-    polynomial q_m(n, n);
+    polynomial w_l(n);
+    polynomial w_r(n);
+    polynomial w_o(n);
+    polynomial q_l(n);
+    polynomial q_r(n);
+    polynomial q_o(n);
+    polynomial q_c(n);
+    polynomial q_m(n);
 
     fr T0;
     for (size_t i = 0; i < n / 4; ++i) {

--- a/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
@@ -114,23 +114,15 @@ waffle::Prover generate_test_data(const size_t n)
     auto crs = std::make_shared<waffle::FileReferenceString>(n + 1, "../srs_db/ignition");
     std::shared_ptr<proving_key> key = std::make_shared<proving_key>(n, 0, crs, waffle::STANDARD);
 
-    polynomial w_l;
-    polynomial w_r;
-    polynomial w_o;
-    polynomial q_l;
-    polynomial q_r;
-    polynomial q_o;
-    polynomial q_c;
-    polynomial q_m;
+    polynomial w_l(n, n);
+    polynomial w_r(n, n);
+    polynomial w_o(n, n);
+    polynomial q_l(n, n);
+    polynomial q_r(n, n);
+    polynomial q_o(n, n);
+    polynomial q_c(n, n);
+    polynomial q_m(n, n);
 
-    w_l.resize(n);
-    w_r.resize(n);
-    w_o.resize(n);
-    q_l.resize(n);
-    q_r.resize(n);
-    q_o.resize(n);
-    q_m.resize(n);
-    q_c.resize(n);
     fr T0;
     for (size_t i = 0; i < n / 4; ++i) {
         w_l.at(2 * i) = fr::random_element();

--- a/cpp/src/aztec/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
+++ b/cpp/src/aztec/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
@@ -267,7 +267,7 @@ void ProverPermutationWidget<program_width, idpolys, num_roots_cut_out_of_vanish
 
     // Construct permutation polynomial 'z' in lagrange form as:
     // z = [1 accumulators[0][0] accumulators[0][1] ... accumulators[0][n-2]]
-    polynomial z_perm(key->circuit_size, key->circuit_size);
+    polynomial z_perm(key->circuit_size);
     z_perm[0] = fr::one();
     barretenberg::polynomial_arithmetic::copy_polynomial(
         accumulators[0], &z_perm[1], key->circuit_size - 1, key->circuit_size - 1);

--- a/cpp/src/aztec/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
+++ b/cpp/src/aztec/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
@@ -58,7 +58,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_sor
     const fr* s_3 = key->polynomial_cache.get("s_3_lagrange").get_coefficients();
     const fr* s_4 = key->polynomial_cache.get("s_4_lagrange").get_coefficients();
 
-    barretenberg::polynomial s_accum(key->circuit_size, key->circuit_size);
+    barretenberg::polynomial s_accum(key->circuit_size);
     barretenberg::polynomial_arithmetic::copy_polynomial(&s_1[0], &s_accum[0], key->circuit_size, key->circuit_size);
 
     // Get challenge η
@@ -128,7 +128,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_gra
 
     // Note: z_lookup ultimately is only only size 'n' but we allow 'n+1' for convenience
     // essentially as scratch space in the calculation to follow
-    polynomial z_lookup(key->circuit_size + 1, key->circuit_size + 1);
+    polynomial z_lookup(key->circuit_size + 1);
 
     // Allocate 4 length n 'accumulators'. accumulators[0] points to the 1th index of
     // z_lookup and will be used to construct z_lookup (lagrange base) in place. The

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -77,12 +77,16 @@ Polynomial<Fr>::Polynomial(Fr* buf, const size_t size_)
 
 template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator=(const Polynomial<Fr>& other)
 {
+    if (is_empty()) {
+        size_ = other.size();
+        coefficients_ = (Fr*)(aligned_alloc(32, sizeof(Fr) * other.capacity()));
+    }
+
     mapped_ = false;
 
     ASSERT(other.size_ <= size_);
 
     if (other.coefficients_ != nullptr) {
-        ASSERT(coefficients_);
         memcpy(static_cast<void*>(coefficients_), static_cast<void*>(other.coefficients_), sizeof(Fr) * other.size_);
     }
 

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -179,7 +179,7 @@ template <typename Fr> void Polynomial<Fr>::free()
 
 template <typename Fr> void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     ASSERT(domain.size <= size_);
 
@@ -199,7 +199,7 @@ template <typename Fr> void Polynomial<Fr>::partial_fft(const EvaluationDomain<F
 
 template <typename Fr> void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     ASSERT(domain.size <= size_);
 
@@ -213,7 +213,7 @@ void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain,
                                const EvaluationDomain<Fr>& large_domain,
                                const size_t domain_extension)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     size_t extended_size = domain.size * domain_extension;
 
@@ -227,7 +227,7 @@ void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain,
 template <typename Fr>
 void Polynomial<Fr>::coset_fft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& constant)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     ASSERT(domain.size <= size_);
 
@@ -239,7 +239,7 @@ void Polynomial<Fr>::coset_fft_with_constant(const EvaluationDomain<Fr>& domain,
 template <typename Fr>
 void Polynomial<Fr>::coset_fft_with_generator_shift(const EvaluationDomain<Fr>& domain, const Fr& constant)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     ASSERT(domain.size <= size_);
 
@@ -250,7 +250,7 @@ void Polynomial<Fr>::coset_fft_with_generator_shift(const EvaluationDomain<Fr>& 
 
 template <typename Fr> void Polynomial<Fr>::ifft(const EvaluationDomain<Fr>& domain)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     ASSERT(domain.size <= size_);
 
@@ -261,7 +261,7 @@ template <typename Fr> void Polynomial<Fr>::ifft(const EvaluationDomain<Fr>& dom
 
 template <typename Fr> void Polynomial<Fr>::ifft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& constant)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     ASSERT(domain.size <= size_);
 
@@ -272,7 +272,7 @@ template <typename Fr> void Polynomial<Fr>::ifft_with_constant(const EvaluationD
 
 template <typename Fr> void Polynomial<Fr>::coset_ifft(const EvaluationDomain<Fr>& domain)
 {
-    ASSERT(!empty());
+    ASSERT(!is_empty());
 
     ASSERT(domain.size <= size_);
 

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -41,7 +41,7 @@ Polynomial<Fr>::Polynomial(const size_t size_, const size_t initial_size_hint)
     , coefficients_(nullptr)
     , size_(size_)
 {
-    size_t target_size = std::max(size_, initial_size_hint + DEFAULT_PAGE_SPILL);
+    size_t target_size = std::max(size_, initial_size_hint) + DEFAULT_PAGE_SPILL;
     if (target_size > 0) {
 
         coefficients_ = (Fr*)(aligned_alloc(32, sizeof(Fr) * target_size));
@@ -333,7 +333,6 @@ Polynomial<Fr>::Polynomial(std::span<const Fr> interpolation_points, std::span<c
         evaluations.data(), coefficients_, interpolation_points.data(), size_);
 }
 
-// TODO(luke): only allow this for equal size polys?
 template <typename Fr> void Polynomial<Fr>::add_scaled(std::span<const Fr> other, Fr scaling_factor)
 {
     ASSERT(!mapped_);
@@ -348,8 +347,6 @@ template <typename Fr> void Polynomial<Fr>::add_scaled(std::span<const Fr> other
     for (size_t i = 0; i < other_size; ++i) {
         coefficients_[i] += scaling_factor * other[i];
     }
-
-    zero_memory(other_size, size_);
 }
 
 template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator+=(std::span<const Fr> other)
@@ -366,7 +363,6 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator+=(std::span<cons
         coefficients_[i] += other[i];
     }
 
-    zero_memory(other_size, size_);
     return *this;
 }
 
@@ -384,7 +380,6 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator-=(std::span<cons
         coefficients_[i] -= other[i];
     }
 
-    zero_memory(other_size, size_);
     return *this;
 }
 

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -75,13 +75,6 @@ Polynomial<Fr>::Polynomial(Fr* buf, const size_t size_)
     , mapped_(false)
 {}
 
-template <typename Fr>
-Polynomial<Fr>::Polynomial()
-    : coefficients_(nullptr)
-    , size_(0)
-    , mapped_(false)
-{}
-
 template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator=(const Polynomial<Fr>& other)
 {
     mapped_ = false;

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -222,6 +222,8 @@ template <typename Fr> void Polynomial<Fr>::zero_memory(const size_t zero_size)
 
 template <typename Fr> void Polynomial<Fr>::bump_memory(const size_t new_size_hint)
 {
+    info("WARNING: attempting to bump memory in Polynomial.");
+    ASSERT(false);
     ASSERT(!mapped_);
     size_t amount = (new_size_hint / page_size_) * page_size_;
 
@@ -277,64 +279,66 @@ template <typename Fr> void Polynomial<Fr>::free()
     coefficients_ = nullptr;
 }
 
-template <typename Fr> void Polynomial<Fr>::reserve(const size_t amount)
-{
-    ASSERT(!mapped_);
-    if (amount > max_size_) {
-        bump_memory(amount);
-        memset(static_cast<void*>(&coefficients_[size_]), 0, sizeof(Fr) * (amount - max_size_));
-    }
-}
+// template <typename Fr> void Polynomial<Fr>::reserve(const size_t amount)
+// {
+//     ASSERT(!mapped_);
+//     if (amount > max_size_) {
+//         bump_memory(amount);
+//         memset(static_cast<void*>(&coefficients_[size_]), 0, sizeof(Fr) * (amount - max_size_));
+//     }
+// }
 
-template <typename Fr> void Polynomial<Fr>::resize(const size_t amount)
-{
-    ASSERT(!mapped_);
+// template <typename Fr> void Polynomial<Fr>::resize(const size_t amount)
+// {
+//     ASSERT(!mapped_);
 
-    if (amount > max_size_) {
-        bump_memory(amount);
-    }
+//     if (amount > max_size_) {
+//         bump_memory(amount);
+//     }
 
-    if (coefficients_ != 0 && amount > size_) {
+//     if (coefficients_ != 0 && amount > size_) {
 
-        ASSERT(amount > size_);
+//         ASSERT(amount > size_);
 
-        Fr* back = &coefficients_[size_];
-        memset(static_cast<void*>(back), 0, sizeof(Fr) * (amount - size_));
-    }
+//         Fr* back = &coefficients_[size_];
+//         memset(static_cast<void*>(back), 0, sizeof(Fr) * (amount - size_));
+//     }
 
-    size_ = amount;
-}
+//     size_ = amount;
+// }
 
-// does not zero out memory
-template <typename Fr> void Polynomial<Fr>::resize_unsafe(const size_t amount)
-{
-    ASSERT(!mapped_);
+// // does not zero out memory
+// template <typename Fr> void Polynomial<Fr>::resize_unsafe(const size_t amount)
+// {
+//     ASSERT(!mapped_);
+//     info("amount = ", amount);
+//     info("max_size_ = ", max_size_);
 
-    if (amount > max_size_) {
-        bump_memory(amount);
-    }
+//     if (amount > max_size_) {
+//         bump_memory(amount);
+//     }
 
-    size_ = amount;
-}
+//     size_ = amount;
+// }
 
 /**
  * FFTs
  **/
 
-template <typename Fr> void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain)
-{
-    ASSERT(!empty());
+// template <typename Fr> void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain)
+// {
+//     ASSERT(!empty());
 
-    if (domain.size > max_size_) {
-        bump_memory(domain.size);
-    }
+//     if (domain.size > max_size_) {
+//         bump_memory(domain.size);
+//     }
 
-    // (ZERO OUT MEMORY!)
-    // TODO: wait, do we still need this?
-    // memset(static_cast<void*>(back), 0, sizeof(Fr) * (amount - size));
-    polynomial_arithmetic::fft(coefficients_, domain);
-    size_ = domain.size;
-}
+//     // (ZERO OUT MEMORY!)
+//     // TODO: wait, do we still need this?
+//     // memset(static_cast<void*>(back), 0, sizeof(Fr) * (amount - size));
+//     polynomial_arithmetic::fft(coefficients_, domain);
+//     size_ = domain.size;
+// }
 
 template <typename Fr> void Polynomial<Fr>::partial_fft(const EvaluationDomain<Fr>& domain, Fr constant, bool is_coset)
 {

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -223,6 +223,8 @@ template <typename Fr> void Polynomial<Fr>::zero_memory(const size_t zero_size)
 template <typename Fr> void Polynomial<Fr>::bump_memory(const size_t new_size_hint)
 {
     info("WARNING: attempting to bump memory in Polynomial.");
+    info("max_size_ = ", max_size_);
+    info("new_size_hint = ", new_size_hint);
     ASSERT(false);
     ASSERT(!mapped_);
     size_t amount = (new_size_hint / page_size_) * page_size_;

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -66,9 +66,7 @@ Polynomial<Fr>::Polynomial(Polynomial<Fr>&& other) noexcept
     : coefficients_(std::exchange(other.coefficients_, nullptr))
     , size_(std::exchange(other.size_, 0))
     , mapped_(std::exchange(other.mapped_, false))
-{
-    info("in move constructor!");
-}
+{}
 
 template <typename Fr>
 Polynomial<Fr>::Polynomial(Fr* buf, const size_t size_)
@@ -147,13 +145,10 @@ template <typename Fr> void Polynomial<Fr>::zero_memory(const size_t start_posit
     ASSERT(end_position >= start_position);
     ASSERT(end_position <= size_);
 
-    if (end_position > start_position) {
-
-        size_t delta = end_position - start_position;
-        if (delta > 0 && coefficients_) {
-            ASSERT(coefficients_);
-            memset(static_cast<void*>(&coefficients_[start_position]), 0, sizeof(Fr) * delta);
-        }
+    size_t delta = end_position - start_position;
+    if (delta > 0) {
+        ASSERT(coefficients_);
+        memset(static_cast<void*>(&coefficients_[start_position]), 0, sizeof(Fr) * delta);
     }
 }
 

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -325,20 +325,20 @@ template <typename Fr> void Polynomial<Fr>::free()
  * FFTs
  **/
 
-// template <typename Fr> void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain)
-// {
-//     ASSERT(!empty());
+template <typename Fr> void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain)
+{
+    ASSERT(!empty());
 
-//     if (domain.size > max_size_) {
-//         bump_memory(domain.size);
-//     }
+    if (domain.size > max_size_) {
+        bump_memory(domain.size);
+    }
 
-//     // (ZERO OUT MEMORY!)
-//     // TODO: wait, do we still need this?
-//     // memset(static_cast<void*>(back), 0, sizeof(Fr) * (amount - size));
-//     polynomial_arithmetic::fft(coefficients_, domain);
-//     size_ = domain.size;
-// }
+    // (ZERO OUT MEMORY!)
+    // TODO: wait, do we still need this?
+    // memset(static_cast<void*>(back), 0, sizeof(Fr) * (amount - size));
+    polynomial_arithmetic::fft(coefficients_, domain);
+    size_ = domain.size;
+}
 
 template <typename Fr> void Polynomial<Fr>::partial_fft(const EvaluationDomain<Fr>& domain, Fr constant, bool is_coset)
 {

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -93,7 +93,6 @@ Polynomial<Fr>::Polynomial()
     , size_(0)
 {}
 
-// TODO(luke): make sure this makes sense!
 template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator=(const Polynomial<Fr>& other)
 {
     mapped_ = false;
@@ -222,7 +221,6 @@ template <typename Fr> void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>
     zero_memory(domain.size, size_);
 
     polynomial_arithmetic::coset_fft(coefficients_, domain);
-    // size_ = domain.size;
 }
 
 template <typename Fr>
@@ -277,7 +275,6 @@ template <typename Fr> void Polynomial<Fr>::ifft(const EvaluationDomain<Fr>& dom
     zero_memory(domain.size, size_);
 
     polynomial_arithmetic::ifft(coefficients_, domain);
-    size_ = domain.size;
 }
 
 template <typename Fr> void Polynomial<Fr>::ifft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& constant)

--- a/cpp/src/aztec/polynomials/polynomial.cpp
+++ b/cpp/src/aztec/polynomials/polynomial.cpp
@@ -36,12 +36,12 @@ Polynomial<Fr>::Polynomial(std::string const& filename)
 }
 
 template <typename Fr>
-Polynomial<Fr>::Polynomial(const size_t size_, const size_t initial_size_hint)
+Polynomial<Fr>::Polynomial(const size_t size_)
     : mapped_(false)
     , coefficients_(nullptr)
     , size_(size_)
 {
-    size_t target_size = std::max(size_, initial_size_hint) + DEFAULT_PAGE_SPILL;
+    size_t target_size = size_ + DEFAULT_SIZE_INCREASE;
     if (target_size > 0) {
 
         coefficients_ = (Fr*)(aligned_alloc(32, sizeof(Fr) * target_size));
@@ -322,7 +322,7 @@ Fr Polynomial<Fr>::evaluate_from_fft(const EvaluationDomain<Fr>& large_domain,
 
 template <typename Fr>
 Polynomial<Fr>::Polynomial(std::span<const Fr> interpolation_points, std::span<const Fr> evaluations)
-    : Polynomial(interpolation_points.size(), interpolation_points.size())
+    : Polynomial(interpolation_points.size())
 {
     ASSERT(size_ > 0);
 

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -225,7 +225,7 @@ template <typename Fr> class Polynomial {
 
     std::size_t size() const { return size_; }
     std::size_t capacity() const { return size_ + DEFAULT_CAPACITY_INCREASE; }
-    std::size_t mapped() const { return mapped_; }
+    bool mapped() const { return mapped_; }
 
   private:
     void free();

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -43,9 +43,9 @@ template <typename Fr> class Polynomial {
     {
         free();
 
-        mapped_ = false;
         coefficients_ = 0;
         size_ = 0;
+        mapped_ = false;
     }
 
     bool operator==(Polynomial const& rhs) const
@@ -226,6 +226,7 @@ template <typename Fr> class Polynomial {
     const_pointer data() const { return coefficients_; }
 
     std::size_t size() const { return size_; }
+    std::size_t capacity() const { return size_ + DEFAULT_SIZE_INCREASE; }
 
   private:
     void free();
@@ -236,9 +237,9 @@ template <typename Fr> class Polynomial {
     const static size_t DEFAULT_SIZE_INCREASE = 1;
 
   public:
-    bool mapped_;
     Fr* coefficients_;
     size_t size_; // This is the size() of the `coefficients` vector.
+    bool mapped_;
 };
 
 template <typename Fr> inline std::ostream& operator<<(std::ostream& os, Polynomial<Fr> const& p)

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -130,6 +130,12 @@ template <typename Fr> class Polynomial {
 
     bool is_empty() const { return (coefficients_ == nullptr) || (size_ == 0); }
 
+    // safety check for in place operations
+    bool in_place_operation_viable(size_t domain_size = 0)
+    {
+        return !is_empty() && !mapped() && (size() >= domain_size);
+    }
+
     /**
      * @brief Returns an std::span of the left-shift of self.
      *
@@ -219,10 +225,11 @@ template <typename Fr> class Polynomial {
 
     std::size_t size() const { return size_; }
     std::size_t capacity() const { return size_ + DEFAULT_CAPACITY_INCREASE; }
+    std::size_t mapped() const { return mapped_; }
 
   private:
     void free();
-    void zero_memory(const size_t start_position, const size_t end_position);
+    void zero_memory_beyond(const size_t start_position);
     // When a polynomial is instantiated from a size alone, the memory allocated corresponds to
     // input size + DEFAULT_CAPACITY_INCREASE. A DEFAULT_CAPACITY_INCREASE of >= 1 is required to ensure
     // that polynomials can be 'shifted' via a span of the 1st to size+1th coefficients.

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -17,7 +17,7 @@ template <typename Fr> class Polynomial {
 
     // TODO: add a 'spill' factor when allocating memory - we sometimes needs to extend poly degree by 2/4,
     // if page size = power of two, will trigger unneccesary copies
-    Polynomial(const size_t initial_size, const size_t initial_size_hint = DEFAULT_SIZE_HINT);
+    Polynomial(const size_t initial_size, const size_t initial_size_hint = 0);
     Polynomial(const Polynomial& other, const size_t target_size = 0);
 
     Polynomial(Polynomial&& other) noexcept;
@@ -84,8 +84,6 @@ template <typename Fr> class Polynomial {
 
     Fr& operator[](const size_t i)
     {
-        info("i = ", i);
-        info("size_ = ", size_);
         ASSERT(i < size_);
         return coefficients_[i];
     }
@@ -144,7 +142,7 @@ template <typename Fr> class Polynomial {
         ASSERT(size_ > 0);
         // TODO(luke): Reinstate the below ASSERT once Adrian's relations update makes this true!
         ASSERT(coefficients_[0].is_zero());
-        ASSERT(coefficients_[size_].is_zero()); // relies on DEFAULT_PAGE_SPILL > 1
+        ASSERT(coefficients_[size_].is_zero()); // relies on DEFAULT_PAGE_SPILL >= 1
         return std::span{ coefficients_ + 1, size_ };
     }
 

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -54,8 +54,8 @@ template <typename Fr> class Polynomial {
         if (is_empty() || rhs.is_empty()) {
             return is_empty() && rhs.is_empty();
         }
-        // Otherwise, check coefficients match on the minimum of the two sizes and that, if one poly is larger, all
-        // higher coefficients are identically zero.
+        // Otherwise, check that the coefficients match on the minimum of the two sizes and that the higher coefficients
+        // of the larger poly (if one exists) are identically zero.
         else {
             size_t min_size = std::min(size(), rhs.size());
             for (size_t i = 0; i < min_size; i++) {
@@ -73,24 +73,6 @@ template <typename Fr> class Polynomial {
 
             return true;
         }
-        /*
-        if (size_ == rhs.size_) {
-
-            // If either poly has null coefficients then we are equal only if both are null
-            if ((coefficients_ == nullptr) || (rhs.coefficients_ == nullptr))
-                return (coefficients_ == nullptr) && (rhs.coefficients_ == nullptr);
-
-            // Size is equal and both have coefficients, compare
-            for (size_t i = 0; i < size_; ++i) {
-                if (coefficients_[i] != rhs.coefficients_[i])
-                    return false;
-            }
-
-            return true;
-        }
-
-        return false;
-        */
     }
 
     // IMPROVEMENT: deprecate in favor of 'data()' and ensure const correctness
@@ -213,16 +195,8 @@ template <typename Fr> class Polynomial {
      *
      * @param roots list of roots (r₁,…,rₘ)
      */
-    void factor_roots(std::span<const Fr> roots)
-    {
-        polynomial_arithmetic::factor_roots(std::span{ *this }, roots);
-        size_ -= roots.size();
-    };
-    void factor_roots(const Fr& root)
-    {
-        polynomial_arithmetic::factor_roots(std::span{ *this }, root);
-        size_--;
-    };
+    void factor_roots(std::span<const Fr> roots) { polynomial_arithmetic::factor_roots(std::span{ *this }, roots); };
+    void factor_roots(const Fr& root) { polynomial_arithmetic::factor_roots(std::span{ *this }, root); };
 
     /**
      * Implements requirements of `std::ranges::contiguous_range` and `std::ranges::sized_range`
@@ -256,7 +230,10 @@ template <typename Fr> class Polynomial {
 
   public:
     Fr* coefficients_ = nullptr;
-    size_t size_ = 0; // This is the size() of the `coefficients` vector.
+    // The size_ effectively represents the 'usable' length of the coefficients array but may be less than the true
+    // 'capacity' of the array. It is not explicitly tied to the degree and is not changed by any operations on the
+    // polynomial.
+    size_t size_ = 0;
     bool mapped_ = false;
 };
 

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -24,7 +24,7 @@ template <typename Fr> class Polynomial {
     Polynomial(Fr* buf, const size_t initial_size);
 
     // Allow polynomials to be entirely reset/dormant
-    Polynomial();
+    Polynomial() = default;
 
     /**
      * @brief Create the degree-(m-1) polynomial T(X) that interpolates the given evaluations.

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -237,9 +237,9 @@ template <typename Fr> class Polynomial {
     const static size_t DEFAULT_SIZE_INCREASE = 1;
 
   public:
-    Fr* coefficients_;
-    size_t size_; // This is the size() of the `coefficients` vector.
-    bool mapped_;
+    Fr* coefficients_ = nullptr;
+    size_t size_ = 0; // This is the size() of the `coefficients` vector.
+    bool mapped_ = false;
 };
 
 template <typename Fr> inline std::ostream& operator<<(std::ostream& os, Polynomial<Fr> const& p)

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -48,9 +48,7 @@ template <typename Fr> class Polynomial {
         mapped_ = false;
         coefficients_ = 0;
         size_ = 0;
-        page_size_ = DEFAULT_SIZE_HINT;
         max_size_ = 0;
-        allocated_pages_ = 0;
     }
 
     bool operator==(Polynomial const& rhs) const
@@ -253,10 +251,8 @@ template <typename Fr> class Polynomial {
   public:
     bool mapped_;
     Fr* coefficients_;
-    size_t size_;      // This is the size() of the `coefficients` vector.
-    size_t page_size_; // DOCTODO: what does 'page' mean? Explain this.
+    size_t size_; // This is the size() of the `coefficients` vector.
     size_t max_size_;
-    size_t allocated_pages_;
 };
 
 template <typename Fr> inline std::ostream& operator<<(std::ostream& os, Polynomial<Fr> const& p)

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -17,8 +17,8 @@ template <typename Fr> class Polynomial {
 
     // TODO: add a 'spill' factor when allocating memory - we sometimes needs to extend poly degree by 2/4,
     // if page size = power of two, will trigger unneccesary copies
-    Polynomial(const size_t initial_size, const size_t initial_max_size_hint = DEFAULT_SIZE_HINT);
-    Polynomial(const Polynomial& other, const size_t target_max_size = 0);
+    Polynomial(const size_t initial_size, const size_t initial_size_hint = DEFAULT_SIZE_HINT);
+    Polynomial(const Polynomial& other, const size_t target_size = 0);
 
     Polynomial(Polynomial&& other) noexcept;
 
@@ -48,7 +48,6 @@ template <typename Fr> class Polynomial {
         mapped_ = false;
         coefficients_ = 0;
         size_ = 0;
-        max_size_ = 0;
     }
 
     bool operator==(Polynomial const& rhs) const
@@ -75,7 +74,6 @@ template <typename Fr> class Polynomial {
     Fr* get_coefficients() { return coefficients_; };
 
     size_t get_size() const { return size_; };
-    size_t get_max_size() const { return max_size_; };
 
     // Const and non const versions of coefficient accessors
     Fr const& operator[](const size_t i) const
@@ -86,6 +84,8 @@ template <typename Fr> class Polynomial {
 
     Fr& operator[](const size_t i)
     {
+        info("i = ", i);
+        info("size_ = ", size_);
         ASSERT(i < size_);
         return coefficients_[i];
     }
@@ -123,15 +123,8 @@ template <typename Fr> class Polynomial {
     void ifft(const EvaluationDomain<Fr>& domain);
     void ifft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& constant);
     void coset_ifft(const EvaluationDomain<Fr>& domain);
-    // void coset_ifft_with_constant(const EvaluationDomain<Fr> &domain, const Fr &constant);
 
     Fr compute_kate_opening_coefficients(const Fr& z);
-    void add_lagrange_base_coefficient(const Fr& coefficient);
-    void add_coefficient(const Fr& coefficient);
-
-    void reserve(const size_t new_max_size);
-    void resize(const size_t new_size);
-    void resize_unsafe(const size_t new_size);
 
     bool empty() const
     {
@@ -165,7 +158,6 @@ template <typename Fr> class Polynomial {
 
     /**
      * @brief adds the polynomial q(X) 'other'.
-     * If the degree of q is larger, we bump the size.
      *
      * @param other q(X)
      */
@@ -173,7 +165,6 @@ template <typename Fr> class Polynomial {
 
     /**
      * @brief subtracts the polynomial q(X) 'other'.
-     * If the degree of q is larger, we bump the size
      *
      * @param other q(X)
      */
@@ -242,17 +233,14 @@ template <typename Fr> class Polynomial {
 
   private:
     void free();
-    void zero_memory(const size_t zero_size);
+    void zero_memory(const size_t start_position, const size_t end_position);
     const static size_t DEFAULT_SIZE_HINT = 1 << 12; // DOCTODO: justify this number.
     const static size_t DEFAULT_PAGE_SPILL = 20;     // DOCTODO: explain this, or rename.
-    void add_coefficient_internal(const Fr& coefficient);
-    void bump_memory();
 
   public:
     bool mapped_;
     Fr* coefficients_;
     size_t size_; // This is the size() of the `coefficients` vector.
-    size_t max_size_;
 };
 
 template <typename Fr> inline std::ostream& operator<<(std::ostream& os, Polynomial<Fr> const& p)

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -47,7 +47,6 @@ template <typename Fr> class Polynomial {
 
         mapped_ = false;
         coefficients_ = 0;
-        initial_size_ = 0;
         size_ = 0;
         page_size_ = DEFAULT_SIZE_HINT;
         max_size_ = 0;
@@ -249,12 +248,11 @@ template <typename Fr> class Polynomial {
     const static size_t DEFAULT_SIZE_HINT = 1 << 12; // DOCTODO: justify this number.
     const static size_t DEFAULT_PAGE_SPILL = 20;     // DOCTODO: explain this, or rename.
     void add_coefficient_internal(const Fr& coefficient);
-    void bump_memory(const size_t new_size);
+    void bump_memory();
 
   public:
     bool mapped_;
     Fr* coefficients_;
-    size_t initial_size_;
     size_t size_;      // This is the size() of the `coefficients` vector.
     size_t page_size_; // DOCTODO: what does 'page' mean? Explain this.
     size_t max_size_;

--- a/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
+++ b/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
@@ -1102,8 +1102,6 @@ TEST(polynomials, factor_roots)
         polynomial quotient(poly);
         quotient.factor_roots(roots);
 
-        EXPECT_EQ(quotient.size(), N - NUM_ROOTS);
-
         // check that (t-r)q(t) == p(t)
         fr t = fr::random_element();
         fr roots_eval = polynomial_arithmetic::compute_linear_polynomial_product_evaluation(roots.data(), t, NUM_ROOTS);

--- a/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
+++ b/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
@@ -1,6 +1,7 @@
 #include "polynomial_arithmetic.hpp"
 #include <algorithm>
 #include <common/mem.hpp>
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <utility>
 #include "numeric/bitop/get_msb.hpp"
@@ -1168,4 +1169,28 @@ TEST(polynomials, move_construct_and_assign)
     EXPECT_EQ(polynomial_c.coefficients_, nullptr);
     EXPECT_EQ(polynomial_c.size(), 0);
     EXPECT_EQ(polynomial_c.mapped_, false);
+}
+
+TEST(polynomials, default_construct_then_assign)
+{
+    // construct an arbitrary but non-empty polynomial
+    size_t num_coeffs = 64;
+    polynomial interesting_poly(num_coeffs);
+    for (auto& coeff : interesting_poly) {
+        coeff = fr::random_element();
+    }
+
+    // construct an empty poly via the default constructor
+    polynomial poly;
+
+    EXPECT_EQ(poly.is_empty(), true);
+
+    // fill the empty poly using the assignment operator
+    poly = interesting_poly;
+
+    // coefficients and size should be equal in value
+    for (size_t i = 0; i < num_coeffs; ++i) {
+        EXPECT_EQ(poly[i], interesting_poly[i]);
+    }
+    EXPECT_EQ(poly.size(), interesting_poly.size());
 }

--- a/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
+++ b/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
@@ -616,9 +616,9 @@ TEST(polynomials, divide_by_vanishing_polynomial)
 
     constexpr size_t n = 16;
 
-    polynomial A(2 * n, 2 * n);
-    polynomial B(2 * n, 2 * n);
-    polynomial C(2 * n, 2 * n);
+    polynomial A(2 * n);
+    polynomial B(2 * n);
+    polynomial C(2 * n);
 
     for (size_t i = 0; i < 13; ++i) {
         A[i] = fr::random_element();
@@ -651,12 +651,12 @@ TEST(polynomials, divide_by_vanishing_polynomial)
     C.coset_fft(large_domain);
 
     // compute A(X) * B(X) - C(X)
-    polynomial R(2 * n, 2 * n);
+    polynomial R(2 * n);
 
     polynomial_arithmetic::mul(&A[0], &B[0], &R[0], large_domain);
     polynomial_arithmetic::sub(&R[0], &C[0], &R[0], large_domain);
 
-    polynomial R_copy(2 * n, 2 * n);
+    polynomial R_copy(2 * n);
     R_copy = R;
 
     polynomial_arithmetic::divide_by_pseudo_vanishing_polynomial({ &R[0] }, small_domain, large_domain, 3);
@@ -1006,7 +1006,7 @@ TEST(polynomials, evaluate_mle)
         auto& engine = numeric::random::get_debug_engine();
         const size_t m = numeric::get_msb(N);
         EXPECT_EQ(N, 1 << m);
-        polynomial poly(N, N);
+        polynomial poly(N);
         for (size_t i = 1; i < N - 1; ++i) {
             poly[i] = fr::random_element(&engine);
         }
@@ -1062,7 +1062,7 @@ TEST(polynomials, factor_roots)
     auto test_case = [](size_t NUM_ZERO_ROOTS, size_t NUM_NON_ZERO_ROOTS) {
         const size_t NUM_ROOTS = NUM_NON_ZERO_ROOTS + NUM_ZERO_ROOTS;
 
-        polynomial poly(N, N);
+        polynomial poly(N);
         for (size_t i = NUM_ZERO_ROOTS; i < N; ++i) {
             poly[i] = fr::random_element();
         }

--- a/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
+++ b/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
@@ -616,9 +616,9 @@ TEST(polynomials, divide_by_vanishing_polynomial)
 
     constexpr size_t n = 16;
 
-    polynomial A(n, 2 * n);
-    polynomial B(n, 2 * n);
-    polynomial C(n, 2 * n);
+    polynomial A(2 * n, 2 * n);
+    polynomial B(2 * n, 2 * n);
+    polynomial C(2 * n, 2 * n);
 
     for (size_t i = 0; i < 13; ++i) {
         A[i] = fr::random_element();

--- a/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
+++ b/cpp/src/aztec/polynomials/polynomial_arithmetic.test.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <common/mem.hpp>
 #include <gtest/gtest.h>
+#include <utility>
 #include "numeric/bitop/get_msb.hpp"
 #include "numeric/random/engine.hpp"
 #include "polynomial.hpp"
@@ -1129,4 +1130,44 @@ TEST(polynomials, factor_roots)
     test_case(2, 0);
     test_case(0, 2);
     test_case(3, 6);
+}
+
+TEST(polynomials, move_construct_and_assign)
+{
+    // construct a poly with some arbitrary data
+    size_t num_coeffs = 64;
+    polynomial polynomial_a(num_coeffs);
+    for (auto& coeff : polynomial_a) {
+        coeff = fr::random_element();
+    }
+
+    // construct a new poly from the original via the move constructor
+    polynomial polynomial_b(std::move(polynomial_a));
+
+    // verifiy that source poly is appropriately destroyed
+    EXPECT_EQ(polynomial_a.coefficients_, nullptr);
+    EXPECT_EQ(polynomial_a.size(), 0);
+    EXPECT_EQ(polynomial_a.mapped_, false);
+
+    // construct another poly; this will also use the move constructor!
+    auto polynomial_c = std::move(polynomial_b);
+
+    // verifiy that source poly is appropriately destroyed
+    EXPECT_EQ(polynomial_b.coefficients_, nullptr);
+    EXPECT_EQ(polynomial_b.size(), 0);
+    EXPECT_EQ(polynomial_b.mapped_, false);
+
+    // define a poly with some arbitrary coefficients
+    polynomial polynomial_d(num_coeffs);
+    for (auto& coeff : polynomial_d) {
+        coeff = fr::random_element();
+    }
+
+    // reset its data using move assignment
+    polynomial_d = std::move(polynomial_c);
+
+    // verifiy that source poly is appropriately destroyed
+    EXPECT_EQ(polynomial_c.coefficients_, nullptr);
+    EXPECT_EQ(polynomial_c.size(), 0);
+    EXPECT_EQ(polynomial_c.mapped_, false);
 }

--- a/cpp/src/aztec/polynomials/serialize.hpp
+++ b/cpp/src/aztec/polynomials/serialize.hpp
@@ -28,7 +28,7 @@ template <typename B> inline void read(B& buf, polynomial& p)
 
 inline void write(uint8_t*& buf, polynomial const& p)
 {
-    auto size = p.get_size();
+    auto size = p.size();
     serialize::write(buf, static_cast<uint32_t>(size));
     memcpy(&buf[0], &p[0], size * sizeof(fr));
     buf += size * sizeof(fr);
@@ -36,7 +36,7 @@ inline void write(uint8_t*& buf, polynomial const& p)
 
 inline void write(std::vector<uint8_t>& buf, polynomial const& p)
 {
-    auto size = p.get_size();
+    auto size = p.size();
     serialize::write(buf, static_cast<uint32_t>(size));
     auto len = (size * sizeof(fr));
     buf.resize(buf.size() + len);
@@ -67,7 +67,7 @@ inline void read(std::istream& is, polynomial& p)
 
 inline void write(std::ostream& os, polynomial const& p)
 {
-    auto size = p.get_size();
+    auto size = p.size();
     auto len = size * sizeof(fr);
     serialize::write(os, static_cast<uint32_t>(size));
     os.write((char*)&p[0], (std::streamsize)len);

--- a/cpp/src/aztec/polynomials/serialize.hpp
+++ b/cpp/src/aztec/polynomials/serialize.hpp
@@ -6,10 +6,9 @@ namespace barretenberg {
 // Highly optimised read / write of polynomials in little endian montgomery form.
 template <typename B> inline void read(B& buf, polynomial& p)
 {
-    p = polynomial();
     uint32_t size;
     serialize::read(buf, size);
-    p.resize_unsafe(size);
+    p = polynomial(size, size);
     memcpy(&p[0], buf, size * sizeof(fr));
 
     if (!is_little_endian()) {
@@ -47,10 +46,9 @@ inline void write(std::vector<uint8_t>& buf, polynomial const& p)
 
 inline void read(std::istream& is, polynomial& p)
 {
-    p = polynomial();
     uint32_t size;
     serialize::read(is, size);
-    p.resize_unsafe(size);
+    p = polynomial(size, size);
     is.read((char*)&p[0], (std::streamsize)(size * sizeof(fr)));
 
     if (!is_little_endian()) {

--- a/cpp/src/aztec/polynomials/serialize.hpp
+++ b/cpp/src/aztec/polynomials/serialize.hpp
@@ -8,7 +8,7 @@ template <typename B> inline void read(B& buf, polynomial& p)
 {
     uint32_t size;
     serialize::read(buf, size);
-    p = polynomial(size, size);
+    p = polynomial(size);
     memcpy(&p[0], buf, size * sizeof(fr));
 
     if (!is_little_endian()) {
@@ -48,7 +48,7 @@ inline void read(std::istream& is, polynomial& p)
 {
     uint32_t size;
     serialize::read(is, size);
-    p = polynomial(size, size);
+    p = polynomial(size);
     is.read((char*)&p[0], (std::streamsize)(size * sizeof(fr)));
 
     if (!is_little_endian()) {

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
@@ -1,4 +1,5 @@
 #include "polynomial_cache.hpp"
+#include "polynomials/polynomial.hpp"
 #include <common/streams.hpp>
 
 namespace waffle {
@@ -57,7 +58,7 @@ polynomial& PolynomialCache::get(std::string const& key, size_t size)
             throw_or_abort(format("PolynomialCache: get: ", key, " not found and no size given."));
         }
         info_togglable("get: ", key, " will be adding as zero poly of size ", size);
-        poly.resize(size);
+        poly = polynomial(size, size);
     }
 
     map_[key] = std::move(poly);

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
@@ -53,7 +53,7 @@ polynomial& PolynomialCache::get(std::string const& key, size_t size)
         info_togglable("get: ", key, " not in cache.");
     }
 
-    if (poly.get_size() == 0) {
+    if (poly.size() == 0) {
         if (!size) {
             throw_or_abort(format("PolynomialCache: get: ", key, " not found and no size given."));
         }
@@ -70,9 +70,8 @@ polynomial& PolynomialCache::get(std::string const& key, size_t size)
 
 size_t PolynomialCache::get_volume() const
 {
-    return std::accumulate(map_.begin(), map_.end(), size_t(0), [](size_t acc, auto& e) {
-        return acc + e.second.get_size() * sizeof(fr);
-    });
+    return std::accumulate(
+        map_.begin(), map_.end(), size_t(0), [](size_t acc, auto& e) { return acc + e.second.size() * sizeof(fr); });
 }
 
 void PolynomialCache::move_to_front(std::string const& key)

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.cpp
@@ -58,7 +58,7 @@ polynomial& PolynomialCache::get(std::string const& key, size_t size)
             throw_or_abort(format("PolynomialCache: get: ", key, " not found and no size given."));
         }
         info_togglable("get: ", key, " will be adding as zero poly of size ", size);
-        poly = polynomial(size, size);
+        poly = polynomial(size);
     }
 
     map_[key] = std::move(poly);

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.test.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_cache.test.cpp
@@ -24,7 +24,7 @@ TEST(polynomial_cache, get_unknown_with_size)
     PolynomialStoreMem mem_store;
     PolynomialCache cache(&mem_store, CAPACITY);
     auto poly = cache.get("unknown", 1024);
-    EXPECT_EQ(poly.get_size(), 1024);
+    EXPECT_EQ(poly.size(), 1024);
 }
 
 TEST(polynomial_cache, creates_polynomial)
@@ -32,7 +32,7 @@ TEST(polynomial_cache, creates_polynomial)
     PolynomialStoreMem mem_store;
     PolynomialCache cache(&mem_store, CAPACITY);
     polynomial poly(1024);
-    EXPECT_EQ(poly.get_size(), 1024);
+    EXPECT_EQ(poly.size(), 1024);
 }
 
 TEST(polynomial_cache, put_moves_polynomial)
@@ -41,7 +41,7 @@ TEST(polynomial_cache, put_moves_polynomial)
     PolynomialCache cache(&mem_store, CAPACITY);
     polynomial poly(1024);
     cache.put("id", std::move(poly));
-    EXPECT_EQ(poly.get_size(), 0);
+    EXPECT_EQ(poly.size(), 0);
 }
 
 TEST(polynomial_cache, put_polynomial_overwrite)
@@ -52,14 +52,14 @@ TEST(polynomial_cache, put_polynomial_overwrite)
         polynomial poly(1024);
         cache.put("id", std::move(poly));
         auto got = cache.get("id");
-        EXPECT_EQ(got.get_size(), 1024);
+        EXPECT_EQ(got.size(), 1024);
         EXPECT_EQ(cache.get_volume(), 1024 * 32);
     }
     {
         polynomial poly(2048);
         cache.put("id", std::move(poly));
         auto got = cache.get("id");
-        EXPECT_EQ(got.get_size(), 2048);
+        EXPECT_EQ(got.size(), 2048);
         EXPECT_EQ(cache.get_volume(), 2048 * 32);
     }
 }
@@ -72,7 +72,7 @@ TEST(polynomial_cache, put_polynomial_self_overwrite)
     cache.put("id", std::move(poly));
     cache.put("id", std::move(cache.get("id")));
     auto got = cache.get("id");
-    EXPECT_EQ(got.get_size(), 1024);
+    EXPECT_EQ(got.size(), 1024);
     EXPECT_EQ(cache.get_volume(), 1024 * 32);
 }
 
@@ -83,7 +83,7 @@ TEST(polynomial_cache, get_polynomial)
     polynomial poly(1024);
     cache.put("id", std::move(poly));
     auto got = cache.get("id");
-    EXPECT_EQ(got.get_size(), 1024);
+    EXPECT_EQ(got.size(), 1024);
 }
 
 TEST(polynomial_cache, get_polynomial_from_store)
@@ -93,7 +93,7 @@ TEST(polynomial_cache, get_polynomial_from_store)
     polynomial poly(1024);
     mem_store.put("id", poly);
     auto got = cache.get("id");
-    EXPECT_EQ(got.get_size(), 1024);
+    EXPECT_EQ(got.size(), 1024);
 }
 
 TEST(polynomial_cache, overflow_flush_and_get)
@@ -108,16 +108,16 @@ TEST(polynomial_cache, overflow_flush_and_get)
 
     EXPECT_EQ(cache.get_lru(), (std::vector<std::string>{ "id4", "id3" }));
 
-    EXPECT_EQ(cache.get("id1").get_size(), 512);
+    EXPECT_EQ(cache.get("id1").size(), 512);
     EXPECT_EQ(cache.get_lru(), (std::vector<std::string>{ "id1", "id4" }));
 
-    EXPECT_EQ(cache.get("id2").get_size(), 512);
+    EXPECT_EQ(cache.get("id2").size(), 512);
     EXPECT_EQ(cache.get_lru(), (std::vector<std::string>{ "id2", "id1", "id4" }));
 
-    EXPECT_EQ(cache.get("id3").get_size(), 1024);
+    EXPECT_EQ(cache.get("id3").size(), 1024);
     EXPECT_EQ(cache.get_lru(), (std::vector<std::string>{ "id3", "id2", "id1" }));
 
-    EXPECT_EQ(cache.get("id4").get_size(), 1024);
+    EXPECT_EQ(cache.get("id4").size(), 1024);
     EXPECT_EQ(cache.get_lru(), (std::vector<std::string>{ "id4", "id3" }));
 }
 
@@ -127,7 +127,7 @@ TEST(polynomial_cache, no_store)
     polynomial poly(1024);
     cache.put("id", std::move(poly));
     auto got = cache.get("id");
-    EXPECT_EQ(got.get_size(), 1024);
+    EXPECT_EQ(got.size(), 1024);
 }
 
 } // namespace waffle

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store.test.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store.test.cpp
@@ -12,7 +12,7 @@ TEST(polynomial_store, get_unknown)
 {
     PolynomialStoreMem store;
     auto poly = store.get("unknown");
-    EXPECT_EQ(poly.get_size(), 0);
+    EXPECT_EQ(poly.size(), 0);
     EXPECT_EQ(store.get_stats()["unknown"].first, 0);
     EXPECT_EQ(store.get_stats()["unknown"].second, 1);
 }
@@ -22,7 +22,7 @@ TEST(polynomial_store, put_copies_polynomial)
     PolynomialStoreMem store;
     auto poly = polynomial(1024);
     store.put("id", poly);
-    EXPECT_EQ(poly.get_size(), 1024);
+    EXPECT_EQ(poly.size(), 1024);
     EXPECT_EQ(store.get_stats()["id"].first, 1);
     EXPECT_EQ(store.get_stats()["id"].second, 0);
 }
@@ -33,7 +33,7 @@ TEST(polynomial_store, get_polynomial)
     auto poly = polynomial(1024);
     store.put("id", poly);
     auto got = store.get("id");
-    EXPECT_EQ(got.get_size(), 1024);
+    EXPECT_EQ(got.size(), 1024);
     EXPECT_EQ(store.get_stats()["id"].first, 1);
     EXPECT_EQ(store.get_stats()["id"].second, 1);
 }

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_mem.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_mem.cpp
@@ -1,4 +1,5 @@
 #include "polynomial_store.hpp"
+#include "polynomials/polynomial.hpp"
 
 namespace waffle {
 
@@ -17,7 +18,8 @@ template <typename... Args> inline void debug(Args...) {}
 void PolynomialStoreMem::put(std::string const& key, polynomial const& value)
 {
     debug("put: taking copy of polynomial: ", key);
-    map_[key] = value;
+    polynomial store_value = value;
+    map_[key] = std::move(store_value);
     auto& stats = stats_[key];
     stats.first++;
 }

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_mem.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_mem.cpp
@@ -18,7 +18,7 @@ template <typename... Args> inline void debug(Args...) {}
 void PolynomialStoreMem::put(std::string const& key, polynomial const& value)
 {
     debug("put: taking copy of polynomial: ", key);
-    map_.emplace(key, std::move(value));
+    map_.emplace(key, value);
     auto& stats = stats_[key];
     stats.first++;
 }

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_mem.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_mem.cpp
@@ -18,8 +18,7 @@ template <typename... Args> inline void debug(Args...) {}
 void PolynomialStoreMem::put(std::string const& key, polynomial const& value)
 {
     debug("put: taking copy of polynomial: ", key);
-    polynomial store_value = value;
-    map_[key] = std::move(store_value);
+    map_.emplace(key, std::move(value));
     auto& stats = stats_[key];
     stats.first++;
 }

--- a/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_wasm.cpp
+++ b/cpp/src/aztec/proof_system/polynomial_cache/polynomial_store_wasm.cpp
@@ -17,7 +17,7 @@ template <typename... Args> inline void debug(Args...) {}
 
 void PolynomialStoreWasm::put(std::string const& key, polynomial const& poly)
 {
-    set_data(key.c_str(), poly.get_coefficients(), poly.get_size() * sizeof(fr));
+    set_data(key.c_str(), poly.get_coefficients(), poly.size() * sizeof(fr));
 }
 
 polynomial PolynomialStoreWasm::get(std::string const& key) const

--- a/cpp/src/aztec/proof_system/proving_key/proving_key.cpp
+++ b/cpp/src/aztec/proof_system/proving_key/proving_key.cpp
@@ -80,10 +80,10 @@ void proving_key::init()
     }
 
     // t_i for i = 1,2,3 have n+1 coefficients after blinding. t_4 has only n coefficients.
-    quotient_polynomial_parts[0] = barretenberg::polynomial(circuit_size + 1, circuit_size + 1);
-    quotient_polynomial_parts[1] = barretenberg::polynomial(circuit_size + 1, circuit_size + 1);
-    quotient_polynomial_parts[2] = barretenberg::polynomial(circuit_size + 1, circuit_size + 1);
-    quotient_polynomial_parts[3] = barretenberg::polynomial(circuit_size, circuit_size);
+    quotient_polynomial_parts[0] = barretenberg::polynomial(circuit_size + 1);
+    quotient_polynomial_parts[1] = barretenberg::polynomial(circuit_size + 1);
+    quotient_polynomial_parts[2] = barretenberg::polynomial(circuit_size + 1);
+    quotient_polynomial_parts[3] = barretenberg::polynomial(circuit_size);
 
     memset((void*)&quotient_polynomial_parts[0][0], 0x00, sizeof(barretenberg::fr) * (circuit_size + 1));
     memset((void*)&quotient_polynomial_parts[1][0], 0x00, sizeof(barretenberg::fr) * (circuit_size + 1));

--- a/cpp/src/aztec/proof_system/proving_key/proving_key.test.cpp
+++ b/cpp/src/aztec/proof_system/proving_key/proving_key.test.cpp
@@ -8,15 +8,6 @@
 using namespace barretenberg;
 using namespace waffle;
 
-polynomial create_polynomial(size_t size)
-{
-    polynomial p(size, size);
-    for (size_t i = 0; i < size; ++i) {
-        p.add_coefficient(fr::random_element());
-    }
-    return p;
-}
-
 // Test proving key serialization/deserialization to/from buffer
 TEST(proving_key, proving_key_from_serialized_key)
 {

--- a/cpp/src/aztec/proof_system/proving_key/serialize.hpp
+++ b/cpp/src/aztec/proof_system/proving_key/serialize.hpp
@@ -99,7 +99,7 @@ template <typename B> inline void write_mmap(B& os, std::string const& path, pro
         auto filename = format(path, "/", file_num++, "_", poly_id);
         write(os, poly_id);
         const barretenberg::polynomial& value = ((proving_key&)key).polynomial_cache.get(poly_id);
-        auto size = value.get_size();
+        auto size = value.size();
         std::ofstream ofs(filename);
         ofs.write((char*)&value[0], (std::streamsize)(size * sizeof(barretenberg::fr)));
         if (!ofs.good()) {

--- a/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
@@ -255,7 +255,7 @@ void work_queue::process_queue()
 
             wire_fft.coset_fft(key->large_domain);
             for (size_t i = 0; i < 4; i++) {
-                wire_fft[4 * key->n + i] = wire_fft[i];
+                wire_fft[4 * key->circuit_size + i] = wire_fft[i];
             }
 
             key->polynomial_cache.put(item.tag + "_fft", std::move(wire_fft));

--- a/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
@@ -248,7 +248,7 @@ void work_queue::process_queue()
         case WorkType::FFT: {
             using namespace barretenberg;
             polynomial& wire = key->polynomial_cache.get(item.tag);
-            polynomial wire_fft(4 * key->circuit_size + 4, 4 * key->circuit_size + 4);
+            polynomial wire_fft(4 * key->circuit_size + 4);
 
             polynomial_arithmetic::copy_polynomial(
                 &wire[0], &wire_fft[0], key->circuit_size, 4 * key->circuit_size + 4);

--- a/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
@@ -251,7 +251,7 @@ void work_queue::process_queue()
             polynomial wire_fft(4 * key->circuit_size + 4);
 
             polynomial_arithmetic::copy_polynomial(
-                &wire[0], &wire_fft[0], key->circuit_size, 4 * key->circuit_size + 4);
+                wire.data(), wire_fft.data(), key->circuit_size, 4 * key->circuit_size + 4);
 
             wire_fft.coset_fft(key->large_domain);
             for (size_t i = 0; i < 4; i++) {

--- a/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/aztec/proof_system/work_queue/work_queue.cpp
@@ -254,10 +254,9 @@ void work_queue::process_queue()
                 &wire[0], &wire_fft[0], key->circuit_size, 4 * key->circuit_size + 4);
 
             wire_fft.coset_fft(key->large_domain);
-            wire_fft.add_lagrange_base_coefficient(wire_fft[0]);
-            wire_fft.add_lagrange_base_coefficient(wire_fft[1]);
-            wire_fft.add_lagrange_base_coefficient(wire_fft[2]);
-            wire_fft.add_lagrange_base_coefficient(wire_fft[3]);
+            for (size_t i = 0; i < 4; i++) {
+                wire_fft[4 * key->n + i] = wire_fft[i];
+            }
 
             key->polynomial_cache.put(item.tag + "_fft", std::move(wire_fft));
 


### PR DESCRIPTION
# Description

The purpose of this work is to clean out outdated/unnecessary memory management stuff from the Polynomial class.

- Reduce Polynomial data to these three: `mapped_`, `coefficients_`, and `size_`
- No more concept of `max_size_`, there is only `size_`
- Remove unused and/or unnecessary operations like 'bump_memory', resize, reserve. These have been replaced with appropriate ASSERTs or avoided altogether as appropriate
- Remove some unused or unnecessary functions like `add_lagrange_base_coefficient()`


# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
