### PR TITLE
No more `n`

### DIFF
--- a/cpp/src/aztec/honk/composer/composer_helper/permutation_helper.hpp
+++ b/cpp/src/aztec/honk/composer/composer_helper/permutation_helper.hpp
@@ -112,7 +112,7 @@ void compute_standard_honk_sigma_permutations(CircuitConstructor& circuit_constr
 {
     // Compute wire copy cycles for public and private variables
     std::vector<CyclicPermutation> copy_cycles = compute_wire_copy_cycles<program_width>(circuit_constructor);
-    const size_t n = key->n;
+    const size_t n = key->circuit_size;
 
     // Initialize sigma[0], sigma[1], ..., as the identity permutation
     // at the end of the loop, sigma[j][i] = j*n + i
@@ -185,12 +185,12 @@ void compute_standard_honk_sigma_permutations(CircuitConstructor& circuit_constr
 template <size_t program_width>
 void compute_standard_honk_id_polynomials(auto key) // proving_key* and share_ptr<proving_key>
 {
-    const size_t n = key->n;
+    const size_t n = key->circuit_size;
     // Fill id polynomials with default values
     for (size_t j = 0; j < program_width; ++j) {
         // Construct permutation polynomials in lagrange base
         barretenberg::polynomial id_j(n, n);
-        for (size_t i = 0; i < key->n; ++i) {
+        for (size_t i = 0; i < key->circuit_size; ++i) {
             id_j[i] = (j * n + i);
         }
         std::string index = std::to_string(j + 1);
@@ -205,7 +205,7 @@ void compute_standard_honk_id_polynomials(auto key) // proving_key* and share_pt
  */
 inline void compute_first_and_last_lagrange_polynomials(auto key) // proving_key* and share_ptr<proving_key>
 {
-    const size_t n = key->n;
+    const size_t n = key->circuit_size;
     // info("Computing Lagrange basis polys, the  value of n is: ",/s n);
     barretenberg::polynomial lagrange_polynomial_0(n, n);
     barretenberg::polynomial lagrange_polynomial_n_min_1(n, n);

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.hpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.hpp
@@ -34,7 +34,7 @@ class StandardHonkComposer {
 
     StandardHonkComposer(const size_t size_hint = 0)
         : circuit_constructor(size_hint)
-        , n(circuit_constructor.num_gates)
+        , num_gates(circuit_constructor.num_gates)
         , variables(circuit_constructor.variables){};
 
     StandardHonkComposer(std::string const& crs_path, const size_t size_hint = 0)
@@ -45,14 +45,14 @@ class StandardHonkComposer {
     StandardHonkComposer(std::shared_ptr<waffle::ReferenceStringFactory> const& crs_factory, const size_t size_hint = 0)
         : circuit_constructor(size_hint)
         , composer_helper(crs_factory)
-        , n(circuit_constructor.num_gates)
+        , num_gates(circuit_constructor.num_gates)
         , variables(circuit_constructor.variables)
 
     {}
     StandardHonkComposer(std::unique_ptr<waffle::ReferenceStringFactory>&& crs_factory, const size_t size_hint = 0)
         : circuit_constructor(size_hint)
         , composer_helper(std::move(crs_factory))
-        , n(circuit_constructor.num_gates)
+        , num_gates(circuit_constructor.num_gates)
         , variables(circuit_constructor.variables)
 
     {}
@@ -62,7 +62,7 @@ class StandardHonkComposer {
                          size_t size_hint = 0)
         : circuit_constructor(size_hint)
         , composer_helper(p_key, v_key)
-        , n(circuit_constructor.num_gates)
+        , num_gates(circuit_constructor.num_gates)
         , variables(circuit_constructor.variables)
     {}
 
@@ -216,7 +216,7 @@ class StandardHonkComposer {
         return composer_helper.create_unrolled_prover<honk::StandardHonk>(circuit_constructor);
     };
 
-    size_t& n; /* n = Enemy */
+    size_t& num_gates;
     std::vector<barretenberg::fr>& variables;
     bool failed() const { return circuit_constructor.failed(); };
     const std::string& err() const { return circuit_constructor.err(); };

--- a/cpp/src/aztec/honk/pcs/commitment_key.hpp
+++ b/cpp/src/aztec/honk/pcs/commitment_key.hpp
@@ -45,9 +45,9 @@ class CommitmentKey {
      *
      * @todo change path to string_view
      */
-    CommitmentKey(const size_t n, std::string_view path)
-        : pippenger_runtime_state(n)
-        , srs(n, std::string(path))
+    CommitmentKey(const size_t num_points, std::string_view path)
+        : pippenger_runtime_state(num_points)
+        , srs(num_points, std::string(path))
     {}
 
     /**

--- a/cpp/src/aztec/honk/proof_system/prover.hpp
+++ b/cpp/src/aztec/honk/proof_system/prover.hpp
@@ -33,10 +33,10 @@ template <typename settings> class Prover {
     waffle::plonk_proof& export_proof();
     waffle::plonk_proof& construct_proof();
 
-    size_t get_circuit_size() const { return n; }
+    size_t get_circuit_size() const { return circuit_size; }
 
     // TODO(luke): Eventually get rid of this but leave it for convenience for now
-    const size_t n;
+    const size_t circuit_size;
 
     // No more widgets. The new 'relations' may be owned by Sumcheck rather than Prover...
     // std::vector<std::unique_ptr<ProverRandomWidget>> random_widgets;

--- a/cpp/src/aztec/honk/proof_system/prover.test.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.test.cpp
@@ -60,9 +60,9 @@ template <class Fscalar> class ProverTests : public testing::Test {
         std::vector<polynomial> wires;
         std::vector<polynomial> sigmas;
         for (size_t i = 0; i < program_width; ++i) {
-            polynomial wire_poly(proving_key->n, proving_key->n);
-            polynomial sigma_poly(proving_key->n, proving_key->n);
-            for (size_t j = 0; j < proving_key->n; ++j) {
+            polynomial wire_poly(proving_key->circuit_size, proving_key->circuit_size);
+            polynomial sigma_poly(proving_key->circuit_size, proving_key->circuit_size);
+            for (size_t j = 0; j < proving_key->circuit_size; ++j) {
                 wire_poly[j] = Fscalar::random_element();
                 sigma_poly[j] = Fscalar::random_element();
             }
@@ -118,9 +118,9 @@ template <class Fscalar> class ProverTests : public testing::Test {
         std::array<std::array<Fscalar, num_gates>, program_width> denominator_accum;
 
         // Step (1)
-        for (size_t i = 0; i < proving_key->n; ++i) {
+        for (size_t i = 0; i < proving_key->circuit_size; ++i) {
             for (size_t k = 0; k < program_width; ++k) {
-                Fscalar idx = k * proving_key->n + i;                                  // id_k[i]
+                Fscalar idx = k * proving_key->circuit_size + i;                       // id_k[i]
                 numererator_accum[k][i] = wires[k][i] + (idx * beta) + gamma;          // w_k(i) + β.(k*n+i) + γ
                 denominator_accum[k][i] = wires[k][i] + (sigmas[k][i] * beta) + gamma; // w_k(i) + β.σ_k(i) + γ
             }
@@ -128,14 +128,14 @@ template <class Fscalar> class ProverTests : public testing::Test {
 
         // Step (2)
         for (size_t k = 0; k < program_width; ++k) {
-            for (size_t i = 0; i < proving_key->n - 1; ++i) {
+            for (size_t i = 0; i < proving_key->circuit_size - 1; ++i) {
                 numererator_accum[k][i + 1] *= numererator_accum[k][i];
                 denominator_accum[k][i + 1] *= denominator_accum[k][i];
             }
         }
 
         // Step (3)
-        for (size_t i = 0; i < proving_key->n; ++i) {
+        for (size_t i = 0; i < proving_key->circuit_size; ++i) {
             for (size_t k = 1; k < program_width; ++k) {
                 numererator_accum[0][i] *= numererator_accum[k][i];
                 denominator_accum[0][i] *= denominator_accum[k][i];
@@ -143,10 +143,10 @@ template <class Fscalar> class ProverTests : public testing::Test {
         }
 
         // Step (4)
-        polynomial z_perm(proving_key->n, proving_key->n);
+        polynomial z_perm(proving_key->circuit_size, proving_key->circuit_size);
         z_perm[0] = Fscalar::zero(); // Z_0 = 1
         // Note: in practice, we replace this expensive element-wise division with Montgomery batch inversion
-        for (size_t i = 0; i < proving_key->n - 1; ++i) {
+        for (size_t i = 0; i < proving_key->circuit_size - 1; ++i) {
             z_perm[i + 1] = numererator_accum[0][i] / denominator_accum[0][i];
         }
 

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.hpp
@@ -85,8 +85,8 @@ template <class FF_, size_t num_polys> class Multivariates {
     };
 
     explicit Multivariates(const std::shared_ptr<waffle::proving_key>& proving_key)
-        : multivariate_n(proving_key->n)
-        , multivariate_d(proving_key->log_n)
+        : multivariate_n(proving_key->circuit_size)
+        , multivariate_d(proving_key->log_circuit_size)
     {
         // Iterate through polynomial manifest to populate full_polynomials from polynomial cache
         size_t poly_idx = 0;

--- a/cpp/src/aztec/plonk/composer/composer_base.hpp
+++ b/cpp/src/aztec/plonk/composer/composer_base.hpp
@@ -63,7 +63,7 @@ class ComposerBase {
                  size_t num_selectors = 0,
                  size_t size_hint = 0,
                  std::vector<SelectorProperties> selector_properties = {})
-        : n(0)
+        : num_gates(0)
         , crs_factory_(crs_factory)
         , num_selectors(num_selectors)
         , selectors(num_selectors)
@@ -78,7 +78,7 @@ class ComposerBase {
     ComposerBase(size_t num_selectors = 0,
                  size_t size_hint = 0,
                  std::vector<SelectorProperties> selector_properties = {})
-        : n(0)
+        : num_gates(0)
         , crs_factory_(std::make_unique<FileReferenceStringFactory>("../srs_db/ignition"))
         , num_selectors(num_selectors)
         , selectors(num_selectors)
@@ -95,7 +95,7 @@ class ComposerBase {
                  size_t num_selectors = 0,
                  size_t size_hint = 0,
                  std::vector<SelectorProperties> selector_properties = {})
-        : n(0)
+        : num_gates(0)
         , circuit_proving_key(p_key)
         , circuit_verification_key(v_key)
         , num_selectors(num_selectors)
@@ -112,8 +112,8 @@ class ComposerBase {
     ComposerBase& operator=(ComposerBase&& other) = default;
     virtual ~ComposerBase(){};
 
-    virtual size_t get_num_gates() const { return n; }
-    virtual void print_num_gates() const { std::cout << n << std::endl; }
+    virtual size_t get_num_gates() const { return num_gates; }
+    virtual void print_num_gates() const { std::cout << num_gates << std::endl; }
     virtual size_t get_num_variables() const { return variables.size(); }
     virtual std::shared_ptr<proving_key> compute_proving_key_base(const waffle::ComposerType type = waffle::STANDARD,
                                                                   const size_t minimum_ciricut_size = 0,
@@ -297,7 +297,7 @@ class ComposerBase {
     std::string _err;
 
   public:
-    size_t n; /* n = Enemy */
+    size_t num_gates;
     std::vector<uint32_t> w_l;
     std::vector<uint32_t> w_r;
     std::vector<uint32_t> w_o;

--- a/cpp/src/aztec/plonk/composer/standard_composer.cpp
+++ b/cpp/src/aztec/plonk/composer/standard_composer.cpp
@@ -38,7 +38,7 @@ void StandardComposer::create_add_gate(const add_triple& in)
     q_3.emplace_back(in.c_scaling);
     q_c.emplace_back(in.const_scaling);
 
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -91,7 +91,7 @@ void StandardComposer::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(fr::neg_one());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 
     w_l.emplace_back(temp_idx);
     w_r.emplace_back(in.c);
@@ -102,7 +102,7 @@ void StandardComposer::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(in.d_scaling);
     q_c.emplace_back(in.const_scaling);
 
-    ++n;
+    ++num_gates;
 
     // in.d must be between 0 and 3
     // i.e. in.d * (in.d - 1) * (in.d - 2) = 0
@@ -117,7 +117,7 @@ void StandardComposer::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(fr::neg_one());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 
     constexpr fr neg_two = -fr(2);
     w_l.emplace_back(temp_2_idx);
@@ -129,7 +129,7 @@ void StandardComposer::create_balanced_add_gate(const add_quad& in)
     q_3.emplace_back(fr::zero());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 }
 
 void StandardComposer::create_big_add_gate_with_bit_extraction(const add_quad& in)
@@ -207,7 +207,7 @@ void StandardComposer::create_mul_gate(const mul_triple& in)
     q_3.emplace_back(in.c_scaling);
     q_c.emplace_back(in.const_scaling);
 
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -231,7 +231,7 @@ void StandardComposer::create_bool_gate(const uint32_t variable_index)
     q_3.emplace_back(fr::neg_one());
     q_c.emplace_back(fr::zero());
 
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -253,7 +253,7 @@ void StandardComposer::create_poly_gate(const poly_triple& in)
     q_3.emplace_back(in.q_o);
     q_c.emplace_back(in.q_c);
 
-    ++n;
+    ++num_gates;
 }
 
 void StandardComposer::create_fixed_group_add_gate_with_init(const fixed_group_add_quad& in,
@@ -693,7 +693,7 @@ void StandardComposer::fix_witness(const uint32_t witness_index, const barretenb
     q_2.emplace_back(fr::zero());
     q_3.emplace_back(fr::zero());
     q_c.emplace_back(-witness_value);
-    ++n;
+    ++num_gates;
 }
 
 uint32_t StandardComposer::put_constant_variable(const barretenberg::fr& variable)
@@ -885,7 +885,7 @@ bool StandardComposer::check_circuit()
 
     fr gate_sum;
     fr left, right, output;
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < num_gates; i++) {
         gate_sum = fr::zero();
         left = get_variable(w_l[i]);
         right = get_variable(w_r[i]);

--- a/cpp/src/aztec/plonk/composer/standard_composer.test.cpp
+++ b/cpp/src/aztec/plonk/composer/standard_composer.test.cpp
@@ -53,7 +53,8 @@ TEST(standard_composer, composer_from_serialized_keys)
     auto vk_data = from_buffer<waffle::verification_key_data>(vk_buf);
 
     auto crs = std::make_unique<waffle::FileReferenceStringFactory>("../srs_db/ignition");
-    auto proving_key = std::make_shared<waffle::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.n + 1));
+    auto proving_key =
+        std::make_shared<waffle::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.circuit_size + 1));
     auto verification_key = std::make_shared<waffle::verification_key>(std::move(vk_data), crs->get_verifier_crs());
 
     waffle::StandardComposer composer2 = waffle::StandardComposer(proving_key, verification_key);

--- a/cpp/src/aztec/plonk/composer/turbo_composer.cpp
+++ b/cpp/src/aztec/plonk/composer/turbo_composer.cpp
@@ -117,7 +117,7 @@ void TurboComposer::create_add_gate(const add_triple& in)
     q_fixed_base.emplace_back(fr::zero());
     q_range.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -149,7 +149,7 @@ void TurboComposer::create_big_add_gate(const add_quad& in)
     q_fixed_base.emplace_back(fr::zero());
     q_range.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -188,7 +188,7 @@ void TurboComposer::create_big_add_gate_with_bit_extraction(const add_quad& in)
     q_fixed_base.emplace_back(fr::zero());
     q_range.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 void TurboComposer::create_big_mul_gate(const mul_quad& in)
@@ -211,7 +211,7 @@ void TurboComposer::create_big_mul_gate(const mul_quad& in)
     q_fixed_base.emplace_back(fr::zero());
     q_range.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -251,7 +251,7 @@ void TurboComposer::create_balanced_add_gate(const add_quad& in)
     q_fixed_base.emplace_back(fr::zero());
     q_range.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -283,7 +283,7 @@ void TurboComposer::create_mul_gate(const mul_triple& in)
     q_fixed_base.emplace_back(fr::zero());
     q_range.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -314,7 +314,7 @@ void TurboComposer::create_bool_gate(const uint32_t variable_index)
     q_3.emplace_back(fr::neg_one());
     q_c.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -347,7 +347,7 @@ void TurboComposer::create_poly_gate(const poly_triple& in)
     q_4.emplace_back(fr::zero());
     q_5.emplace_back(fr::zero());
     q_fixed_base.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -377,7 +377,7 @@ void TurboComposer::create_fixed_group_add_gate(const fixed_group_add_quad& in)
     q_2.emplace_back(in.q_x_2);
     q_3.emplace_back(in.q_y_1);
     q_fixed_base.emplace_back(in.q_y_2);
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -409,7 +409,7 @@ void TurboComposer::create_fixed_group_add_gate_with_init(const fixed_group_add_
     q_2.emplace_back(in.q_x_2);
     q_3.emplace_back(in.q_y_1);
     q_fixed_base.emplace_back(in.q_y_2);
-    ++n;
+    ++num_gates;
 }
 
 void TurboComposer::create_fixed_group_add_gate_final(const add_quad& in)
@@ -443,7 +443,7 @@ void TurboComposer::fix_witness(const uint32_t witness_index, const barretenberg
     q_fixed_base.emplace_back(fr::zero());
     q_range.emplace_back(fr::zero());
     q_logic.emplace_back(fr::zero());
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -616,7 +616,7 @@ std::vector<uint32_t> TurboComposer::decompose_into_base4_accumulators(const uin
 
     accumulators[accumulators.size() - 1] = witness_index;
 
-    n += used_gates;
+    num_gates += used_gates;
 
     // constrain top bit of top quad to zero in case num_bits is odd
     if ((num_bits & 1ULL) == 1ULL) {
@@ -817,7 +817,7 @@ accumulator_triple TurboComposer::create_logic_constraint(const uint32_t a,
 
     accumulators.right[accumulators.right.size() - 1] = b;
 
-    n += (num_quads + 1);
+    num_gates += (num_quads + 1);
 
     return accumulators;
 }

--- a/cpp/src/aztec/plonk/composer/turbo_composer.hpp
+++ b/cpp/src/aztec/plonk/composer/turbo_composer.hpp
@@ -250,7 +250,7 @@ class CheckGetter {
         size_t actual_index = index;
         if constexpr (EvaluationType::SHIFTED == value_type) {
             actual_index += 1;
-            if (actual_index >= composer.n) {
+            if (actual_index >= composer.num_gates) {
                 return zero;
             }
         }

--- a/cpp/src/aztec/plonk/composer/turbo_composer.test.cpp
+++ b/cpp/src/aztec/plonk/composer/turbo_composer.test.cpp
@@ -53,7 +53,8 @@ TEST(turbo_composer, composer_from_serialized_keys)
     auto vk_data = from_buffer<waffle::verification_key_data>(vk_buf);
 
     auto crs = std::make_unique<waffle::FileReferenceStringFactory>("../srs_db/ignition");
-    auto proving_key = std::make_shared<waffle::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.n + 1));
+    auto proving_key =
+        std::make_shared<waffle::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.circuit_size + 1));
     auto verification_key = std::make_shared<waffle::verification_key>(std::move(vk_data), crs->get_verifier_crs());
 
     waffle::TurboComposer composer2 = waffle::TurboComposer(proving_key, verification_key);

--- a/cpp/src/aztec/plonk/composer/ultra_composer.cpp
+++ b/cpp/src/aztec/plonk/composer/ultra_composer.cpp
@@ -113,7 +113,7 @@ void UltraComposer::create_add_gate(const add_triple& in)
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -145,7 +145,7 @@ void UltraComposer::create_big_add_gate(const add_quad& in, const bool include_n
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -238,7 +238,7 @@ void UltraComposer::create_big_mul_gate(const mul_quad& in)
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 // Creates a width-4 addition gate, where the fourth witness must be a boolean.
@@ -264,7 +264,7 @@ void UltraComposer::create_balanced_add_gate(const add_quad& in)
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
     // Why 3? TODO: return to this
     create_new_range_constraint(in.d, 3);
 }
@@ -296,7 +296,7 @@ void UltraComposer::create_mul_gate(const mul_triple& in)
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 /**
  * @brief Generate an arithmetic gate equivalent to x^2 - x = 0, which forces x to be 0 or 1
@@ -325,7 +325,7 @@ void UltraComposer::create_bool_gate(const uint32_t variable_index)
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -355,7 +355,7 @@ void UltraComposer::create_poly_gate(const poly_triple& in)
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 // adds a grumpkin point, from a 2-bit lookup table, into an accumulator point
@@ -382,7 +382,7 @@ void UltraComposer::create_fixed_group_add_gate(const fixed_group_add_quad& in)
     q_sort.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 // adds a grumpkin point into an accumulator, while also initializing the accumulator
@@ -413,7 +413,7 @@ void UltraComposer::create_fixed_group_add_gate_with_init(const fixed_group_add_
     q_sort.emplace_back(0);
     q_elliptic.emplace_back(0);
 
-    ++n;
+    ++num_gates;
 }
 
 void UltraComposer::create_fixed_group_add_gate_final(const add_quad& in)
@@ -445,19 +445,19 @@ void UltraComposer::create_ecc_add_gate(const ecc_add_gate& in)
     assert_valid_variables({ in.x1, in.x2, in.x3, in.y1, in.y2, in.y3 });
 
     bool can_fuse_into_previous_gate = true;
-    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (w_r[n - 1] == in.x1);
-    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (w_o[n - 1] == in.y1);
-    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_3[n - 1] == 0);
-    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_4[n - 1] == 0);
-    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_1[n - 1] == 0);
-    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_arith[n - 1] == 0);
+    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (w_r[num_gates - 1] == in.x1);
+    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (w_o[num_gates - 1] == in.y1);
+    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_3[num_gates - 1] == 0);
+    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_4[num_gates - 1] == 0);
+    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_1[num_gates - 1] == 0);
+    can_fuse_into_previous_gate = can_fuse_into_previous_gate && (q_arith[num_gates - 1] == 0);
 
     if (can_fuse_into_previous_gate) {
 
-        q_3[n - 1] = in.endomorphism_coefficient;
-        q_4[n - 1] = in.endomorphism_coefficient.sqr();
-        q_1[n - 1] = in.sign_coefficient;
-        q_elliptic[n - 1] = 1;
+        q_3[num_gates - 1] = in.endomorphism_coefficient;
+        q_4[num_gates - 1] = in.endomorphism_coefficient.sqr();
+        q_1[num_gates - 1] = in.sign_coefficient;
+        q_elliptic[num_gates - 1] = 1;
     } else {
         w_l.emplace_back(zero_idx);
         w_r.emplace_back(in.x1);
@@ -476,7 +476,7 @@ void UltraComposer::create_ecc_add_gate(const ecc_add_gate& in)
         q_lookup_type.emplace_back(0);
         q_elliptic.emplace_back(1);
         q_aux.emplace_back(0);
-        ++n;
+        ++num_gates;
     }
 
     w_l.emplace_back(in.x2);
@@ -495,7 +495,7 @@ void UltraComposer::create_ecc_add_gate(const ecc_add_gate& in)
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 /**
@@ -525,7 +525,7 @@ void UltraComposer::fix_witness(const uint32_t witness_index, const barretenberg
     q_lookup_type.emplace_back(0);
     q_elliptic.emplace_back(0);
     q_aux.emplace_back(0);
-    ++n;
+    ++num_gates;
 }
 
 uint32_t UltraComposer::put_constant_variable(const barretenberg::fr& variable)
@@ -548,7 +548,7 @@ void UltraComposer::add_table_column_selector_poly_to_proving_key(polynomial& se
     selector_poly_lagrange_form.ifft(circuit_proving_key->small_domain);
     auto& selector_poly_coeff_form = selector_poly_lagrange_form;
 
-    polynomial selector_poly_coset_form(selector_poly_coeff_form, circuit_proving_key->n * 4);
+    polynomial selector_poly_coset_form(selector_poly_coeff_form, circuit_proving_key->circuit_size * 4);
     selector_poly_coset_form.coset_fft(circuit_proving_key->large_domain);
 
     circuit_proving_key->polynomial_cache.put(tag, std::move(selector_poly_coeff_form));
@@ -572,10 +572,10 @@ std::shared_ptr<proving_key> UltraComposer::compute_proving_key()
      *  1. ComposerBase::n => refers to the size of the witness of a given program,
      *  2. proving_key::n => the next power of two ≥ total witness size.
      *
-     * In this case, we have composer.n = n_computation before we execute the following two functions.
+     * In this case, we have composer.num_gates = n_computation before we execute the following two functions.
      * After these functions are executed, the composer's `n` is incremented to include the ROM
      * and range list gates. Therefore we have:
-     * composer.n = n_computation + n_rom + n_range.
+     * composer.num_gates = n_computation + n_rom + n_range.
      *
      * Its necessary to include the (n_rom + n_range) gates at this point because if we already have a
      * proving key, and we just return it without including these ROM and range list gates, the overall
@@ -594,18 +594,18 @@ std::shared_ptr<proving_key> UltraComposer::compute_proving_key()
         return circuit_proving_key;
     }
 
-    ASSERT(n == q_m.size());
-    ASSERT(n == q_c.size());
-    ASSERT(n == q_1.size());
-    ASSERT(n == q_2.size());
-    ASSERT(n == q_3.size());
-    ASSERT(n == q_4.size());
-    ASSERT(n == q_arith.size());
-    ASSERT(n == q_fixed_base.size());
-    ASSERT(n == q_elliptic.size());
-    ASSERT(n == q_sort.size());
-    ASSERT(n == q_lookup_type.size());
-    ASSERT(n == q_aux.size());
+    ASSERT(num_gates == q_m.size());
+    ASSERT(num_gates == q_c.size());
+    ASSERT(num_gates == q_1.size());
+    ASSERT(num_gates == q_2.size());
+    ASSERT(num_gates == q_3.size());
+    ASSERT(num_gates == q_4.size());
+    ASSERT(num_gates == q_arith.size());
+    ASSERT(num_gates == q_fixed_base.size());
+    ASSERT(num_gates == q_elliptic.size());
+    ASSERT(num_gates == q_sort.size());
+    ASSERT(num_gates == q_lookup_type.size());
+    ASSERT(num_gates == q_aux.size());
 
     size_t tables_size = 0;
     size_t lookups_size = 0;
@@ -617,7 +617,7 @@ std::shared_ptr<proving_key> UltraComposer::compute_proving_key()
     // Compute selector polynomials and appropriate fft versions and put them in the proving key
     ComposerBase::compute_proving_key_base(type, tables_size + lookups_size, NUM_RESERVED_GATES);
 
-    const size_t subgroup_size = circuit_proving_key->n;
+    const size_t subgroup_size = circuit_proving_key->circuit_size;
 
     polynomial poly_q_table_column_1(subgroup_size);
     polynomial poly_q_table_column_2(subgroup_size);
@@ -749,7 +749,7 @@ void UltraComposer::compute_witness()
         lookups_size += table.lookup_gates.size();
     }
 
-    const size_t filled_gates = n + public_inputs.size();
+    const size_t filled_gates = num_gates + public_inputs.size();
     const size_t total_num_gates = std::max(filled_gates, tables_size + lookups_size);
 
     const size_t subgroup_size = get_circuit_subgroup_size(total_num_gates + NUM_RESERVED_GATES);
@@ -1107,7 +1107,7 @@ plookup::ReadData<uint32_t> UltraComposer::create_gates_from_plookup_accumulator
         q_sort.emplace_back(0);
         q_elliptic.emplace_back(0);
         q_aux.emplace_back(0);
-        ++n;
+        ++num_gates;
     }
     return read_data;
 }
@@ -1330,7 +1330,7 @@ void UltraComposer::create_sort_constraint(const std::vector<uint32_t>& variable
         w_r.emplace_back(variable_index[i + 1]);
         w_o.emplace_back(variable_index[i + 2]);
         w_4.emplace_back(variable_index[i + 3]);
-        ++n;
+        ++num_gates;
         q_m.emplace_back(0);
         q_1.emplace_back(0);
         q_2.emplace_back(0);
@@ -1349,7 +1349,7 @@ void UltraComposer::create_sort_constraint(const std::vector<uint32_t>& variable
     w_r.emplace_back(zero_idx);
     w_o.emplace_back(zero_idx);
     w_4.emplace_back(zero_idx);
-    ++n;
+    ++num_gates;
     q_m.emplace_back(0);
     q_1.emplace_back(0);
     q_2.emplace_back(0);
@@ -1383,7 +1383,7 @@ void UltraComposer::create_dummy_constraints(const std::vector<uint32_t>& variab
         w_r.emplace_back(padded_list[i + 1]);
         w_o.emplace_back(padded_list[i + 2]);
         w_4.emplace_back(padded_list[i + 3]);
-        ++n;
+        ++num_gates;
         q_m.emplace_back(0);
         q_1.emplace_back(0);
         q_2.emplace_back(0);
@@ -1415,7 +1415,7 @@ void UltraComposer::create_sort_constraint_with_edges(const std::vector<uint32_t
     w_r.emplace_back(variable_index[1]);
     w_o.emplace_back(variable_index[2]);
     w_4.emplace_back(variable_index[3]);
-    ++n;
+    ++num_gates;
     q_m.emplace_back(0);
     q_1.emplace_back(1);
     q_2.emplace_back(0);
@@ -1435,7 +1435,7 @@ void UltraComposer::create_sort_constraint_with_edges(const std::vector<uint32_t
         w_r.emplace_back(variable_index[i + 1]);
         w_o.emplace_back(variable_index[i + 2]);
         w_4.emplace_back(variable_index[i + 3]);
-        ++n;
+        ++num_gates;
         q_m.emplace_back(0);
         q_1.emplace_back(0);
         q_2.emplace_back(0);
@@ -1455,7 +1455,7 @@ void UltraComposer::create_sort_constraint_with_edges(const std::vector<uint32_t
         w_r.emplace_back(variable_index[variable_index.size() - 3]);
         w_o.emplace_back(variable_index[variable_index.size() - 2]);
         w_4.emplace_back(variable_index[variable_index.size() - 1]);
-        ++n;
+        ++num_gates;
         q_m.emplace_back(0);
         q_1.emplace_back(0);
         q_2.emplace_back(0);
@@ -1476,7 +1476,7 @@ void UltraComposer::create_sort_constraint_with_edges(const std::vector<uint32_t
     w_r.emplace_back(zero_idx);
     w_o.emplace_back(zero_idx);
     w_4.emplace_back(zero_idx);
-    ++n;
+    ++num_gates;
     q_m.emplace_back(0);
     q_1.emplace_back(1);
     q_2.emplace_back(0);
@@ -1750,7 +1750,7 @@ void UltraComposer::range_constrain_two_limbs(const uint32_t lo_idx,
     apply_aux_selectors(AUX_SELECTORS::LIMB_ACCUMULATE_1);
     apply_aux_selectors(AUX_SELECTORS::LIMB_ACCUMULATE_2);
     apply_aux_selectors(AUX_SELECTORS::NONE);
-    n += 3;
+    num_gates += 3;
 
     for (size_t i = 0; i < 5; i++) {
         if (lo_masks[i] != 0) {
@@ -1905,25 +1905,25 @@ std::array<uint32_t, 2> UltraComposer::evaluate_non_native_field_multiplication(
     w_o.emplace_back(input.r[0]);
     w_4.emplace_back(lo_0_idx);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_1);
-    ++n;
+    ++num_gates;
     w_l.emplace_back(input.a[0]);
     w_r.emplace_back(input.b[0]);
     w_o.emplace_back(input.a[3]);
     w_4.emplace_back(input.b[3]);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_2);
-    ++n;
+    ++num_gates;
     w_l.emplace_back(input.a[2]);
     w_r.emplace_back(input.b[2]);
     w_o.emplace_back(input.r[3]);
     w_4.emplace_back(hi_0_idx);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_3);
-    ++n;
+    ++num_gates;
     w_l.emplace_back(input.a[1]);
     w_r.emplace_back(input.b[1]);
     w_o.emplace_back(input.r[2]);
     w_4.emplace_back(hi_1_idx);
     apply_aux_selectors(AUX_SELECTORS::NONE);
-    ++n;
+    ++num_gates;
 
     /**
      * product gate 6
@@ -2005,25 +2005,25 @@ std::array<uint32_t, 2> UltraComposer::evaluate_partial_non_native_field_multipl
     w_o.emplace_back(zero_idx);
     w_4.emplace_back(lo_0_idx);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_1);
-    ++n;
+    ++num_gates;
     w_l.emplace_back(input.a[0]);
     w_r.emplace_back(input.b[0]);
     w_o.emplace_back(input.a[3]);
     w_4.emplace_back(input.b[3]);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_2);
-    ++n;
+    ++num_gates;
     w_l.emplace_back(input.a[2]);
     w_r.emplace_back(input.b[2]);
     w_o.emplace_back(zero_idx);
     w_4.emplace_back(hi_0_idx);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_3);
-    ++n;
+    ++num_gates;
     w_l.emplace_back(input.a[1]);
     w_r.emplace_back(input.b[1]);
     w_o.emplace_back(zero_idx);
     w_4.emplace_back(hi_1_idx);
     apply_aux_selectors(AUX_SELECTORS::NONE);
-    ++n;
+    ++num_gates;
     return std::array<uint32_t, 2>{ lo_0_idx, hi_1_idx };
 }
 
@@ -2154,7 +2154,7 @@ std::array<uint32_t, 5> UltraComposer::evaluate_non_native_field_addition(
         q_aux.emplace_back(0);
     }
 
-    n += 4;
+    num_gates += 4;
     return std::array<uint32_t, 5>{
         z_0, z_1, z_2, z_3, z_p,
     };
@@ -2281,7 +2281,7 @@ std::array<uint32_t, 5> UltraComposer::evaluate_non_native_field_subtraction(
         q_aux.emplace_back(0);
     }
 
-    n += 4;
+    num_gates += 4;
     return std::array<uint32_t, 5>{
         z_0, z_1, z_2, z_3, z_p,
     };
@@ -2296,8 +2296,8 @@ void UltraComposer::create_memory_gate(MemoryRecord& record)
     w_r.emplace_back(record.timestamp_witness);
     w_o.emplace_back(record.value_witness);
     w_4.emplace_back(record.record_witness);
-    record.gate_index = n;
-    ++n;
+    record.gate_index = num_gates;
+    ++num_gates;
 }
 
 void UltraComposer::create_sorted_memory_gate(MemoryRecord& record, const bool is_ram_transition_or_rom)
@@ -2310,8 +2310,8 @@ void UltraComposer::create_sorted_memory_gate(MemoryRecord& record, const bool i
     w_o.emplace_back(record.value_witness);
     w_4.emplace_back(record.record_witness);
 
-    record.gate_index = n;
-    ++n;
+    record.gate_index = num_gates;
+    ++num_gates;
 }
 
 /**

--- a/cpp/src/aztec/plonk/composer/ultra_composer.hpp
+++ b/cpp/src/aztec/plonk/composer/ultra_composer.hpp
@@ -181,7 +181,7 @@ class UltraComposer : public ComposerBase {
      */
     virtual size_t get_num_gates() const override
     {
-        size_t count = n;
+        size_t count = num_gates;
         size_t rangecount = 0;
         size_t romcount = 0;
         for (size_t i = 0; i < rom_arrays.size(); ++i) {
@@ -209,7 +209,7 @@ class UltraComposer : public ComposerBase {
 
     virtual void print_num_gates() const override
     {
-        size_t count = n;
+        size_t count = num_gates;
         size_t rangecount = 0;
         size_t romcount = 0;
         for (size_t i = 0; i < rom_arrays.size(); ++i) {

--- a/cpp/src/aztec/plonk/composer/ultra_composer.test.cpp
+++ b/cpp/src/aztec/plonk/composer/ultra_composer.test.cpp
@@ -755,7 +755,7 @@ TEST(ultra_composer, rom)
     });
 
     auto prover = composer.create_prover();
-    std::cout << "prover n = " << composer.n << std::endl;
+    info("composer.num_gates after constructing prover: ", composer.num_gates);
 
     auto verifier = composer.create_verifier();
 

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.hpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.hpp
@@ -40,7 +40,7 @@ template <typename settings> class ProverBase {
     waffle::plonk_proof& export_proof();
     waffle::plonk_proof& construct_proof();
 
-    size_t get_circuit_size() const { return n; }
+    size_t get_circuit_size() const { return circuit_size; }
 
     void flush_queued_work_items() { queue.flush_queue(); }
 
@@ -83,7 +83,7 @@ template <typename settings> class ProverBase {
 
     void reset();
 
-    size_t n;
+    size_t circuit_size;
 
     std::vector<std::unique_ptr<ProverRandomWidget>> random_widgets;
     std::vector<std::unique_ptr<widget::TransitionWidgetBase<barretenberg::fr>>> transition_widgets;

--- a/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
+++ b/cpp/src/aztec/plonk/proof_system/prover/prover.test.cpp
@@ -192,17 +192,17 @@ waffle::Prover generate_test_data(const size_t n)
     sigma_2_mapping[n - 1] = (uint32_t)n - 1 + (1U << 30U);
     sigma_3_mapping[n - 1] = (uint32_t)n - 1 + (1U << 31U);
 
-    polynomial sigma_1(key->n);
-    polynomial sigma_2(key->n);
-    polynomial sigma_3(key->n);
+    polynomial sigma_1(key->circuit_size);
+    polynomial sigma_2(key->circuit_size);
+    polynomial sigma_3(key->circuit_size);
 
     waffle::compute_permutation_lagrange_base_single<standard_settings>(sigma_1, sigma_1_mapping, key->small_domain);
     waffle::compute_permutation_lagrange_base_single<standard_settings>(sigma_2, sigma_2_mapping, key->small_domain);
     waffle::compute_permutation_lagrange_base_single<standard_settings>(sigma_3, sigma_3_mapping, key->small_domain);
 
-    polynomial sigma_1_lagrange_base(sigma_1, key->n);
-    polynomial sigma_2_lagrange_base(sigma_2, key->n);
-    polynomial sigma_3_lagrange_base(sigma_3, key->n);
+    polynomial sigma_1_lagrange_base(sigma_1, key->circuit_size);
+    polynomial sigma_2_lagrange_base(sigma_2, key->circuit_size);
+    polynomial sigma_3_lagrange_base(sigma_3, key->circuit_size);
 
     key->polynomial_cache.put("sigma_1_lagrange", std::move(sigma_1_lagrange_base));
     key->polynomial_cache.put("sigma_2_lagrange", std::move(sigma_2_lagrange_base));
@@ -212,9 +212,9 @@ waffle::Prover generate_test_data(const size_t n)
     sigma_2.ifft(key->small_domain);
     sigma_3.ifft(key->small_domain);
     constexpr size_t width = 4;
-    polynomial sigma_1_fft(sigma_1, key->n * width);
-    polynomial sigma_2_fft(sigma_2, key->n * width);
-    polynomial sigma_3_fft(sigma_3, key->n * width);
+    polynomial sigma_1_fft(sigma_1, key->circuit_size * width);
+    polynomial sigma_2_fft(sigma_2, key->circuit_size * width);
+    polynomial sigma_3_fft(sigma_3, key->circuit_size * width);
 
     sigma_1_fft.coset_fft(key->large_domain);
     sigma_2_fft.coset_fft(key->large_domain);

--- a/cpp/src/aztec/plonk/proof_system/utils/kate_verification.hpp
+++ b/cpp/src/aztec/plonk/proof_system/utils/kate_verification.hpp
@@ -102,7 +102,7 @@ void populate_kate_element_map(verification_key* key,
     const auto zeta = transcript.get_challenge_field_element("z", 0);
     const auto quotient_nu = transcript.get_challenge_field_element_from_map("nu", "t");
 
-    Field z_pow_n = zeta.pow(key->n);
+    Field z_pow_n = zeta.pow(key->circuit_size);
     Field z_power = 1;
     for (size_t i = 0; i < program_settings::program_width; ++i) {
         std::string quotient_label = "T_" + std::to_string(i + 1);

--- a/cpp/src/aztec/plonk/proof_system/verifier/verifier.cpp
+++ b/cpp/src/aztec/plonk/proof_system/verifier/verifier.cpp
@@ -56,10 +56,10 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
 
     // From the verification key, also add n & l (the circuit size and the number of public inputs) to the transcript.
     transcript.add_element("circuit_size",
-                           { static_cast<uint8_t>(key->n >> 24),
-                             static_cast<uint8_t>(key->n >> 16),
-                             static_cast<uint8_t>(key->n >> 8),
-                             static_cast<uint8_t>(key->n) });
+                           { static_cast<uint8_t>(key->circuit_size >> 24),
+                             static_cast<uint8_t>(key->circuit_size >> 16),
+                             static_cast<uint8_t>(key->circuit_size >> 8),
+                             static_cast<uint8_t>(key->circuit_size) });
 
     transcript.add_element("public_input_size",
                            { static_cast<uint8_t>(key->num_public_inputs >> 24),

--- a/cpp/src/aztec/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
+++ b/cpp/src/aztec/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
@@ -58,8 +58,8 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_sor
     const fr* s_3 = key->polynomial_cache.get("s_3_lagrange").get_coefficients();
     const fr* s_4 = key->polynomial_cache.get("s_4_lagrange").get_coefficients();
 
-    barretenberg::polynomial s_accum(key->n, key->n);
-    barretenberg::polynomial_arithmetic::copy_polynomial(&s_1[0], &s_accum[0], key->n, key->n);
+    barretenberg::polynomial s_accum(key->circuit_size, key->circuit_size);
+    barretenberg::polynomial_arithmetic::copy_polynomial(&s_1[0], &s_accum[0], key->circuit_size, key->circuit_size);
 
     // Get challenge η
     const auto eta = fr::serialize_from_buffer(transcript.get_challenge("eta", 0).begin());
@@ -92,7 +92,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_sor
     const size_t s_randomness = 3;
     ASSERT(s_randomness < num_roots_cut_out_of_vanishing_polynomial);
     for (size_t k = 0; k < s_randomness; ++k) {
-        s_accum[((key->n - num_roots_cut_out_of_vanishing_polynomial) + 1 + k)] = fr::random_element();
+        s_accum[((key->circuit_size - num_roots_cut_out_of_vanishing_polynomial) + 1 + k)] = fr::random_element();
     }
 
     // Save the lagrange base representation of s
@@ -124,11 +124,11 @@ template <const size_t num_roots_cut_out_of_vanishing_polynomial>
 void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_grand_product_polynomial(
     transcript::StandardTranscript& transcript)
 {
-    const size_t n = key->n;
+    const size_t n = key->circuit_size;
 
     // Note: z_lookup ultimately is only only size 'n' but we allow 'n+1' for convenience
     // essentially as scratch space in the calculation to follow
-    polynomial z_lookup(key->n + 1, key->n + 1);
+    polynomial z_lookup(key->circuit_size + 1, key->circuit_size + 1);
 
     // Allocate 4 length n 'accumulators'. accumulators[0] points to the 1th index of
     // z_lookup and will be used to construct z_lookup (lagrange base) in place. The
@@ -559,7 +559,8 @@ barretenberg::fr ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>:
             //      - z_lookup(Xω)*(s + βs(Xω) + γ(1 + β)) + [z_lookup(Xω) - [γ(1 + β)]^{n-k}]*α²L_{n-k}(X)
             T0 = numerator - denominator;
             // key->quotient_large[i] += T0 * alpha_base; // CODY: Luke did this while documenting
-            key->quotient_polynomial_parts[i >> key->small_domain.log2_size][i & (key->n - 1)] += T0 * alpha_base;
+            key->quotient_polynomial_parts[i >> key->small_domain.log2_size][i & (key->circuit_size - 1)] +=
+                T0 * alpha_base;
         }
     }
     return alpha_base * alpha.sqr() * alpha;
@@ -627,7 +628,7 @@ barretenberg::fr ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>:
     fr beta = transcript.get_challenge_field_element("beta", 0);
     fr gamma = transcript.get_challenge_field_element("beta", 1);
     fr eta = transcript.get_challenge_field_element("eta", 0);
-    fr l_numerator = z.pow(key->n) - fr(1);
+    fr l_numerator = z.pow(key->circuit_size) - fr(1);
 
     // Compute evaluation L_1(z)
     l_numerator *= key->small_domain.domain_inverse;

--- a/cpp/src/aztec/plonk/proof_system/widgets/transition_widgets/transition_widget.hpp
+++ b/cpp/src/aztec/plonk/proof_system/widgets/transition_widgets/transition_widget.hpp
@@ -355,7 +355,8 @@ class TransitionWidget : public TransitionWidgetBase<Field> {
         Field sum_of_linear_terms = FFTKernel::sum_linear_terms(polynomials, challenges, linear_terms, i);
 
         // populate split quotient components
-        Field& quotient_term = key->quotient_polynomial_parts[i >> key->small_domain.log2_size][i & (key->n - 1)];
+        Field& quotient_term =
+            key->quotient_polynomial_parts[i >> key->small_domain.log2_size][i & (key->circuit_size - 1)];
         quotient_term += sum_of_linear_terms;
         FFTKernel::compute_non_linear_terms(polynomials, challenges, quotient_term, i);
         ITERATE_OVER_DOMAIN_END;

--- a/cpp/src/aztec/proof_system/proving_key/proving_key.hpp
+++ b/cpp/src/aztec/proof_system/proving_key/proving_key.hpp
@@ -15,7 +15,7 @@ namespace waffle {
 
 struct proving_key_data {
     uint32_t composer_type;
-    uint32_t n;
+    uint32_t circuit_size;
     uint32_t num_public_inputs;
     bool contains_recursive_proof;
     std::vector<uint32_t> recursive_proof_public_input_indices;
@@ -43,8 +43,8 @@ struct proving_key {
     void init();
 
     uint32_t composer_type;
-    size_t n;
-    size_t log_n;
+    size_t circuit_size;
+    size_t log_circuit_size;
     size_t num_public_inputs;
     bool contains_recursive_proof = false;
     std::vector<uint32_t> recursive_proof_public_input_indices;

--- a/cpp/src/aztec/proof_system/proving_key/proving_key.test.cpp
+++ b/cpp/src/aztec/proof_system/proving_key/proving_key.test.cpp
@@ -28,7 +28,8 @@ TEST(proving_key, proving_key_from_serialized_key)
     auto pk_buf = to_buffer(p_key);
     auto pk_data = from_buffer<waffle::proving_key_data>(pk_buf);
     auto crs = std::make_unique<waffle::FileReferenceStringFactory>("../srs_db/ignition");
-    auto proving_key = std::make_shared<waffle::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.n + 1));
+    auto proving_key =
+        std::make_shared<waffle::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.circuit_size + 1));
 
     // Loop over all pre-computed polys for the given composer type and ensure equality
     // between original proving key polynomial store and the polynomial store that was
@@ -47,7 +48,7 @@ TEST(proving_key, proving_key_from_serialized_key)
 
     // Check equality of other proving_key_data data
     EXPECT_EQ(p_key.composer_type, proving_key->composer_type);
-    EXPECT_EQ(p_key.n, proving_key->n);
+    EXPECT_EQ(p_key.circuit_size, proving_key->circuit_size);
     EXPECT_EQ(p_key.num_public_inputs, proving_key->num_public_inputs);
     EXPECT_EQ(p_key.contains_recursive_proof, proving_key->contains_recursive_proof);
 }
@@ -113,7 +114,7 @@ TEST(proving_key, proving_key_from_mmaped_key)
 
     // Check equality of other proving_key_data data
     EXPECT_EQ(p_key.composer_type, pk_data.composer_type);
-    EXPECT_EQ(p_key.n, pk_data.n);
+    EXPECT_EQ(p_key.circuit_size, pk_data.circuit_size);
     EXPECT_EQ(p_key.num_public_inputs, pk_data.num_public_inputs);
     EXPECT_EQ(p_key.contains_recursive_proof, pk_data.contains_recursive_proof);
 }

--- a/cpp/src/aztec/proof_system/proving_key/serialize.hpp
+++ b/cpp/src/aztec/proof_system/proving_key/serialize.hpp
@@ -13,7 +13,7 @@ template <typename B> inline void read(B& any, proving_key_data& key)
     using std::read;
 
     read(any, key.composer_type);
-    read(any, (uint32_t&)key.n);
+    read(any, (uint32_t&)key.circuit_size);
     read(any, (uint32_t&)key.num_public_inputs);
 
     uint32_t amount = 0;
@@ -39,7 +39,7 @@ template <typename B> inline void write(B& buf, proving_key const& key)
 {
     using serialize::write;
     write(buf, key.composer_type);
-    write(buf, (uint32_t)key.n);
+    write(buf, (uint32_t)key.circuit_size);
     write(buf, (uint32_t)key.num_public_inputs);
 
     // Write only the pre-computed polys from the store
@@ -65,7 +65,7 @@ template <typename B> inline void read_mmap(B& is, std::string const& path, prov
 
     size_t file_num = 0;
     read(is, key.composer_type);
-    read(is, key.n);
+    read(is, key.circuit_size);
     read(is, key.num_public_inputs);
 
     uint32_t size;
@@ -86,7 +86,7 @@ template <typename B> inline void write_mmap(B& os, std::string const& path, pro
 
     size_t file_num = 0;
     write(os, key.composer_type);
-    write(os, static_cast<uint32_t>(key.n));
+    write(os, static_cast<uint32_t>(key.circuit_size));
     write(os, static_cast<uint32_t>(key.num_public_inputs));
 
     // Write only the pre-computed polys from the store

--- a/cpp/src/aztec/proof_system/verification_key/verification_key.cpp
+++ b/cpp/src/aztec/proof_system/verification_key/verification_key.cpp
@@ -9,20 +9,20 @@ verification_key::verification_key(const size_t num_gates,
                                    std::shared_ptr<VerifierReferenceString> const& crs,
                                    uint32_t composer_type_)
     : composer_type(composer_type_)
-    , n(num_gates)
-    , log_n(numeric::get_msb(num_gates))
+    , circuit_size(num_gates)
+    , log_circuit_size(numeric::get_msb(num_gates))
     , num_public_inputs(num_inputs)
-    , domain(n)
+    , domain(circuit_size)
     , reference_string(crs)
     , polynomial_manifest(composer_type)
 {}
 
 verification_key::verification_key(verification_key_data&& data, std::shared_ptr<VerifierReferenceString> const& crs)
     : composer_type(data.composer_type)
-    , n(data.n)
-    , log_n(numeric::get_msb(data.n))
+    , circuit_size(data.circuit_size)
+    , log_circuit_size(numeric::get_msb(data.circuit_size))
     , num_public_inputs(data.num_public_inputs)
-    , domain(n)
+    , domain(circuit_size)
     , reference_string(crs)
     , commitments(std::move(data.commitments))
     , polynomial_manifest(data.composer_type)
@@ -32,8 +32,8 @@ verification_key::verification_key(verification_key_data&& data, std::shared_ptr
 
 verification_key::verification_key(const verification_key& other)
     : composer_type(other.composer_type)
-    , n(other.n)
-    , log_n(numeric::get_msb(other.n))
+    , circuit_size(other.circuit_size)
+    , log_circuit_size(numeric::get_msb(other.circuit_size))
     , num_public_inputs(other.num_public_inputs)
     , domain(other.domain)
     , reference_string(other.reference_string)
@@ -45,8 +45,8 @@ verification_key::verification_key(const verification_key& other)
 
 verification_key::verification_key(verification_key&& other)
     : composer_type(other.composer_type)
-    , n(other.n)
-    , log_n(numeric::get_msb(other.n))
+    , circuit_size(other.circuit_size)
+    , log_circuit_size(numeric::get_msb(other.circuit_size))
     , num_public_inputs(other.num_public_inputs)
     , domain(other.domain)
     , reference_string(other.reference_string)
@@ -59,8 +59,8 @@ verification_key::verification_key(verification_key&& other)
 verification_key& verification_key::operator=(verification_key&& other)
 {
     composer_type = other.composer_type;
-    n = other.n;
-    log_n = numeric::get_msb(other.n);
+    circuit_size = other.circuit_size;
+    log_circuit_size = numeric::get_msb(other.circuit_size);
     num_public_inputs = other.num_public_inputs;
     reference_string = std::move(other.reference_string);
     commitments = std::move(other.commitments);
@@ -74,7 +74,7 @@ verification_key& verification_key::operator=(verification_key&& other)
 sha256::hash verification_key::sha256_hash()
 {
     std::vector<uint256_t> vk_data;
-    vk_data.emplace_back(n);
+    vk_data.emplace_back(circuit_size);
     vk_data.emplace_back(num_public_inputs);
     for (auto& commitment_entry : commitments) {
         vk_data.emplace_back(commitment_entry.second.x);

--- a/cpp/src/aztec/proof_system/verification_key/verification_key.hpp
+++ b/cpp/src/aztec/proof_system/verification_key/verification_key.hpp
@@ -9,7 +9,7 @@ namespace waffle {
 
 struct verification_key_data {
     uint32_t composer_type;
-    uint32_t n;
+    uint32_t circuit_size;
     uint32_t num_public_inputs;
     std::map<std::string, barretenberg::g1::affine_element> commitments;
     bool contains_recursive_proof = false;
@@ -20,7 +20,7 @@ template <typename B> inline void read(B& buf, verification_key_data& key)
 {
     using serialize::read;
     read(buf, key.composer_type);
-    read(buf, key.n);
+    read(buf, key.circuit_size);
     read(buf, key.num_public_inputs);
     read(buf, key.commitments);
     read(buf, key.contains_recursive_proof);
@@ -31,7 +31,7 @@ template <typename B> inline void write(B& buf, verification_key_data const& key
 {
     using serialize::write;
     write(buf, key.composer_type);
-    write(buf, key.n);
+    write(buf, key.circuit_size);
     write(buf, key.num_public_inputs);
     write(buf, key.commitments);
     write(buf, key.contains_recursive_proof);
@@ -40,8 +40,8 @@ template <typename B> inline void write(B& buf, verification_key_data const& key
 
 inline bool operator==(verification_key_data const& lhs, verification_key_data const& rhs)
 {
-    return lhs.composer_type == rhs.composer_type && lhs.n == rhs.n && lhs.num_public_inputs == rhs.num_public_inputs &&
-           lhs.commitments == rhs.commitments;
+    return lhs.composer_type == rhs.composer_type && lhs.circuit_size == rhs.circuit_size &&
+           lhs.num_public_inputs == rhs.num_public_inputs && lhs.commitments == rhs.commitments;
 }
 
 struct verification_key {
@@ -59,8 +59,8 @@ struct verification_key {
     sha256::hash sha256_hash();
 
     uint32_t composer_type;
-    size_t n;
-    size_t log_n;
+    size_t circuit_size;
+    size_t log_circuit_size;
     size_t num_public_inputs;
 
     barretenberg::evaluation_domain domain;
@@ -84,7 +84,7 @@ template <typename B> inline void write(B& buf, verification_key const& key)
 {
     using serialize::write;
     write(buf, key.composer_type);
-    write(buf, static_cast<uint32_t>(key.n));
+    write(buf, static_cast<uint32_t>(key.circuit_size));
     write(buf, static_cast<uint32_t>(key.num_public_inputs));
     write(buf, key.commitments);
     write(buf, key.contains_recursive_proof);

--- a/cpp/src/aztec/proof_system/verification_key/verification_key.test.cpp
+++ b/cpp/src/aztec/proof_system/verification_key/verification_key.test.cpp
@@ -9,7 +9,7 @@ TEST(verification_key, buffer_serialization)
 {
     verification_key_data key;
     key.composer_type = static_cast<uint32_t>(ComposerType::STANDARD);
-    key.n = 1234;
+    key.circuit_size = 1234;
     key.num_public_inputs = 10;
     key.commitments["test1"] = g1::element::random_element();
     key.commitments["test2"] = g1::element::random_element();
@@ -26,7 +26,7 @@ TEST(verification_key, stream_serialization)
 {
     verification_key_data key;
     key.composer_type = static_cast<uint32_t>(ComposerType::STANDARD);
-    key.n = 1234;
+    key.circuit_size = 1234;
     key.num_public_inputs = 10;
     key.commitments["test1"] = g1::element::random_element();
     key.commitments["test2"] = g1::element::random_element();

--- a/cpp/src/aztec/rollup/proofs/account/account.cpp
+++ b/cpp/src/aztec/rollup/proofs/account/account.cpp
@@ -211,7 +211,7 @@ void init_verification_key(std::shared_ptr<waffle::ReferenceStringFactory> const
         throw_or_abort("Compute proving key first.");
     } else {
         // Patch the 'nothing' reference string fed to init_proving_key.
-        proving_key->reference_string = crs_factory->get_prover_crs(proving_key->n + 1);
+        proving_key->reference_string = crs_factory->get_prover_crs(proving_key->circuit_size + 1);
     }
 
     verification_key =

--- a/cpp/src/aztec/rollup/proofs/compute_circuit_data.hpp
+++ b/cpp/src/aztec/rollup/proofs/compute_circuit_data.hpp
@@ -104,9 +104,9 @@ circuit_data get_circuit_data(std::string const& name,
             auto pk_stream = std::ifstream(pk_path);
             waffle::proving_key_data pk_data;
             read_mmap(pk_stream, pk_dir, pk_data);
-            data.proving_key =
-                std::make_shared<waffle::proving_key>(std::move(pk_data), srs->get_prover_crs(pk_data.n + 1));
-            data.num_gates = pk_data.n;
+            data.proving_key = std::make_shared<waffle::proving_key>(std::move(pk_data),
+                                                                     srs->get_prover_crs(pk_data.circuit_size + 1));
+            data.num_gates = pk_data.circuit_size;
             info(name, ": Circuit size 2^n: ", data.num_gates);
             benchmark_collator.benchmark_info_deferred(GET_COMPOSER_NAME_STRING(ComposerType),
                                                        "Core",
@@ -120,22 +120,22 @@ circuit_data get_circuit_data(std::string const& name,
             if (!mock) {
                 data.num_gates = composer.get_num_gates();
                 data.proving_key = composer.compute_proving_key();
-                info(name, ": Circuit size 2^n: ", data.proving_key->n);
+                info(name, ": Circuit size 2^n: ", data.proving_key->circuit_size);
 
                 benchmark_collator.benchmark_info_deferred(GET_COMPOSER_NAME_STRING(ComposerType),
                                                            "Core",
                                                            name + name_suffix_for_benchmarks,
                                                            "Gates 2^n",
-                                                           data.proving_key->n);
+                                                           data.proving_key->circuit_size);
             } else {
                 data.num_gates = mock_proof_composer.get_num_gates();
                 data.proving_key = mock_proof_composer.compute_proving_key();
-                info(name, ": Mock circuit size 2^n: ", data.proving_key->n);
+                info(name, ": Mock circuit size 2^n: ", data.proving_key->circuit_size);
                 benchmark_collator.benchmark_info_deferred(GET_COMPOSER_NAME_STRING(ComposerType),
                                                            "Core",
                                                            name + name_suffix_for_benchmarks,
                                                            "Mock Gates 2^n",
-                                                           data.proving_key->n);
+                                                           data.proving_key->circuit_size);
             }
 
             info(name, ": Proving key computed in ", timer.toString(), "s");

--- a/cpp/src/aztec/rollup/proofs/join_split/join_split.cpp
+++ b/cpp/src/aztec/rollup/proofs/join_split/join_split.cpp
@@ -52,7 +52,7 @@ void init_verification_key(std::unique_ptr<waffle::ReferenceStringFactory>&& crs
         std::abort();
     }
     // Patch the 'nothing' reference string fed to init_proving_key.
-    proving_key->reference_string = crs_factory->get_prover_crs(proving_key->n + 1);
+    proving_key->reference_string = crs_factory->get_prover_crs(proving_key->circuit_size + 1);
 
     verification_key =
         plonk::stdlib::types::Composer::compute_verification_key_base(proving_key, crs_factory->get_verifier_crs());

--- a/cpp/src/aztec/rollup/proofs/standard_example/standard_example.cpp
+++ b/cpp/src/aztec/rollup/proofs/standard_example/standard_example.cpp
@@ -43,7 +43,7 @@ void init_verification_key(std::unique_ptr<waffle::ReferenceStringFactory>&& crs
         std::abort();
     }
     // Patch the 'nothing' reference string fed to init_proving_key.
-    proving_key->reference_string = crs_factory->get_prover_crs(proving_key->n);
+    proving_key->reference_string = crs_factory->get_prover_crs(proving_key->circuit_size);
     verification_key = Composer::compute_verification_key_base(proving_key, crs_factory->get_verifier_crs());
 }
 

--- a/cpp/src/aztec/srs/reference_string/file_reference_string.hpp
+++ b/cpp/src/aztec/srs/reference_string/file_reference_string.hpp
@@ -36,16 +36,16 @@ class VerifierFileReferenceString : public VerifierReferenceString {
 class FileReferenceString : public ProverReferenceString {
   public:
     FileReferenceString(const size_t num_points, std::string const& path, bool is_lagrange = false)
-        : n(num_points)
+        : num_points(num_points)
         , pippenger_(path, num_points, is_lagrange)
     {}
 
     g1::affine_element* get_monomials() override { return pippenger_.get_point_table(); }
 
-    size_t get_size() const override { return n; }
+    size_t get_size() const override { return num_points; }
 
   private:
-    size_t n;
+    size_t num_points;
     scalar_multiplication::Pippenger pippenger_;
 };
 

--- a/cpp/src/aztec/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/cpp/src/aztec/stdlib/hash/blake2s/blake2s.test.cpp
@@ -51,7 +51,7 @@ TEST(stdlib_blake2s, test_single_block_plookup)
     EXPECT_EQ(output.get_value(), expected);
 
     auto prover = composer.create_prover();
-    std::cout << "prover gates = " << prover.n << std::endl;
+    std::cout << "prover gates = " << prover.circuit_size << std::endl;
     printf("composer gates = %zu\n", composer.get_num_gates());
     auto verifier = composer.create_verifier();
 
@@ -99,7 +99,7 @@ TEST(stdlib_blake2s, test_double_block_plookup)
     EXPECT_EQ(output.get_value(), expected);
 
     auto prover = composer.create_prover();
-    std::cout << "prover gates = " << prover.n << std::endl;
+    std::cout << "prover gates = " << prover.circuit_size << std::endl;
     printf("composer gates = %zu\n", composer.get_num_gates());
     auto verifier = composer.create_verifier();
 

--- a/cpp/src/aztec/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/cpp/src/aztec/stdlib/hash/blake3s/blake3s.test.cpp
@@ -64,7 +64,7 @@ TEST(stdlib_blake3s, test_single_block_plookup)
     EXPECT_EQ(output.get_value(), expected);
 
     auto prover = composer.create_prover();
-    std::cout << "prover gates = " << prover.n << std::endl;
+    std::cout << "prover gates = " << prover.circuit_size << std::endl;
     printf("composer gates = %zu\n", composer.get_num_gates());
     auto verifier = composer.create_verifier();
 
@@ -112,7 +112,7 @@ TEST(stdlib_blake3s, test_double_block_plookup)
     EXPECT_EQ(output.get_value(), expected);
 
     auto prover = composer.create_prover();
-    std::cout << "prover gates = " << prover.n << std::endl;
+    std::cout << "prover gates = " << prover.circuit_size << std::endl;
     printf("composer gates = %zu\n", composer.get_num_gates());
     auto verifier = composer.create_verifier();
 

--- a/cpp/src/aztec/stdlib/hash/pedersen/pedersen.bench.cpp
+++ b/cpp/src/aztec/stdlib/hash/pedersen/pedersen.bench.cpp
@@ -97,7 +97,7 @@ void construct_pedersen_witnesses_bench(State& state) noexcept
         waffle::TurboComposer composer =
             waffle::TurboComposer(BARRETENBERG_SRS_PATH, static_cast<size_t>(state.range(0)));
         generate_test_pedersen_circuit(composer, static_cast<size_t>(state.range(0)));
-        std::cout << "composer gates = " << composer.n << std::endl;
+        std::cout << "composer gates = " << composer.num_gates << std::endl;
         composer.compute_witness();
     }
 }

--- a/cpp/src/aztec/stdlib/hash/sha256/sha256.test.cpp
+++ b/cpp/src/aztec/stdlib/hash/sha256/sha256.test.cpp
@@ -121,7 +121,7 @@ TEST(stdlib_sha256, test_duplicate_proving_key)
     EXPECT_EQ(proof_result_one, true);
     auto proving_key = prover.key;
     auto verification_key = verifier.key;
-    auto circuit_size = prover.n;
+    auto circuit_size = prover.circuit_size;
 
     // Test a second time with same keys and different input.
     waffle::StandardComposer second_composer = waffle::StandardComposer(proving_key, verification_key, circuit_size);

--- a/cpp/src/aztec/stdlib/primitives/bool/bool.test.cpp
+++ b/cpp/src/aztec/stdlib/primitives/bool/bool.test.cpp
@@ -65,7 +65,7 @@ TEST(stdlib_bool, test_basic_operations)
     //     EXPECT_EQ(prover.key->polynomial_cache.get("w_2_lagrange")[6], fr(1));
     //     EXPECT_EQ(prover.key->polynomial_cache.get("w_3_lagrange")[6], fr(1));
     // }
-    EXPECT_EQ(prover.n, 16UL);
+    EXPECT_EQ(prover.circuit_size, 16UL);
 }
 
 TEST(stdlib_bool, xor)

--- a/cpp/src/aztec/stdlib/primitives/field/field.test.cpp
+++ b/cpp/src/aztec/stdlib/primitives/field/field.test.cpp
@@ -198,7 +198,7 @@ template <typename Composer> class stdlib_field : public testing::Test {
             EXPECT_EQ(prover.key->polynomial_cache.get("w_3_lagrange")[18], fr(expected));
         }
 
-        EXPECT_EQ(prover.n, 32UL);
+        EXPECT_EQ(prover.circuit_size, 32UL);
         auto verifier = composer.create_verifier();
         waffle::plonk_proof proof = prover.construct_proof();
         bool result = verifier.verify_proof(proof);
@@ -255,7 +255,7 @@ template <typename Composer> class stdlib_field : public testing::Test {
             EXPECT_EQ(prover.key->polynomial_cache.get("w_3_lagrange")[17], fr(4181));
         }
 
-        EXPECT_EQ(prover.n, 32UL);
+        EXPECT_EQ(prover.circuit_size, 32UL);
         auto verifier = composer.create_verifier();
 
         waffle::plonk_proof proof = prover.construct_proof();
@@ -306,7 +306,7 @@ template <typename Composer> class stdlib_field : public testing::Test {
         fr x = composer.get_variable(r.witness_index);
         EXPECT_EQ(x, fr(1));
 
-        EXPECT_EQ(prover.n, 16UL);
+        EXPECT_EQ(prover.circuit_size, 16UL);
         auto verifier = composer.create_verifier();
 
         waffle::plonk_proof proof = prover.construct_proof();
@@ -330,7 +330,7 @@ template <typename Composer> class stdlib_field : public testing::Test {
         fr x = composer.get_variable(r.witness_index);
         EXPECT_EQ(x, fr(0));
 
-        EXPECT_EQ(prover.n, 16UL);
+        EXPECT_EQ(prover.circuit_size, 16UL);
         auto verifier = composer.create_verifier();
 
         waffle::plonk_proof proof = prover.construct_proof();
@@ -355,7 +355,7 @@ template <typename Composer> class stdlib_field : public testing::Test {
         fr x = composer.get_variable(r.witness_index);
         EXPECT_EQ(x, fr(1));
 
-        EXPECT_EQ(prover.n, 16UL);
+        EXPECT_EQ(prover.circuit_size, 16UL);
         auto verifier = composer.create_verifier();
 
         waffle::plonk_proof proof = prover.construct_proof();
@@ -831,7 +831,7 @@ template <typename Composer> class stdlib_field : public testing::Test {
     {
         Composer composer = Composer();
 
-        const size_t num_gates_start = composer.n;
+        const size_t num_gates_start = composer.num_gates;
 
         barretenberg::fr base_val(engine.get_random_uint256());
         uint32_t exponent_val = engine.get_random_uint32();
@@ -843,7 +843,7 @@ template <typename Composer> class stdlib_field : public testing::Test {
 
         EXPECT_EQ(result.get_value(), expected);
 
-        const size_t num_gates_end = composer.n;
+        const size_t num_gates_end = composer.num_gates;
         EXPECT_EQ(num_gates_start, num_gates_end);
     }
 

--- a/cpp/src/aztec/stdlib/primitives/memory/rom_table.test.cpp
+++ b/cpp/src/aztec/stdlib/primitives/memory/rom_table.test.cpp
@@ -39,9 +39,9 @@ TEST(rom_table, rom_table_read_write_consistency)
         field_ct index(witness_ct(&composer, (uint64_t)i));
 
         if (i % 2 == 0) {
-            const auto before_n = composer.n;
+            const auto before_n = composer.num_gates;
             const auto to_add = table[index];
-            const auto after_n = composer.n;
+            const auto after_n = composer.num_gates;
             // should cost 1 gates (the ROM read adds 1 extra gate when the proving key is constructed)
             // (but not for 1st entry, the 1st ROM read also builts the ROM table, which will cost table_size * 2 gates)
             if (i != 0) {
@@ -49,9 +49,9 @@ TEST(rom_table, rom_table_read_write_consistency)
             }
             result += to_add; // variable lookup
         } else {
-            const auto before_n = composer.n;
+            const auto before_n = composer.num_gates;
             const auto to_add = table[i]; // constant lookup
-            const auto after_n = composer.n;
+            const auto after_n = composer.num_gates;
             // should cost 0 gates. Constant lookups are free
             EXPECT_EQ(after_n - before_n, 0ULL);
             result += to_add;

--- a/cpp/src/aztec/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/aztec/stdlib/recursion/verification_key/verification_key.hpp
@@ -119,7 +119,7 @@ template <typename Curve> struct verification_key {
         key->polynomial_manifest = input_key->polynomial_manifest;
 
         // Circuit types:
-        key->n = witness_t<Composer>(ctx, barretenberg::fr(input_key->n));
+        key->n = witness_t<Composer>(ctx, barretenberg::fr(input_key->circuit_size));
         key->num_public_inputs = witness_t<Composer>(ctx, input_key->num_public_inputs);
         key->domain = evaluation_domain<Composer>::from_witness(ctx, input_key->domain);
 
@@ -136,7 +136,7 @@ template <typename Curve> struct verification_key {
         std::shared_ptr<verification_key> key = std::make_shared<verification_key>();
         key->context = ctx;
         key->base_key = input_key;
-        key->n = field_t<Composer>(ctx, input_key->n);
+        key->n = field_t<Composer>(ctx, input_key->circuit_size);
         key->num_public_inputs = field_t<Composer>(ctx, input_key->num_public_inputs);
 
         key->domain = evaluation_domain<Composer>::from_constants(ctx, input_key->domain);


### PR DESCRIPTION
# Description

The composers, provers, verifiers, proving key and verification key all have an entity called `n`. It is bad practice to use single-letter names, and is regularly a nuisance that this one in particular is difficult to search. I rename it in the circuit constructor / composer context to `num_gates`, and in the other contexts as `circuit_size`. I'm happy to hear objections to using two names instead of one.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
