### PR TITLE
Make Sumcheck Relations uniform + Efficient Pow

### DIFF
--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -338,6 +338,7 @@ TEST(standard_honk_composer, test_check_sumcheck_relations_correctness)
     // Generate beta and gamma
     fr beta = fr::random_element();
     fr gamma = fr::random_element();
+    fr zeta = fr::random_element();
 
     // Compute grand product polynomial (now all the necessary polynomials are inside the proving key)
     prover.compute_grand_product_polynomial(beta, gamma);
@@ -346,6 +347,15 @@ TEST(standard_honk_composer, test_check_sumcheck_relations_correctness)
     const auto public_inputs = composer.circuit_constructor.get_public_inputs();
     auto public_input_delta = compute_public_input_delta<fr>(public_inputs, beta, gamma, prover.key->circuit_size);
 
+    sumcheck::RelationParameters<fr> params{
+        .zeta = zeta,
+        .alpha = fr::one(),
+        .beta = beta,
+        .gamma = gamma,
+        .public_input_delta = public_input_delta,
+    };
+
+    constexpr size_t num_polynomials = bonk::StandardArithmetization::NUM_POLYNOMIALS;
     // Retrieve polynomials from proving key
     polynomial z_perm = prover.key->polynomial_cache.get("z_perm_lagrange");
     polynomial w_1 = prover.key->polynomial_cache.get("w_1_lagrange");

--- a/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/aztec/honk/composer/standard_honk_composer.test.cpp
@@ -12,8 +12,6 @@
 #include <cstdint>
 #include <gtest/gtest.h>
 
-#pragma GCC diagnostic ignored "-Wunused-variable"
-
 using namespace honk;
 
 namespace test_standard_honk_composer {
@@ -338,7 +336,6 @@ TEST(standard_honk_composer, test_check_sumcheck_relations_correctness)
     // Generate beta and gamma
     fr beta = fr::random_element();
     fr gamma = fr::random_element();
-    fr zeta = fr::random_element();
 
     // Compute grand product polynomial (now all the necessary polynomials are inside the proving key)
     prover.compute_grand_product_polynomial(beta, gamma);
@@ -346,14 +343,6 @@ TEST(standard_honk_composer, test_check_sumcheck_relations_correctness)
     // Compute public input delta
     const auto public_inputs = composer.circuit_constructor.get_public_inputs();
     auto public_input_delta = compute_public_input_delta<fr>(public_inputs, beta, gamma, prover.key->circuit_size);
-
-    sumcheck::RelationParameters<fr> params{
-        .zeta = zeta,
-        .alpha = fr::one(),
-        .beta = beta,
-        .gamma = gamma,
-        .public_input_delta = public_input_delta,
-    };
 
     constexpr size_t num_polynomials = bonk::StandardArithmetization::NUM_POLYNOMIALS;
     // Retrieve polynomials from proving key

--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -300,15 +300,6 @@ template <typename settings> void Prover<settings>::execute_relation_check_round
                                         sumcheck::GrandProductInitializationRelation>;
 
     // Compute alpha challenge
-    transcript.apply_fiat_shamir("zeta");
-
-    // TODO(Cody): This is just temporary of course. Very inefficient, e.g., no commitment needed.
-    Fr zeta_challenge = transcript.get_challenge_field_element("zeta");
-    barretenberg::polynomial pow_zeta = power_polynomial::generate_vector(zeta_challenge, key->circuit_size);
-    auto commitment = commitment_key->commit(pow_zeta);
-    transcript.add_element("POW_ZETA", commitment.to_buffer());
-    key->polynomial_cache.put("pow_zeta", std::move(pow_zeta));
-
     transcript.apply_fiat_shamir("alpha");
 
     auto multivariates = Multivariates(key);

--- a/cpp/src/aztec/honk/proof_system/verifier.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.cpp
@@ -119,7 +119,6 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
     transcript.apply_fiat_shamir("init");
     transcript.apply_fiat_shamir("eta");
     transcript.apply_fiat_shamir("beta");
-    transcript.apply_fiat_shamir("zeta");
     transcript.apply_fiat_shamir("alpha");
     for (size_t idx = 0; idx < log_n; idx++) {
         transcript.apply_fiat_shamir("u_" + std::to_string(log_n - idx));

--- a/cpp/src/aztec/honk/sumcheck/polynomials/pow.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/pow.hpp
@@ -34,8 +34,8 @@ namespace honk::sumcheck {
  *                  = ∏_{0≤k<l} ( (1-iₖ) + iₖ⋅ζₖ )
  *                             ⋅( (1−Xₗ) + Xₗ⋅ζₗ )
  *                    ∏_{l<k<d} ( (1-uₖ) + uₖ⋅ζₖ )
- *                  = ζ^{2^{d-l-1}}^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ
- *                  = ζ_{   l-1   }^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ,
+ *                  = ζ^{2^{d-l}}^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ
+ *                  = ζ_{  l-1  }^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ,
  *
  *   This is the pow polynomial, partially evaluated in
  *     (X_{l+1}, ..., X_{d-1}) = (u_{l+1}, ..., u_{d-1}),
@@ -77,11 +77,12 @@ namespace honk::sumcheck {
  * - ζ_{l-1} <-- ζ_{l}^2                                // Get next power of ζ
  *
  * Final round l=0:
- * - σ_{1} =?= S'⁰(0) + S'⁰(1) = T⁰(0) + ζ_{0}⋅T⁰(1)                            // Check partial sum
- * - σ_{0} <-- ( (1−u_{0}) + u_{0}⋅ζ_{0} )⋅T⁰(u_{0})                            // Compute purported evaluation of P'(u)
- * - c_{0} <-- ∏_{0≤l<d} ( (1-u_{l}) + u_{l}⋅ζ_{l} ) = pow(u_{0}, ..., u_{d-1}) // Full evaluation of pow
- * - σ_{0} =?= c_{0}⋅P(u_{0}, ..., u_{d-1})                                     // Compare against real evaluation of
- * P'(u)
+ * - σ_{1} =?= S'⁰(0) + S'⁰(1) = T⁰(0) + ζ_{0}⋅T⁰(1)    // Check partial sum
+ * - σ_{0} <-- ( (1−u_{0}) + u_{0}⋅ζ_{0} )⋅T⁰(u_{0})    // Compute purported evaluation of P'(u)
+ * - c_{0} <-- ∏_{0≤l<d} ( (1-u_{l}) + u_{l}⋅ζ_{l} )
+ *           = pow(u_{0}, ..., u_{d-1})                 // Full evaluation of pow
+ * - σ_{0} =?= c_{0}⋅P(u_{0}, ..., u_{d-1})             // Compare against real evaluation of P'(u)
+ * @todo(Adrian): Eventually re-index polynomials with LSB first, and also rework the unicode symbols
  */
 template <typename FF> struct PowUnivariate {
     // ζ_{l}, initialized as ζ_{d-1} = ζ

--- a/cpp/src/aztec/honk/sumcheck/polynomials/pow.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/pow.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+namespace honk::sumcheck {
+
+/**
+ * @brief Succinct representation of the `pow` polynomial that can be partially evaluated variable-by-variable.
+ * pow(X) = ∏_{0≤l<d} ((1−Xₗ) + Xₗ⋅ζₗ)
+ *
+ * @details Let
+ * - d be the number of variables
+ * - l be the current Sumcheck round ( l ∈ {d-1, …, 0} )
+ * - u_{d-1}, ..., u_{l+1} the challenges sent by the verifier in rounds d-1 to l+1.
+ *
+ * We define
+ *
+ * - ζ_{0}, ..., ζ_{d-1}, as ζ_{l} = ζ^{ 2^{d-l-1} }.
+ *   When 0 ≤ i < 2^d is represented in bits [i_{0}, ..., i_{d-1}] where i_{0} is the MSB, we have
+ *   ζ^{i} = ζ^{ ∑_{0≤l<d} i_{l}⋅2^{d-l-1} }
+ *         =     ∏_{0≤l<d} ζ^{ i_{l}⋅2^{d-l-1} }
+ *         =     ∏_{0≤l<d} ζ_{l}^{ i_{l} }
+ *         =     ∏_{0≤l<d} ( (1-i_{l}) + i_{l}⋅ζ_{l} )
+ *   Note that
+ *   - ζ_{d-1} = ζ,
+ *   - ζ_{l-1} = ζ_{l}^2,
+ *   - ζ_{0}   = ζ^{ 2^{d-1} }
+ *
+ * - pow(X) = ∏_{0≤l<d} ((1−Xₗ) + Xₗ⋅ζₗ) is the multi-linear polynomial whose evaluation at the i-th index
+ *   of the full hypercube, equals ζⁱ.
+ *   We can also see it as the multi-linear extension of the vector (1, ζ, ζ², ...).
+ *
+ * - powˡᵢ( X_{l} ) = pow( i_{0}, ..., i_{l-1},
+ *                         X_{l},
+ *                         u_{l+1}, ..., u_{d-1} )
+ *                  = ∏_{0≤k<l} ( (1-iₖ) + iₖ⋅ζₖ )
+ *                             ⋅( (1−Xₗ) + Xₗ⋅ζₗ )
+ *                    ∏_{l<k<d} ( (1-uₖ) + uₖ⋅ζₖ )
+ *                  = ζ^{2^{d-l-1}}^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ
+ *                  = ζ_{   l-1   }^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ,
+ *
+ *   This is the pow polynomial, partially evaluated in
+ *     (X_{l+1}, ..., X_{d-1}) = (u_{l+1}, ..., u_{d-1}),
+ *   at the index 0 ≤ i < 2ˡ of the dimension-l hypercube.
+ *
+ * - Sˡᵢ( Xₗ ) is the univariate of the full relation at edge pair i
+ * i.e. it is the alpha-linear-combination of the relations evaluated in the i-th edge.
+ * If our composed Sumcheck relation is a multi-variate polynomial P(X_{0}, ..., X_{d-1}),
+ * Then Sˡᵢ( Xₗ ) = P( i_{0}, ..., i_{l-1}, X_{l}, u_{l+1}, ..., u_{d-1} ).
+ * The l-th univariate would then be Sˡ( Xₗ ) = ∑_{0≤i<2ˡ} Sˡᵢ( Xₗ ) .
+ *
+ * We want to check that P(i)=0 for all i ∈ {0,1}ᵈ. So we use Sumcheck over the polynomial
+ * P'(X) = pow(X)⋅P(X).
+ * The claimed sum is 0 and is equal to ∑_{i ∈ {0,1}ᵈ} pow(i)⋅P(i) = ∑_{i ∈ {0,1}ᵈ} ζ^{i}⋅P(i)
+ * If the Sumcheck passes, then with it must hold with high-probability that all P(i) are 0.
+ *
+ * The trivial implementation using P'(X) directly would increase the degree of our combined relation by 1.
+ * Instead, we exploit the special structure of pow to preserve the same degree.
+ *
+ * In each round l, the prover should compute the univariate polynomial for the relation defined by P'(X)
+ * S'ˡ(Xₗ) = ∑_{0≤i<2ˡ} powˡᵢ( Xₗ ) Sˡᵢ( Xₗ ) .
+ *        = ∑_{0≤i<2ˡ} [ ζₗ₋₁ⁱ⋅( (1−Xₗ) + Xₗ⋅ζₗ )⋅cₗ ]⋅Sˡᵢ( Xₗ )
+ *        = ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ ∑_{0≤i<2ˡ} [ cₗ ⋅ ζₗ₋₁ⁱ ⋅ Sˡᵢ( Xₗ ) ]
+ *
+ * If we define Tˡ( Xₗ ) := ∑_{0≤i<2ˡ} [ cₗ ⋅ ζₗ₋₁ⁱ ⋅ Sˡᵢ( Xₗ ) ], then Tˡ has the same degree as the original Sˡ( Xₗ )
+ * for the relation P(X) and is only slightly more expensive to compute than Sˡ( Xₗ ).
+ * Moreover, given Tˡ( Xₗ ), the verifier can evaluate S'ˡ( uₗ ) by evaluating ( (1−uₗ) + uₗ⋅ζₗ )Tˡ( uₗ ).
+ * When the verifier checks the claimed sum, the procedure is modified as follows
+ *
+ * Init:
+ * - σ_{ d } <-- 0 // Claimed Sumcheck sum
+ * - c_{d-1} <-- 1 // Partial evaluation constant, before any evaluation
+ * - ζ_{d-1} <-- ζ // Initial power of ζ
+ *
+ * Round l:
+ * - σ_{l+1} =?= S'ˡ(0) + S'ˡ(1) = Tˡ(0) + ζ_{l}⋅Tˡ(1)  // Check partial sum
+ * - σ_{ l } <-- ( (1−u_{l}) + u_{l}⋅ζ_{l} )⋅Tʲ(u_{l})  // Compute next partial sum
+ * - c_{ l } <-- ( (1−u_{l}) + u_{l}⋅ζ_{l} )⋅c_{l-1}    // Partially evaluate pow in u_{l}
+ * - ζ_{l-1} <-- ζ_{l}^2                                // Get next power of ζ
+ *
+ * Final round l=0:
+ * - σ_{1} =?= S'⁰(0) + S'⁰(1) = T⁰(0) + ζ_{0}⋅T⁰(1)                            // Check partial sum
+ * - σ_{0} <-- ( (1−u_{0}) + u_{0}⋅ζ_{0} )⋅T⁰(u_{0})                            // Compute purported evaluation of P'(u)
+ * - c_{0} <-- ∏_{0≤l<d} ( (1-u_{l}) + u_{l}⋅ζ_{l} ) = pow(u_{0}, ..., u_{d-1}) // Full evaluation of pow
+ * - σ_{0} =?= c_{0}⋅P(u_{0}, ..., u_{d-1})                                     // Compare against real evaluation of
+ * P'(u)
+ */
+template <typename FF> struct PowUnivariate {
+    // ζ_{l}, initialized as ζ_{d-1} = ζ
+    // At round l, equals ζ^{ 2^{d-l-1} }
+    FF zeta_pow;
+    // ζ_{l-1}, initialized as ζ_{d-2} = ζ^2
+    // Always equal to zeta_pow^2
+    // At round l, equals ζ^{ 2^{d-l} }
+    FF zeta_pow_sqr;
+    // c_{l}, initialized as c_{d-1} = 1
+    // c_{l} = ∏_{l<k<d} ( (1-u_{k}) + u_{k}⋅ζ_{k} )
+    // At round 0, equals pow(u_{0}, ..., u_{d-1}).
+    FF partial_evaluation_constant = FF::one();
+
+    // Initialize with the random zeta
+    PowUnivariate(FF zeta_pow)
+        : zeta_pow(zeta_pow)
+        , zeta_pow_sqr(zeta_pow.sqr())
+    {}
+
+    // Evaluate the monomial ((1−X_{l}) + X_{l}⋅ζ_{l}) in the challenge point X_{l}=u_{l}.
+    FF univariate_eval(FF challenge) const { return (FF::one() + (challenge * (zeta_pow - FF::one()))); };
+
+    /**
+     * @brief Parially evaluate the polynomial in the new challenge, by updating the constant c_{l} -> c_{l-1}.
+     * Also update (ζ_{l}, ζ_{l-1}) -> (ζ_{l-1}, ζ_{l-1}^2)
+     *
+     * @param challenge l-th verifier challenge u_{l}
+     */
+    void partially_evaluate(FF challenge)
+    {
+        FF current_univariate_eval = univariate_eval(challenge);
+        zeta_pow = zeta_pow_sqr;
+        zeta_pow_sqr.self_sqr();
+        partial_evaluation_constant *= current_univariate_eval;
+    }
+};
+} // namespace honk::sumcheck

--- a/cpp/src/aztec/honk/sumcheck/polynomials/pow.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/pow.test.cpp
@@ -1,0 +1,26 @@
+#include "pow.hpp"
+#include "honk/utils/power_polynomial.hpp"
+#include <ecc/curves/bn254/fr.hpp>
+#include <gtest/gtest.h>
+
+namespace honk::sumcheck::pow_test {
+
+using FF = barretenberg::fr;
+
+TEST(SumcheckPow, FullPowConsistency)
+{
+    constexpr size_t d = 5;
+
+    FF zeta = FF::random_element();
+    PowUnivariate<FF> pow_univariate(zeta);
+
+    std::array<FF, d> variables{};
+    for (auto& u_i : variables) {
+        u_i = FF::random_element();
+        pow_univariate.partially_evaluate(u_i);
+    }
+
+    FF expected_eval = honk::power_polynomial::evaluate<FF>(zeta, variables);
+    EXPECT_EQ(pow_univariate.partial_evaluation_constant, expected_eval);
+}
+} // namespace honk::sumcheck::pow_test

--- a/cpp/src/aztec/honk/sumcheck/relations/grand_product_initialization_relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/grand_product_initialization_relation.hpp
@@ -8,7 +8,7 @@ namespace honk::sumcheck {
 template <typename FF> class GrandProductInitializationRelation : public Relation<FF> {
   public:
     // 1 + polynomial degree of this relation
-    static constexpr size_t RELATION_LENGTH = 4;
+    static constexpr size_t RELATION_LENGTH = 3;
     using MULTIVARIATE = StandardHonk::MULTIVARIATE; // could just get from StandardArithmetization
 
     GrandProductInitializationRelation() = default;
@@ -27,9 +27,13 @@ template <typename FF> class GrandProductInitializationRelation : public Relatio
      * we don't need challenges in this relation.
      *
      */
-    template <typename T> void add_edge_contribution(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals, T)
+    template <typename T>
+    void add_edge_contribution(auto& extended_edges,
+                               Univariate<FF, RELATION_LENGTH>& evals,
+                               T,
+                               const FF& scaling_factor)
     {
-        add_edge_contribution_internal(extended_edges, evals);
+        add_edge_contribution_internal(extended_edges, evals, scaling_factor);
     };
 
     /**
@@ -38,13 +42,14 @@ template <typename FF> class GrandProductInitializationRelation : public Relatio
      * @param extended_edges
      * @param evals
      */
-    void add_edge_contribution_internal(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals)
+    void add_edge_contribution_internal(auto& extended_edges,
+                                        Univariate<FF, RELATION_LENGTH>& evals,
+                                        const FF& scaling_factor)
     {
         auto z_perm_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::Z_PERM_SHIFT]);
         auto lagrange_last = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::LAGRANGE_LAST]);
-        auto pow_zeta = UnivariateView<FF, RELATION_LENGTH>(extended_edges[MULTIVARIATE::POW_ZETA]);
 
-        evals += pow_zeta * (lagrange_last * z_perm_shift);
+        evals += (lagrange_last * z_perm_shift) * scaling_factor;
     }
     /**
      * @brief A version of `add_edge_contribution` used for testing the relation
@@ -58,7 +63,7 @@ template <typename FF> class GrandProductInitializationRelation : public Relatio
     template <typename T>
     void add_edge_contribution_testing(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals, T)
     {
-        add_edge_contribution_internal(extended_edges, evals);
+        add_edge_contribution_internal(extended_edges, evals, FF::one());
     }
 
     template <typename T>
@@ -66,9 +71,8 @@ template <typename FF> class GrandProductInitializationRelation : public Relatio
     {
         auto z_perm_shift = purported_evaluations[MULTIVARIATE::Z_PERM_SHIFT];
         auto lagrange_last = purported_evaluations[MULTIVARIATE::LAGRANGE_LAST];
-        auto pow_zeta = purported_evaluations[MULTIVARIATE::POW_ZETA];
 
-        full_honk_relation_value += pow_zeta * (lagrange_last * z_perm_shift);
+        full_honk_relation_value += lagrange_last * z_perm_shift;
     };
 };
 } // namespace honk::sumcheck

--- a/cpp/src/aztec/honk/sumcheck/relations/relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/relation.hpp
@@ -4,6 +4,7 @@ namespace honk::sumcheck {
 
 template <typename Fr> class Relation {}; // TODO(Cody): Use or eventually remove.
 
+// TODO(Adrian): Remove zeta, alpha as they are not used by the relations.
 template <typename FF> struct RelationParameters {
     FF zeta;
     FF alpha;

--- a/cpp/src/aztec/honk/sumcheck/relations/relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/relation.hpp
@@ -5,6 +5,7 @@ namespace honk::sumcheck {
 template <typename Fr> class Relation {}; // TODO(Cody): Use or eventually remove.
 
 template <typename FF> struct RelationParameters {
+    FF zeta;
     FF alpha;
     FF beta;
     FF gamma;

--- a/cpp/src/aztec/honk/sumcheck/relations/relation.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/relation.test.cpp
@@ -22,36 +22,35 @@ template <class FF> class SumcheckRelation : public testing::Test {
     template <size_t t> using UnivariateView = UnivariateView<FF, t>;
 
     // TODO(luke): may want to make this more flexible/genericzs
-    static std::array<Univariate<6>, bonk::StandardArithmetization::NUM_POLYNOMIALS> compute_mock_extended_edges()
+    static std::array<Univariate<5>, bonk::StandardArithmetization::NUM_POLYNOMIALS> compute_mock_extended_edges()
     {
         // TODO(Cody): build from Univariate<2>'s?
         // evaluation form, i.e. w_l(0) = 1, w_l(1) = 2,.. The poly is x+1.
-        auto w_l = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto w_r = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto w_o = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto z_perm = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
+        auto w_l = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto w_r = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto w_o = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto z_perm = Univariate<5>({ 1, 2, 3, 4, 5 });
         // Note: z_perm and z_perm_shift can be any linear poly for the sake of the tests but should not be be equal to
         // each other In order to avoid a trivial computation in the case of the grand_product_computation_relation.
         // Values here were chosen so that output univariates in tests are small positive numbers.
-        auto z_perm_shift = Univariate<6>({ 0, 1, 2, 3, 4, 5 }); // this is not real shifted data
-        auto q_m = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto q_l = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto q_r = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto q_o = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto q_c = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto sigma_1 = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto sigma_2 = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto sigma_3 = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto id_1 = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto id_2 = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto id_3 = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto lagrange_first = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto lagrange_last = Univariate<6>({ 1, 2, 3, 4, 5, 6 });
-        auto pow_zeta = Univariate<6>({ 1, 1, 1, 1, 1, 1 });
+        auto z_perm_shift = Univariate<5>({ 0, 1, 2, 3, 4 }); // this is not real shifted data
+        auto q_m = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto q_l = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto q_r = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto q_o = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto q_c = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto sigma_1 = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto sigma_2 = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto sigma_3 = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto id_1 = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto id_2 = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto id_3 = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto lagrange_first = Univariate<5>({ 1, 2, 3, 4, 5 });
+        auto lagrange_last = Univariate<5>({ 1, 2, 3, 4, 5 });
 
-        std::array<Univariate<6>, bonk::StandardArithmetization::NUM_POLYNOMIALS> extended_edges = {
-            w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,           q_l,     q_r, q_o, q_c, sigma_1, sigma_2,
-            sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last, pow_zeta
+        std::array<Univariate<5>, bonk::StandardArithmetization::NUM_POLYNOMIALS> extended_edges = {
+            w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,          q_l, q_r, q_o, q_c, sigma_1, sigma_2,
+            sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last
         };
         return extended_edges;
     }
@@ -80,12 +79,11 @@ TYPED_TEST(SumcheckRelation, ArithmeticRelation)
     auto q_r = UnivariateView<FF, relation.RELATION_LENGTH>(extended_edges[MULTIVARIATE::Q_R]);
     auto q_o = UnivariateView<FF, relation.RELATION_LENGTH>(extended_edges[MULTIVARIATE::Q_O]);
     auto q_c = UnivariateView<FF, relation.RELATION_LENGTH>(extended_edges[MULTIVARIATE::Q_C]);
-    auto pow_zeta = UnivariateView<FF, relation.RELATION_LENGTH>(extended_edges[MULTIVARIATE::POW_ZETA]);
     // expected_evals, length 4, extends to { { 5, 22, 57, 116, 205} };
-    Univariate expected_evals = pow_zeta * ((q_m * w_r * w_l) + (q_r * w_r) + (q_l * w_l) + (q_o * w_o) + (q_c));
+    Univariate expected_evals = (q_m * w_r * w_l) + (q_r * w_r) + (q_l * w_l) + (q_o * w_o) + q_c;
 
     auto evals = Univariate<FF, relation.RELATION_LENGTH>();
-    relation.add_edge_contribution(extended_edges, evals, 0);
+    relation.add_edge_contribution(extended_edges, evals, 0, FF::one());
 
     EXPECT_EQ(evals, expected_evals);
 };
@@ -121,26 +119,26 @@ TYPED_TEST(SumcheckRelation, GrandProductComputationRelation)
     auto z_perm_shift = UnivariateView(extended_edges[MULTIVARIATE::Z_PERM_SHIFT]);
     auto lagrange_first = UnivariateView(extended_edges[MULTIVARIATE::LAGRANGE_FIRST]);
     auto lagrange_last = UnivariateView(extended_edges[MULTIVARIATE::LAGRANGE_LAST]);
-    auto pow_zeta = UnivariateView(extended_edges[MULTIVARIATE::POW_ZETA]);
 
     // TODO(luke): use real transcript/challenges once manifest is done
+    FF zeta = FF::random_element();
     FF beta = FF::random_element();
     FF gamma = FF::random_element();
     FF public_input_delta = FF::random_element();
     const RelationParameters<FF> relation_parameters = RelationParameters<FF>{
-        .alpha = FF ::zero(), .beta = beta, .gamma = gamma, .public_input_delta = public_input_delta
+        .zeta = zeta, .alpha = FF ::zero(), .beta = beta, .gamma = gamma, .public_input_delta = public_input_delta
     };
 
     auto expected_evals = Univariate();
     // expected_evals in the below step { { 27, 250, 1029, 2916, 6655 } }
-    expected_evals += pow_zeta * ((z_perm + lagrange_first) * (w_1 + id_1 * beta + gamma) *
-                                  (w_2 + id_2 * beta + gamma) * (w_3 + id_3 * beta + gamma));
+    expected_evals += (z_perm + lagrange_first) * (w_1 + id_1 * beta + gamma) * (w_2 + id_2 * beta + gamma) *
+                      (w_3 + id_3 * beta + gamma);
     // expected_evals below is { { 27, 125, 343, 729, 1331 } }
-    expected_evals -= pow_zeta * ((z_perm_shift + lagrange_last * public_input_delta) * (w_1 + sigma_1 * beta + gamma) *
-                                  (w_2 + sigma_2 * beta + gamma) * (w_3 + sigma_3 * beta + gamma));
+    expected_evals -= (z_perm_shift + lagrange_last * public_input_delta) * (w_1 + sigma_1 * beta + gamma) *
+                      (w_2 + sigma_2 * beta + gamma) * (w_3 + sigma_3 * beta + gamma);
 
     auto evals = Univariate();
-    relation.add_edge_contribution(extended_edges, evals, relation_parameters);
+    relation.add_edge_contribution(extended_edges, evals, relation_parameters, FF::one());
 
     EXPECT_EQ(evals, expected_evals);
 };
@@ -159,12 +157,11 @@ TYPED_TEST(SumcheckRelation, GrandProductInitializationRelation)
 
     auto z_perm_shift = UnivariateView(extended_edges[MULTIVARIATE::Z_PERM_SHIFT]);
     auto lagrange_last = UnivariateView(extended_edges[MULTIVARIATE::LAGRANGE_LAST]);
-    auto pow_zeta = UnivariateView(extended_edges[MULTIVARIATE::POW_ZETA]);
-    auto expected_evals = pow_zeta * (z_perm_shift * lagrange_last);
+    auto expected_evals = z_perm_shift * lagrange_last;
 
     // Compute the edge contribution using add_edge_contribution
     auto evals = Univariate();
-    relation.add_edge_contribution(extended_edges, evals, 0);
+    relation.add_edge_contribution(extended_edges, evals, 0, FF::one());
 
     EXPECT_EQ(evals, expected_evals);
 };

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
@@ -44,7 +44,7 @@ Transcript produce_mocked_transcript(size_t multivariate_d, size_t num_public_in
 
     manifest_rounds.emplace_back(transcript::Manifest::RoundManifest({ /* this is a noop */ },
                                                                      /* challenge_name = */ "alpha",
-                                                                     /* num_challenges_in = */ 1));
+                                                                     /* num_challenges_in = */ 2));
     manifest_rounds.emplace_back(transcript::Manifest::RoundManifest(
         { { .name = "public_inputs", .num_bytes = public_input_size, .derived_by_verifier = false } },
         /* challenge_name = */ "beta",
@@ -117,13 +117,12 @@ TEST(Sumcheck, PolynomialNormalization)
     std::array<FF, multivariate_n> id_3 =           { 0, 0, 0, 0, 0, 0, 0, 0 };
     std::array<FF, multivariate_n> lagrange_first = { 0, 0, 0, 0, 0, 0, 0, 0 };
     std::array<FF, multivariate_n> lagrange_last =  { 0, 0, 0, 0, 0, 0, 0, 0 };
-    std::array<FF, multivariate_n> pow_zeta =       { 0, 0, 0, 0, 0, 0, 0, 0 };
     // clang-format on
 
     // These will be owned outside the class, probably by the composer.
     std::array<std::span<FF>, Multivariates::num> full_polynomials = {
-        w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,           q_l,     q_r, q_o, q_c, sigma_1, sigma_2,
-        sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last, pow_zeta
+        w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,          q_l, q_r, q_o, q_c, sigma_1, sigma_2,
+        sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last
     };
 
     auto transcript = produce_mocked_transcript(multivariate_d, num_public_inputs);
@@ -200,13 +199,12 @@ TEST(Sumcheck, Prover)
     std::array<FF, multivariate_n> id_3 =           { 1, 2, 0, 0};
     std::array<FF, multivariate_n> lagrange_first = { 1, 2, 0, 0};
     std::array<FF, multivariate_n> lagrange_last =  { 1, 2, 0, 0};
-    std::array<FF, multivariate_n> pow_zeta      =  { 1, 2, 0, 0};
     // clang-format on
 
     // These will be owned outside the class, probably by the composer.
     std::array<std::span<FF>, Multivariates::num> full_polynomials = {
-        w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,           q_l,     q_r, q_o, q_c, sigma_1, sigma_2,
-        sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last, pow_zeta
+        w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,          q_l, q_r, q_o, q_c, sigma_1, sigma_2,
+        sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last
     };
 
     auto transcript = produce_mocked_transcript(multivariate_d, num_public_inputs);
@@ -269,12 +267,11 @@ TEST(Sumcheck, ProverAndVerifier)
     std::array<FF, 2> id_3 = { 0, 0 };    // NOTE: Not set up to be valid.
     std::array<FF, 2> lagrange_first = { 0, 0 };
     std::array<FF, 2> lagrange_last = { 0, 0 }; // NOTE: Not set up to be valid.
-    std::array<FF, 2> pow_zeta = { 1, 1 };
 
     // These will be owned outside the class, probably by the composer.
     std::array<std::span<FF>, Multivariates::num> full_polynomials = {
-        w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,           q_l,     q_r, q_o, q_c, sigma_1, sigma_2,
-        sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last, pow_zeta
+        w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,          q_l, q_r, q_o, q_c, sigma_1, sigma_2,
+        sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last
     };
 
     auto transcript = produce_mocked_transcript(multivariate_d, num_public_inputs);
@@ -327,6 +324,7 @@ TEST(Sumcheck, ProverAndVerifierLonger)
     std::array<FF, multivariate_n> q_r            = { 0,  1,  0, 0 };
     std::array<FF, multivariate_n> q_o            = { 0, -1,  -1, 0 };
     std::array<FF, multivariate_n> q_c            = { 0,  0,  0, 0 };
+    // Setting all of these to 0 ensures the GrandProductRelation is satisfied
     std::array<FF, multivariate_n> sigma_1        = { 0,  0,  0, 0 };
     std::array<FF, multivariate_n> sigma_2        = { 0,  0,  0, 0 };
     std::array<FF, multivariate_n> sigma_3        = { 0,  0,  0, 0 };
@@ -335,13 +333,12 @@ TEST(Sumcheck, ProverAndVerifierLonger)
     std::array<FF, multivariate_n> id_3           = { 0,  0,  0, 0 };
     std::array<FF, multivariate_n> lagrange_first = { 0,  0,  0, 0 };
     std::array<FF, multivariate_n> lagrange_last  = { 0,  0,  0, 0 };
-    std::array<FF, multivariate_n> pow_zeta       = { 2,  4,  8, 16 }; // TODO(Cody): fails with non-1 entry
         // clang-format on
 
         // These will be owned outside the class, probably by the composer.
         std::array<std::span<FF>, Multivariates::num> full_polynomials = {
-            w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,           q_l,     q_r, q_o, q_c, sigma_1, sigma_2,
-            sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last, pow_zeta
+            w_l,     w_r,  w_o,  z_perm, z_perm_shift,   q_m,          q_l, q_r, q_o, q_c, sigma_1, sigma_2,
+            sigma_3, id_1, id_2, id_3,   lagrange_first, lagrange_last
         };
 
         auto transcript = produce_mocked_transcript(multivariate_d, num_public_inputs);

--- a/cpp/src/aztec/honk/utils/power_polynomial.hpp
+++ b/cpp/src/aztec/honk/utils/power_polynomial.hpp
@@ -5,8 +5,7 @@
 #ifndef NO_MULTITHREADING
 #include "omp.h"
 #endif
-namespace honk {
-namespace power_polynomial {
+namespace honk::power_polynomial {
 /**
  * @brief Generate the power polynomial vector
  *
@@ -62,7 +61,7 @@ template <typename Fr> barretenberg::Polynomial<Fr> generate_vector(Fr zeta, siz
  * @param variables
  * @return barretenberg::fr
  */
-template <typename Fr> Fr evaluate(Fr zeta, const std::span<Fr>& variables)
+template <typename Fr> Fr evaluate(Fr zeta, std::span<const Fr> variables)
 {
     Fr evaluation = Fr::one();
     for (size_t i = 0; i < variables.size(); i++) {
@@ -72,5 +71,4 @@ template <typename Fr> Fr evaluate(Fr zeta, const std::span<Fr>& variables)
     }
     return evaluation;
 }
-} // namespace power_polynomial
-} // namespace honk
+} // namespace honk::power_polynomial

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -26,7 +26,6 @@ struct StandardArithmetization {
         ID_3,
         LAGRANGE_FIRST,
         LAGRANGE_LAST, // = LAGRANGE_N-1 whithout ZK, but can be less
-        POW_ZETA,
         COUNT
     };
 
@@ -44,7 +43,7 @@ struct StandardHonk {
     // TODO(Cody): Maybe relation should be supplied and this should be computed as is done in sumcheck?
     // Then honk::StandardHonk (or whatever we rename it) would become an alias for a Honk flavor with a
     // certain set of parameters, including the relations?
-    static constexpr size_t MAX_RELATION_LENGTH = 6;
+    static constexpr size_t MAX_RELATION_LENGTH = 5;
 
     // TODO(Cody): should extract this from the parameter pack. Maybe that should be done here?
 
@@ -90,18 +89,11 @@ struct StandardHonk {
         // Round 3
         manifest_rounds.emplace_back(transcript::Manifest::RoundManifest(
             { { .name = "Z_PERM", .num_bytes = g1_size, .derived_by_verifier = false } },
-            /* challenge_name = */ "zeta",
-            /* num_challenges_in = */ 1)
-        ); 
-
-        // Round 4
-        manifest_rounds.emplace_back(transcript::Manifest::RoundManifest(
-            { { .name = "POW_ZETA", .num_bytes = g1_size, .derived_by_verifier = false } },
             /* challenge_name = */ "alpha",
-            /* num_challenges_in = */ 1) // Will bump to 2 when zeta if computed in same round at alpha
+            /* num_challenges_in = */ 2)
         ); 
 
-        // Rounds 4 + 1, ... 4 + num_sumcheck_rounds
+        // Rounds 4, ... 4 + num_sumcheck_rounds-1
         for (size_t i = 0; i < num_sumcheck_rounds; i++) {
             auto label = std::to_string(num_sumcheck_rounds - i);
             manifest_rounds.emplace_back(

--- a/cpp/src/aztec/proof_system/types/polynomial_manifest.hpp
+++ b/cpp/src/aztec/proof_system/types/polynomial_manifest.hpp
@@ -51,7 +51,6 @@ enum PolynomialIndex {
     Z_LOOKUP,
     LAGRANGE_FIRST,
     LAGRANGE_LAST,
-    POW_ZETA,
     // SUBGROUP_GENERATOR,
     MAX_NUM_POLYNOMIALS,
 };
@@ -173,7 +172,7 @@ static constexpr PolynomialDescriptor ultra_polynomial_manifest[ULTRA_UNROLLED_M
 };
 
 // TODO(Cody): Get this right; just using for now to extract names.
-static constexpr size_t STANDARD_HONK_MANIFEST_SIZE = 18; // equivalent to num unshifted polynomials
+static constexpr size_t STANDARD_HONK_MANIFEST_SIZE = 17; // equivalent to num unshifted polynomials
 static constexpr size_t NUM_SHIFTED_POLYNOMIALS = 1;
 static constexpr size_t STANDARD_HONK_TOTAL_NUM_POLYS = STANDARD_HONK_MANIFEST_SIZE + NUM_SHIFTED_POLYNOMIALS;
 static constexpr PolynomialDescriptor standard_honk_polynomial_manifest[STANDARD_HONK_MANIFEST_SIZE]{
@@ -195,7 +194,6 @@ static constexpr PolynomialDescriptor standard_honk_polynomial_manifest[STANDARD
     PolynomialDescriptor("ID_3", "id_3_lagrange", true, false, PERMUTATION, ID_3),                   //
     PolynomialDescriptor("LAGRANGE_FIRST", "L_first_lagrange", false, false, OTHER, LAGRANGE_FIRST), //
     PolynomialDescriptor("LAGRANGE_LAST", "L_last_lagrange", false, false, OTHER, LAGRANGE_LAST),    //
-    PolynomialDescriptor("POW_ZETA", "pow_zeta", false, false, WITNESS, POW_ZETA)                    //
 };
 
 // Simple class allowing for access to a polynomial manifest based on composer type


### PR DESCRIPTION
# Description

### [standard_honk_composer.test.cpp](https://github.com/AztecProtocol/barretenberg/pull/119#diff-5e2d6f2e2599f3bbe32d93ab2a2f57bc4af3ca2cdae402f5659e435910b8e5e0)

- Rename the test name to conform to the rest of Honk tests.
- Changed `SumcheckRelationCorrectness` to call the relation directly. Simplified the way the transposition is handled, we know create an array of all evaluations in each iteration over the subgroup size.

### [ipa.test.cpp](https://github.com/AztecProtocol/barretenberg/pull/119#diff-c62c1c572829cfe0a5f91185a276bc1b04b0b5b299914be14cde0e56fe33fe8b)

- Changed the number of iterations to make tests run faster.

### [sumcheck/polynomials/pow.hpp](https://github.com/AztecProtocol/barretenberg/pull/119#diff-5fa2ebe2998d794b3c89279e54dc0b8acc1c3ec5f7df1f6079f0023fbfaa8805)

- New class for efficiently handling the `pow` multiplication.
- Added test to check consistency with existing `pow_polynomial`

### [sumcheck/polynomials/univariate.hpp](https://github.com/AztecProtocol/barretenberg/pull/119#diff-7561d70e2ca8f39c279e5d3516c5026c27f15f3cb8c5784b43d398b38572d8a0)

- Use default copy/move constructors, fix the return value of copy/move assignment operators.
- `value_at` return `const Fr&` if `Univariate` is `const` 
- `UnivariateView` now holds a `const` pointer to the `Univariate` 
- Added functions for easily converting `array<T>` to `array<U>`, used to convert `Univariate` to `UnivariateView`


### [sumcheck/relations](https://github.com/AztecProtocol/barretenberg/pull/119#diff-bd7286a4095bfa7fc0bedd97208fa07be939f18e67faa8922dcbd395a0b0e856)
- All relations have been made uniform, and testing methods removed.
- Universal `accumulate_relation_evaluation` that handles scaling by the `zeta` power efficiently
- Always accept a `RelationParameters` object.
- Reset `RELATION_LENGTH` to before the `pow_zeta` change.

### [sumcheck/relations/relation.test.cpp](https://github.com/AztecProtocol/barretenberg/pull/119#diff-e7bfa83c5f7646d5a09549cf12cbabedffaf984fae63a2468ce7260fe6b328ef)

- Revert size of `MAX_RELATION_LENGTH`
- Make testing more robust, by computing the relation 3 different ways
- This structure also will help test expression templates down the road.

1. Evaluate the expression with hard coded relation value
2. Evaluate using `UnivariateView` 
3. Evaluate by computing the relation index-by-index.

### [sumcheck/sumcheck.hpp](https://github.com/AztecProtocol/barretenberg/pull/119#diff-1fb008d408165b19fcc4556fc36dbeed74b5f614089836bf0ec3d22bb3efe5c2)

- Add `zeta` to relation parameters
- Pass the `pow_univariate` to the Sumcheck round and apply necessary adaptations.

### [sumcheck/sumcheck_round.hpp](https://github.com/AztecProtocol/barretenberg/pull/119#diff-1de71b7e7a66c2701a1b33cf8750660ac6f33e1fedc2df702e6ceaaa6d9d7fe8)

There are many changes here. The main point was to make the prover and verifier code paths uniform. 
The main hot-loop in `add_scaled_expressions` calls the `add_scaled_expression_at_idx` for each relation. This latter function can almost be called the same way for both parties, but for now a `constexpr` statement is necessary to apply the conversion from `Univariate` to `UnivariateView`. There may be a slight overhead from constructing this array for all Univariates, but this could be overcome with something like the tricks used in `array_to_array` with an `std::integer_sequence` containing the indices of the required polynomials.

The `scale_tuple` and `batch_over_relations` were merged into a single method `batch_over_relations` that works for both parties. The prover performs the `extend_univariate_accumulators` in their own `compute_univariate` method.

The modification to the `Relation` interface now allow us to scale the relation by `pow_zeta` inside the evaluation itself, rather than handling this inside the `Sumcheck_round`. 



# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
