### PR TITLE
fix: Avoid targeting honk test files when testing is disabled

### DIFF
--- a/cpp/src/aztec/honk/CMakeLists.txt
+++ b/cpp/src/aztec/honk/CMakeLists.txt
@@ -1,18 +1,20 @@
 barretenberg_module(honk numeric ecc srs proof_system transcript)
 
-# TODO: Re-enable all these warnings once PoC is finished 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(
-        honk_test_objects 
-        PRIVATE 
-        -Wno-error=unused-variable
-    )
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    target_compile_options(
-        honk_test_objects 
-        PRIVATE 
-        -Wno-error=maybe-uninitialized
-        -Wno-error=uninitialized
-        -Wno-error=unused-variable
-    )
+if(TESTING)
+    # TODO: Re-enable all these warnings once PoC is finished
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(
+            honk_test_objects
+            PRIVATE
+            -Wno-error=unused-variable
+        )
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        target_compile_options(
+            honk_test_objects
+            PRIVATE
+            -Wno-error=maybe-uninitialized
+            -Wno-error=uninitialized
+            -Wno-error=unused-variable
+        )
+    endif()
 endif()


### PR DESCRIPTION
# Description

This is the first in a series of PRs to get barretenberg builds working for Noir. As I started porting things over, I was getting a crash due to using `-DTESTING=OFF` because the `honk_test_objects` target didn't exist.

(I'm not sure who to request reviews from so sorry if I added someone by mistake)

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
