### PR TITLE
feat: Allow bootstrap to work with linux + clang on ARM

### DIFF
--- a/cpp/bootstrap.sh
+++ b/cpp/bootstrap.sh
@@ -32,6 +32,7 @@ cd ./srs_db
 cd ..
 
 # Pick native toolchain file.
+ARCH=$(uname -m)
 if [ "$OS" == "macos" ]; then
   export BREW_PREFIX=$(brew --prefix)
   # Ensure we have toolchain.
@@ -39,14 +40,17 @@ if [ "$OS" == "macos" ]; then
     echo "Default clang not sufficient. Install homebrew, and then: brew install llvm libomp clang-format"
     exit 1
   fi
-  ARCH=$(uname -m)
   if [ "$ARCH" = "arm64" ]; then
     TOOLCHAIN=arm-apple-clang
   else
     TOOLCHAIN=x86_64-apple-clang
   fi
 else
-  TOOLCHAIN=x86_64-linux-clang
+  if [ "$ARCH" = "aarch64" ]; then
+      TOOLCHAIN=aarch64-linux-clang
+  else
+      TOOLCHAIN=x86_64-linux-clang
+  fi
 fi
 
 # Build native.

--- a/cpp/cmake/arch.cmake
+++ b/cpp/cmake/arch.cmake
@@ -5,6 +5,6 @@ if(WASM)
     add_compile_options(-fno-exceptions -fno-slp-vectorize)
 endif()
 
-if(NOT WASM AND NOT APPLE)
+if(NOT WASM AND NOT APPLE AND NOT ARM)
     add_compile_options(-march=skylake)
 endif()

--- a/cpp/cmake/toolchains/aarch64-linux-clang.cmake
+++ b/cpp/cmake/toolchains/aarch64-linux-clang.cmake
@@ -1,0 +1,6 @@
+set(ARM ON)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER "clang")
+set(CMAKE_CXX_COMPILER "clang++")


### PR DESCRIPTION
# Description

This adds a `aarch64-linux-clang` target that will be detected by `bootstrap.sh` if you are running on an ARM linux system. I didn't change anything related to the arm64-linux-gcc cross compilation stuff since that's a larger discussion.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
