### PR TITLE
feat: Utilize globally installed leveldb if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The structured reference string contains monomials up to x^{2^20}. This SRS was 
 
 ### Dependencies
 
-- cmake >= 3.16
+- cmake >= 3.24
 - clang >= 10 or gcc >= 10
 - clang-format
 - libomp (if multithreading is required. Multithreading can be disabled using the compiler flag `-DMULTITHREADING 0`)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # barretenberg
 # copyright 2019 Spilsbury Holdings Ltd
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 include(cmake/toolchain.cmake)
 

--- a/cpp/cmake/module.cmake
+++ b/cpp/cmake/module.cmake
@@ -23,6 +23,7 @@ function(barretenberg_module MODULE_NAME)
             OBJECT
             ${SOURCE_FILES}
         )
+        list(APPEND lib_targets ${MODULE_NAME}_objects)
 
         add_library(
             ${MODULE_NAME}
@@ -36,6 +37,7 @@ function(barretenberg_module MODULE_NAME)
             ${ARGN}
             ${TBB_IMPORTED_TARGETS}
         )
+        list(APPEND lib_targets ${MODULE_NAME})
 
         set(MODULE_LINK_NAME ${MODULE_NAME})
     endif()
@@ -47,6 +49,7 @@ function(barretenberg_module MODULE_NAME)
             OBJECT
             ${TEST_SOURCE_FILES}
         )
+        list(APPEND lib_targets ${MODULE_NAME}_test_objects)
 
         target_link_libraries(
             ${MODULE_NAME}_test_objects
@@ -59,6 +62,7 @@ function(barretenberg_module MODULE_NAME)
             ${MODULE_NAME}_tests
             $<TARGET_OBJECTS:${MODULE_NAME}_test_objects>
         )
+        list(APPEND exe_targets ${MODULE_NAME}_tests)
 
         if(WASM)
             target_link_options(
@@ -111,22 +115,23 @@ function(barretenberg_module MODULE_NAME)
         foreach(FUZZER_SOURCE_FILE ${FUZZERS_SOURCE_FILES})
             get_filename_component(FUZZER_NAME_STEM ${FUZZER_SOURCE_FILE} NAME_WE)
             add_executable(
-            ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
-            ${FUZZER_SOURCE_FILE}
+                ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
+                ${FUZZER_SOURCE_FILE}
             )
+            list(APPEND exe_targets ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer)
 
             target_link_options(
-            ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
+                ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
                 PRIVATE
                 "-fsanitize=fuzzer"
                 ${SANITIZER_OPTIONS}
-                )
+            )
 
             target_link_libraries(
-            ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
-            PRIVATE
+                ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
+                PRIVATE
                 ${MODULE_LINK_NAME}
-                )
+            )
         endforeach()
     endif()
 
@@ -137,6 +142,7 @@ function(barretenberg_module MODULE_NAME)
             OBJECT
             ${BENCH_SOURCE_FILES}
         )
+        list(APPEND lib_targets ${MODULE_NAME}_bench_objects)
 
         target_link_libraries(
             ${MODULE_NAME}_bench_objects
@@ -149,6 +155,7 @@ function(barretenberg_module MODULE_NAME)
             ${MODULE_NAME}_bench
             $<TARGET_OBJECTS:${MODULE_NAME}_bench_objects>
         )
+        list(APPEND exe_targets ${MODULE_NAME}_bench)
 
         target_link_libraries(
             ${MODULE_NAME}_bench
@@ -165,4 +172,7 @@ function(barretenberg_module MODULE_NAME)
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
     endif()
+
+    set(${MODULE_NAME}_lib_targets ${lib_targets} PARENT_SCOPE)
+    set(${MODULE_NAME}_exe_targets ${exe_targets} PARENT_SCOPE)
 endfunction()

--- a/cpp/dockerfiles/Dockerfile.wasm-linux-clang
+++ b/cpp/dockerfiles/Dockerfile.wasm-linux-clang
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS builder
+FROM ubuntu:kinetic AS builder
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential wget git libssl-dev cmake curl binaryen
 RUN curl https://wasmtime.dev/install.sh -sSf | bash /dev/stdin --version v3.0.1
 WORKDIR /usr/src/barretenberg/cpp/src

--- a/cpp/src/aztec/stdlib/merkle_tree/CMakeLists.txt
+++ b/cpp/src/aztec/stdlib/merkle_tree/CMakeLists.txt
@@ -1,26 +1,49 @@
+barretenberg_module(stdlib_merkle_tree stdlib_primitives stdlib_blake3s stdlib_pedersen)
+
 if(NOT WASM)
     include(FetchContent)
     FetchContent_Declare(
         leveldb
         GIT_REPOSITORY https://github.com/google/leveldb.git
         GIT_TAG 1.22
+        FIND_PACKAGE_ARGS
     )
 
-    FetchContent_GetProperties(leveldb)
-    if(NOT leveldb_POPULATED)
-        FetchContent_Populate(leveldb)
-        set(LEVELDB_BUILD_TESTS OFF CACHE BOOL "LevelDB tests off")
-        add_subdirectory(${leveldb_SOURCE_DIR} ${leveldb_BINARY_DIR} EXCLUDE_FROM_ALL)
+    # Disable some leveldb targets before we call FetchContent_MakeAvailable
+    # so they are configured correctly if it needs to fetch
+    set(LEVELDB_BUILD_TESTS OFF CACHE BOOL "LevelDB tests off")
+    set(LEVELDB_BUILD_BENCHMARKS OFF CACHE BOOL "LevelDB benchmarks off")
+
+    FetchContent_MakeAvailable(leveldb)
+
+    if (leveldb_FOUND)
+        # Globally installed leveldb needs Threads available as Threads::Threads as discovered by `find_package`
+        find_package(Threads REQUIRED)
+
+        target_link_libraries(stdlib_merkle_tree PRIVATE leveldb::leveldb)
+        target_link_libraries(stdlib_merkle_tree_objects PRIVATE leveldb::leveldb)
+    else()
+        # FetchContent_MakeAvailable calls FetchContent_Populate if `find_package` is unsuccessful
+        # so these variables will be available if we reach this case
+        set_property(DIRECTORY ${leveldb_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL)
+        set_property(DIRECTORY ${leveldb_BINARY_DIR} PROPERTY EXCLUDE_FROM_ALL)
+
+        # Silence all compiler warnings from LevelDB
+        target_compile_options(
+            leveldb
+            PRIVATE
+            -w
+        )
+
+        target_link_libraries(stdlib_merkle_tree PRIVATE leveldb)
+        target_link_libraries(stdlib_merkle_tree_objects PRIVATE leveldb)
+        if(TESTING)
+            target_link_libraries(stdlib_merkle_tree_tests PRIVATE leveldb)
+            target_link_libraries(stdlib_merkle_tree_test_objects PRIVATE leveldb)
+        endif()
+        if(BENCHMARKS)
+            target_link_libraries(stdlib_merkle_tree_bench PRIVATE leveldb)
+            target_link_libraries(stdlib_merkle_tree_bench_objects PRIVATE leveldb)
+        endif()
     endif()
-
-    # Silence all compiler warnings from LevelDB
-    target_compile_options(
-        leveldb
-        PRIVATE
-        -w
-    )
-
-    link_libraries(leveldb)
 endif()
-
-barretenberg_module(stdlib_merkle_tree stdlib_primitives stdlib_blake3s stdlib_pedersen)

--- a/cpp/src/aztec/stdlib/merkle_tree/CMakeLists.txt
+++ b/cpp/src/aztec/stdlib/merkle_tree/CMakeLists.txt
@@ -20,8 +20,9 @@ if(NOT WASM)
         # Globally installed leveldb needs Threads available as Threads::Threads as discovered by `find_package`
         find_package(Threads REQUIRED)
 
-        target_link_libraries(stdlib_merkle_tree PRIVATE leveldb::leveldb)
-        target_link_libraries(stdlib_merkle_tree_objects PRIVATE leveldb::leveldb)
+        foreach(target IN LISTS stdlib_merkle_tree_lib_targets stdlib_merkle_tree_exe_targets)
+            target_link_libraries(${target} PRIVATE leveldb::leveldb)
+        endforeach()
     else()
         # FetchContent_MakeAvailable calls FetchContent_Populate if `find_package` is unsuccessful
         # so these variables will be available if we reach this case
@@ -35,15 +36,8 @@ if(NOT WASM)
             -w
         )
 
-        target_link_libraries(stdlib_merkle_tree PRIVATE leveldb)
-        target_link_libraries(stdlib_merkle_tree_objects PRIVATE leveldb)
-        if(TESTING)
-            target_link_libraries(stdlib_merkle_tree_tests PRIVATE leveldb)
-            target_link_libraries(stdlib_merkle_tree_test_objects PRIVATE leveldb)
-        endif()
-        if(BENCHMARKS)
-            target_link_libraries(stdlib_merkle_tree_bench PRIVATE leveldb)
-            target_link_libraries(stdlib_merkle_tree_bench_objects PRIVATE leveldb)
-        endif()
+        foreach(target IN LISTS stdlib_merkle_tree_lib_targets stdlib_merkle_tree_exe_targets)
+            target_link_libraries(${target} PRIVATE leveldb)
+        endforeach()
     endif()
 endif()


### PR DESCRIPTION
# Description

This allows leveldb to be provided globally in environments where there is no network access or where the sandbox cannot be changed (e.g. nix) during the building of the package. This is done through `FetchContent_MakeAvailable` which can be used in combination with `FIND_PACKAGE_ARGS` to start with a `find_package` search before trying to fetch from the network.

This changes requires a CMake minimum version upgrade because `FIND_PACKAGE_ARGS` wasn't added until v3.24 as documented at https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_declare. Does anyone know which version of CMake is being used in the docker containers?

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
