### PR TITLE
fix(srs): Detect shasum utility when downloading lagrange

### DIFF
--- a/cpp/srs_db/download_ignition_lagrange.sh
+++ b/cpp/srs_db/download_ignition_lagrange.sh
@@ -18,8 +18,14 @@ cd lagrange
 num_transcripts=${1:-25}
 ARGS=$(seq 1 $num_transcripts)
 
+if command -v sha256sum > /dev/null; then
+  SHASUM=sha256sum
+else
+  SHASUM="shasum -a 256"
+fi
+
 checksum() {
-  grep transcript_${1}.dat checksums | sha256sum -c
+  grep transcript_${1}.dat checksums | $SHASUM -c
   return $?
 }
 


### PR DESCRIPTION
# Description

This switches the shasum utility from `sha256sum` to `shasum -a 256`, since `sha256sum` is not available on a default mac system and would require coreutils to be installed. My understanding is that `shasum` with the `256` algorithm selected is the same thing (and is working on my nearly-default mac). `shasum` manpage: https://linux.die.net/man/1/shasum

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
