### PR TITLE
Port timer.hpp fixes from db46ae9

### DIFF
--- a/cpp/src/aztec/common/timer.hpp
+++ b/cpp/src/aztec/common/timer.hpp
@@ -5,6 +5,10 @@
 #include <sys/time.h>
 #include <ctime>
 
+/**
+ * @brief Get the execution between a block of code.
+ *
+ */
 class Timer {
   private:
     struct timespec _startTime;
@@ -12,17 +16,30 @@ class Timer {
 
     static constexpr int64_t NanosecondsPerSecond = 1000LL * 1000 * 1000;
 
+    /**
+     * @brief Manually sets the start time.
+     */
+    void start() { clock_gettime(CLOCK_REALTIME, &_startTime); }
+
+    /**
+     * @brief Manually sets the end time.
+     */
+    void end() { clock_gettime(CLOCK_REALTIME, &_endTime); }
+
   public:
+    /**
+     * @brief Initialize a Timer with the current time.
+     *
+     */
     Timer()
         : _endTime({})
     {
         start();
     }
 
-    void start() { clock_gettime(CLOCK_REALTIME, &_startTime); }
-
-    void end() { clock_gettime(CLOCK_REALTIME, &_endTime); }
-
+    /**
+     * @brief Return the number of nanoseconds elapsed since the start of the timer.
+     */
     [[nodiscard]] int64_t nanoseconds() const
     {
         struct timespec end;
@@ -38,6 +55,9 @@ class Timer {
         return nanos;
     }
 
+    /**
+     * @brief Return the number of seconds elapsed since the start of the timer.
+     */
     [[nodiscard]] double seconds() const
     {
         int64_t nanos = nanoseconds();
@@ -45,6 +65,9 @@ class Timer {
         return secs;
     }
 
+    /**
+     * @brief Return the number of seconds elapsed since the start of the timer as a string.
+     */
     [[nodiscard]] std::string toString() const
     {
         double secs = seconds();

--- a/cpp/src/aztec/common/timer.hpp
+++ b/cpp/src/aztec/common/timer.hpp
@@ -1,14 +1,16 @@
 #pragma once
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <sys/resource.h>
 #include <sys/time.h>
-#include <time.h>
+#include <ctime>
 
 class Timer {
   private:
     struct timespec _startTime;
     struct timespec _endTime;
+
+    static constexpr int64_t NanosecondsPerSecond = 1000LL * 1000 * 1000;
 
   public:
     Timer()
@@ -21,23 +23,31 @@ class Timer {
 
     void end() { clock_gettime(CLOCK_REALTIME, &_endTime); }
 
-    std::string toString() const
+    [[nodiscard]] int64_t nanoseconds() const
     {
-        struct timespec endTime;
+        struct timespec end;
         if (_endTime.tv_nsec == 0 && _endTime.tv_sec == 0) {
-            clock_gettime(CLOCK_REALTIME, &endTime);
+            clock_gettime(CLOCK_REALTIME, &end);
         } else {
-            endTime = _endTime;
+            end = _endTime;
         }
 
-        auto seconds = endTime.tv_sec - _startTime.tv_sec;
-        auto ns = endTime.tv_nsec - _startTime.tv_nsec;
+        int64_t nanos = (end.tv_sec - _startTime.tv_sec) * NanosecondsPerSecond;
+        nanos += (end.tv_nsec - _startTime.tv_nsec);
 
-        if (_startTime.tv_nsec > endTime.tv_nsec) { // clock underflow
-            --seconds;
-            ns += 1000000000;
-        }
+        return nanos;
+    }
 
-        return std::to_string((double)seconds + (double)ns / (double)1000000000);
+    [[nodiscard]] double seconds() const
+    {
+        int64_t nanos = nanoseconds();
+        double secs = static_cast<double>(nanos) / NanosecondsPerSecond;
+        return secs;
+    }
+
+    [[nodiscard]] std::string toString() const
+    {
+        double secs = seconds();
+        return std::to_string(secs);
     }
 };


### PR DESCRIPTION
# Description

Ports the fix from [commit db46ae9](https://github.com/AztecProtocol/aztec2-internal/commit/db46ae9a5a41ccd5f384ca1eb277809119c716ef). 


**Note**: Only `to_string()` was used in the codebase. The methods `start()` and `end()` were changed to `private` to simplify the description of the class.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
