### PR TITLE
feat: Utilize globally installed gtest if available

### DIFF
--- a/cpp/cmake/gtest.cmake
+++ b/cpp/cmake/gtest.cmake
@@ -3,38 +3,48 @@ if(TESTING)
     include(FetchContent)
 
     FetchContent_Declare(
-        googletest
+        GTest
         GIT_REPOSITORY https://github.com/google/googletest.git
         # Version 1.12.1 is not compatible with WASI-SDK 12
-        GIT_TAG release-1.10.0 
+        GIT_TAG release-1.10.0
+        FIND_PACKAGE_ARGS
     )
 
-    FetchContent_GetProperties(googletest)
-    if(NOT googletest_POPULATED)
-        FetchContent_Populate(googletest)
-        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-    endif()
+    set(BUILD_GMOCK OFF CACHE BOOL "Build with gMock disabled")
 
-    # Disable all warning when compiling gtest
-    target_compile_options(
-        gtest
-        PRIVATE
-        -w
-    )
+    FetchContent_MakeAvailable(GTest)
 
-    if(WASM)
-        target_compile_definitions(
+    if (NOT GTest_FOUND)
+        # FetchContent_MakeAvailable calls FetchContent_Populate if `find_package` is unsuccessful
+        # so these variables will be available if we reach this case
+        set_property(DIRECTORY ${gtest_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL)
+        set_property(DIRECTORY ${gtest_BINARY_DIR} PROPERTY EXCLUDE_FROM_ALL)
+
+        # Disable all warning when compiling gtest
+        target_compile_options(
             gtest
             PRIVATE
-            -DGTEST_HAS_EXCEPTIONS=0
-            -DGTEST_HAS_STREAM_REDIRECTION=0)
-    endif()
+            -w
+        )
 
-    mark_as_advanced(
-        BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
-        gmock_build_tests gtest_build_samples gtest_build_tests
-        gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
-    )
+        if(WASM)
+            target_compile_definitions(
+                gtest
+                PRIVATE
+                -DGTEST_HAS_EXCEPTIONS=0
+                -DGTEST_HAS_STREAM_REDIRECTION=0
+            )
+        endif()
+
+        mark_as_advanced(
+            BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
+            gmock_build_tests gtest_build_samples gtest_build_tests
+            gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
+        )
+
+        add_library(GTest::gtest ALIAS gtest)
+        add_library(GTest::gtest_main ALIAS gtest_main)
+    endif()
 
     enable_testing()
 endif()

--- a/cpp/cmake/module.cmake
+++ b/cpp/cmake/module.cmake
@@ -54,7 +54,7 @@ function(barretenberg_module MODULE_NAME)
         target_link_libraries(
             ${MODULE_NAME}_test_objects
             PRIVATE
-            gtest
+            GTest::gtest
             ${TBB_IMPORTED_TARGETS}
         )
 
@@ -93,8 +93,8 @@ function(barretenberg_module MODULE_NAME)
             PRIVATE
             ${MODULE_LINK_NAME}
             ${ARGN}
-            gtest
-            gtest_main
+            GTest::gtest
+            GTest::gtest_main
             ${TBB_IMPORTED_TARGETS}
         )
 


### PR DESCRIPTION
# Description

This is similar to #134 in that it first checks to see if GTest is available in the CMake path before it attempts to download it. I've also made sure to disable gMock, which doesn't seem to be used, if gtest is built from source.

The aliases are created to ensure the namespace stays consistent between globally installed and source builds.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
