### PR TITLE
feat: Utilize globally installed benchmark if available

### DIFF
--- a/cpp/cmake/benchmark.cmake
+++ b/cpp/cmake/benchmark.cmake
@@ -9,12 +9,16 @@ if(BENCHMARKS)
         benchmark
         GIT_REPOSITORY https://github.com/google/benchmark
         GIT_TAG v1.7.1
+        FIND_PACKAGE_ARGS
     )
 
-    FetchContent_GetProperties(benchmark)
-    if(NOT benchmark_POPULATED)
-        fetchcontent_populate(benchmark)
-        set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Benchmark tests off")
-        add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR} EXCLUDE_FROM_ALL)
+    set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Benchmark tests off")
+
+    FetchContent_MakeAvailable(benchmark)
+    if(NOT benchmark_FOUND)
+        # FetchContent_MakeAvailable calls FetchContent_Populate if `find_package` is unsuccessful
+        # so these variables will be available if we reach this case
+        set_property(DIRECTORY ${benchmark_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL)
+        set_property(DIRECTORY ${benchmark_BINARY_DIR} PROPERTY EXCLUDE_FROM_ALL)
     endif()
 endif()

--- a/cpp/cmake/module.cmake
+++ b/cpp/cmake/module.cmake
@@ -147,7 +147,7 @@ function(barretenberg_module MODULE_NAME)
         target_link_libraries(
             ${MODULE_NAME}_bench_objects
             PRIVATE
-            benchmark
+            benchmark::benchmark
             ${TBB_IMPORTED_TARGETS}
         )
 
@@ -162,7 +162,7 @@ function(barretenberg_module MODULE_NAME)
             PRIVATE
             ${MODULE_LINK_NAME}
             ${ARGN}
-            benchmark
+            benchmark::benchmark
             ${TBB_IMPORTED_TARGETS}
         )
 

--- a/cpp/src/aztec/benchmark/honk_bench/CMakeLists.txt
+++ b/cpp/src/aztec/benchmark/honk_bench/CMakeLists.txt
@@ -4,7 +4,7 @@ target_link_libraries(
   honk_bench
   stdlib_primitives
   env
-  benchmark
+  benchmark::benchmark
 )
 
 add_custom_target(

--- a/cpp/src/aztec/benchmark/plonk_bench/CMakeLists.txt
+++ b/cpp/src/aztec/benchmark/plonk_bench/CMakeLists.txt
@@ -4,7 +4,7 @@ target_link_libraries(
   plonk_bench
   stdlib_primitives
   env
-  benchmark
+  benchmark::benchmark
 )
 
 add_custom_target(


### PR DESCRIPTION
# Description

This is similar to #151  in that it first checks to see if benchmark is available in the CMake path before it attempts to download it.

Unlike gtest, benchmark always provides itself as `benchmark::benchmark` so I've just updated the references throughout the various cmake files.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
