### PR TITLE
Add needed 'redundant' checks.

### DIFF
--- a/cpp/.clangd
+++ b/cpp/.clangd
@@ -30,13 +30,14 @@ Diagnostics:
       - cppcoreguidelines-pro-bounds-pointer-arithmetic
       # Huge diff.
       - readability-magic-numbers
+      - cppcoreguidelines-avoid-magic-numbers
       # We use short names because we do math. Also, huge diff.
       - readability-identifier-length
       # Fixing this would be a lot of work.
       - bugprone-easily-swappable-parameters
       # Huge diff
       - misc-non-private-member-variables-in-classes
-
+      - cppcoreguidelines-non-private-member-variables-in-classes
       # We have many `for` loops that violate this part of the bounds safety profile
       - cppcoreguidelines-pro-bounds-constant-array-index 
       # Large diff; we often `use` an entire namespace.


### PR DESCRIPTION
# Description

clang-tidy has some duplicated checks with different names. In order to suppress these checks, we have to suppress for both names.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
