### PR TITLE
Increase Pedersen Generator indices and subindices.

### DIFF
--- a/cpp/src/aztec/crypto/generators/generator_data.cpp
+++ b/cpp/src/aztec/crypto/generators/generator_data.cpp
@@ -243,7 +243,7 @@ const fixed_base_ladder* get_g1_ladder(const size_t num_bits)
  * Default generators:
  * 0: P_0  P_1  P_2  ...  P_{N'-1}
  *
- * Hash-index dependent generators: (let N' = 3 * N)
+ * Hash-index dependent generators: (let N' = t * N)
  * 1:  P_{N' + 0*h*t}   P_{N' + 0*h*t + 1*t}  ...  P_{N' + 0*h*t + (h-1)*t}
  * 2:  P_{N' + 1*h*t}   P_{N' + 1*h*t + 1*t}  ...  P_{N' + 1*h*t + (h-1)*t}
  * 2:  P_{N' + 2*h*t}   P_{N' + 2*h*t + 1*t}  ...  P_{N' + 2*h*t + (h-1)*t}

--- a/cpp/src/aztec/crypto/generators/generator_data.cpp
+++ b/cpp/src/aztec/crypto/generators/generator_data.cpp
@@ -235,21 +235,26 @@ const fixed_base_ladder* get_g1_ladder(const size_t num_bits)
 /**
  * Generator indexing:
  *
- * Default generators:
- * 0: P_0  P_1  P_2  ...  P_{2047}
+ * Number of default generators (index = 0): N = 2048
+ * Number of hash indices: H = 32
+ * Number of sub indices for a given hash index: h = 64.
+ * Number of types of generators needed per hash index: t = 3
  *
- * Hash-index dependent generators:
- * 1:  P_{2048 + 0*8}   P_{2049}  ...  P_{2055}
- * 2:  P_{2048 + 1*8}   P_{2048 + 1*8 + 1}   ...  P_{2048 + 1*8 + 7}
- * 3:
+ * Default generators:
+ * 0: P_0  P_1  P_2  ...  P_{N'-1}
+ *
+ * Hash-index dependent generators: (let N' = 3 * N)
+ * 1:  P_{N' + 0*h*t}   P_{N' + 0*h*t + 1*t}  ...  P_{N' + 0*h*t + (h-1)*t}
+ * 2:  P_{N' + 1*h*t}   P_{N' + 1*h*t + 1*t}  ...  P_{N' + 1*h*t + (h-1)*t}
+ * 2:  P_{N' + 2*h*t}   P_{N' + 2*h*t + 1*t}  ...  P_{N' + 2*h*t + (h-1)*t}
  * 4:
  * .
  * .
  * .
- * 31: P_{2048 + 30*8}  P_{2048 + 30*8 + 1}  ...  P_{2048 + 30*8 + 7}
- * 32: P_{2048 + 31*8}  P_{2048 + 31*8 + 1}  ...  P_{2048 + 31*8 + 7}
+ * H-1:  P_{N' + (H-2)*h*t}   P_{N' + (H-2)*h*t + 1*t}  ...  P_{N' + (H-2)*h*t + (h-1)*t}
+ * H  :  P_{N' + (H-1)*h*t}   P_{N' + (H-1)*h*t + 1*t}  ...  P_{N' + (H-1)*h*t + (h-1)*t}
  *
- * Total generators = 2048 + 32*8 = 2304
+ * Total generators = (N + H * h) * t = 2304
  */
 generator_data const& get_generator_data(generator_index_t index)
 {

--- a/cpp/src/aztec/crypto/generators/generator_data.cpp
+++ b/cpp/src/aztec/crypto/generators/generator_data.cpp
@@ -12,8 +12,8 @@ constexpr size_t num_default_generators = 2048;
 #endif
 
 constexpr size_t hash_indices_generator_offset = 2048;
-constexpr size_t num_hash_indices = 16;
-constexpr size_t num_generators_per_hash_index = 8;
+constexpr size_t num_hash_indices = 32;
+constexpr size_t num_generators_per_hash_index = 64;
 constexpr size_t num_indexed_generators = num_hash_indices * num_generators_per_hash_index;
 constexpr size_t size_of_generator_data_array = hash_indices_generator_offset + num_indexed_generators;
 constexpr size_t num_generator_types = 3;

--- a/cpp/src/aztec/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/cpp/src/aztec/join_split_example/proofs/join_split/join_split.test.cpp
@@ -700,7 +700,7 @@ TEST_F(join_split_tests, test_0_input_notes_and_detect_circuit_change)
     // The below part detects any changes in the join-split circuit
     constexpr uint32_t CIRCUIT_GATE_COUNT = 59175;
     constexpr uint32_t GATES_NEXT_POWER_OF_TWO = 65536;
-    const uint256_t VK_HASH("edcee79f9736d8a9dcc7a5c822a49bc930315bdad7f7b67accc60ab196eb63d9");
+    const uint256_t VK_HASH("7c5f17b829f8a6b17292a998ec06b2481abb82923e838d7422c3aec5cd5edd95");
 
     auto number_of_gates_js = result.number_of_gates;
     auto vk_hash_js = get_verification_key()->sha256_hash();


### PR DESCRIPTION
# Description

Need to increase the number of generator indices to 32 (and subindices to 64). This should suffice for whatever we need to hash in aztec3. 

Side note: This PR changes the join-split circuit because we've added more generators. This changes the generators for hash indices $>1$. 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
