### PR TITLE
feat: Make pedersen `commit` function public

### DIFF
--- a/cpp/src/aztec/stdlib/hash/pedersen/pedersen.hpp
+++ b/cpp/src/aztec/stdlib/hash/pedersen/pedersen.hpp
@@ -46,7 +46,6 @@ template <typename ComposerContext> class pedersen {
 
     static void validate_wnaf_is_in_field(ComposerContext* ctx, const std::vector<uint32_t>& accumulator);
 
-  private:
     static point commit(const std::vector<field_t>& inputs, const size_t hash_index = 0);
 };
 


### PR DESCRIPTION
# Description

Noir needs the pedersen `commit` function to be public because it needs to be able to return the x and y.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
