### PR TITLE
feat: Add `copy_from_to` function to ComposerBase

### DIFF
--- a/cpp/src/aztec/plonk/composer/composer_base.cpp
+++ b/cpp/src/aztec/plonk/composer/composer_base.cpp
@@ -85,6 +85,13 @@ template <size_t program_width> void ComposerBase::compute_wire_copy_cycles()
     }
 }
 
+// Copies the value of a_variable_idx into b_variable_idx
+// Can be seen as us replacing all occurrences of b_variable_idx with a_variable_idx
+void ComposerBase::copy_from_to(const uint32_t a_variable_idx, const uint32_t b_variable_idx)
+{
+    assert_equal(a_variable_idx, b_variable_idx, "");
+}
+
 /**
  * Compute sigma and id permutation polynomials in lagrange base.
  *

--- a/cpp/src/aztec/plonk/composer/composer_base.cpp
+++ b/cpp/src/aztec/plonk/composer/composer_base.cpp
@@ -85,8 +85,13 @@ template <size_t program_width> void ComposerBase::compute_wire_copy_cycles()
     }
 }
 
-// Copies the value of a_variable_idx into b_variable_idx
-// Can be seen as us replacing all occurrences of b_variable_idx with a_variable_idx
+/**
+ * Copies the value of a_variable_idx into b_variable_idx.
+ * Can be seen as us replacing all occurrences of b_variable_idx with a_variable_idx.
+ *
+ * @param a_variable_idx The value to replace.
+ * @param b_variable_idx The value to be replaced.
+ */
 void ComposerBase::copy_from_to(const uint32_t a_variable_idx, const uint32_t b_variable_idx)
 {
     assert_equal(a_variable_idx, b_variable_idx, "");

--- a/cpp/src/aztec/plonk/composer/composer_base.hpp
+++ b/cpp/src/aztec/plonk/composer/composer_base.hpp
@@ -132,6 +132,7 @@ class ComposerBase {
     virtual void create_bool_gate(const uint32_t a) = 0;
     virtual void create_poly_gate(const poly_triple& in) = 0;
     virtual size_t get_num_constant_gates() const = 0;
+    virtual void copy_from_to(const uint32_t from_idx, const uint32_t to_idx);
 
     /**
      * Get the index of the first variable in class.


### PR DESCRIPTION
# Description

This adds a `copy_from_to` function to ComposerBase. Noir needs this so it can be used as a cheap way to do equality on the expected witness.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
