### PR TITLE
feat: Add `signature_verification_result` to schnorr stdlib

### DIFF
--- a/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.cpp
+++ b/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.cpp
@@ -312,8 +312,8 @@ template <typename C>
 void verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig)
 {
     auto [output_lo, output_hi] = verify_signature_internal(message, pub_key, sig);
-    output_lo.assert_equal(sig.e_lo, "signature verification failed on low limb");
-    output_hi.assert_equal(sig.e_hi, "signature verification failed on high limb");
+    output_lo.assert_equal(sig.e_lo, "verify signature failed");
+    output_hi.assert_equal(sig.e_hi, "verify signature failed");
 }
 
 /**

--- a/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.cpp
+++ b/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.cpp
@@ -270,7 +270,7 @@ point<C> variable_base_mul(const point<C>& pub_key, const point<C>& current_accu
  * @details TurboPlonk: ~10850 gates (~4k for variable_base_mul, ~6k for blake2s) for a string of length < 32.
  */
 template <typename C>
-bool verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig)
+bool_t<C> verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig)
 {
     // Compute [s]g, where s = (s_lo, s_hi) and g = G1::one.
     point<C> R_1 = group<C>::fixed_base_scalar_mul(sig.s_lo, sig.s_hi);
@@ -293,14 +293,8 @@ bool verify_signature(const byte_array<C>& message, const point<C>& pub_key, con
 
     field_t<C> output_hi(output.slice(0, 16));
     field_t<C> output_lo(output.slice(16, 16));
-    output_lo.assert_equal(sig.e_lo, "verify signature failed");
-    output_hi.assert_equal(sig.e_hi, "verify signature failed");
 
-    // This is not secure because we want to constrain the
-    // `valid` variable to the two equalities below and not
-    // just return the value.
-    bool valid = (output_lo.get_value() == sig.e_lo.get_value());
-    valid = valid && (output_hi.get_value() == sig.e_hi.get_value());
+    bool_t<C> valid = output_lo == sig.e_lo && output_hi == sig.e_hi;
     return valid;
 }
 
@@ -318,12 +312,14 @@ template point<plonk::TurboComposer> variable_base_mul<plonk::TurboComposer>(con
                                                                              const point<plonk::TurboComposer>&,
                                                                              const wnaf_record<plonk::TurboComposer>&);
 
-template bool verify_signature<plonk::TurboComposer>(const byte_array<plonk::TurboComposer>&,
-                                                     const point<plonk::TurboComposer>&,
-                                                     const signature_bits<plonk::TurboComposer>&);
-template bool verify_signature<plonk::UltraComposer>(const byte_array<plonk::UltraComposer>&,
-                                                     const point<plonk::UltraComposer>&,
-                                                     const signature_bits<plonk::UltraComposer>&);
+template bool_t<plonk::TurboComposer> verify_signature<plonk::TurboComposer>(
+    const byte_array<plonk::TurboComposer>&,
+    const point<plonk::TurboComposer>&,
+    const signature_bits<plonk::TurboComposer>&);
+template bool_t<plonk::UltraComposer> verify_signature<plonk::UltraComposer>(
+    const byte_array<plonk::UltraComposer>&,
+    const point<plonk::UltraComposer>&,
+    const signature_bits<plonk::UltraComposer>&);
 
 template signature_bits<plonk::TurboComposer> convert_signature<plonk::TurboComposer>(
     plonk::TurboComposer*, const crypto::schnorr::signature&);

--- a/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.cpp
+++ b/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.cpp
@@ -270,7 +270,7 @@ point<C> variable_base_mul(const point<C>& pub_key, const point<C>& current_accu
  * @details TurboPlonk: ~10850 gates (~4k for variable_base_mul, ~6k for blake2s) for a string of length < 32.
  */
 template <typename C>
-void verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig)
+bool verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig)
 {
     // Compute [s]g, where s = (s_lo, s_hi) and g = G1::one.
     point<C> R_1 = group<C>::fixed_base_scalar_mul(sig.s_lo, sig.s_hi);
@@ -295,6 +295,13 @@ void verify_signature(const byte_array<C>& message, const point<C>& pub_key, con
     field_t<C> output_lo(output.slice(16, 16));
     output_lo.assert_equal(sig.e_lo, "verify signature failed");
     output_hi.assert_equal(sig.e_hi, "verify signature failed");
+
+    // This is not secure because we want to constrain the
+    // `valid` variable to the two equalities below and not
+    // just return the value.
+    bool valid = (output_lo.get_value() == sig.e_lo.get_value());
+    valid = valid && (output_hi.get_value() == sig.e_hi.get_value());
+    return valid;
 }
 
 template wnaf_record<plonk::TurboComposer> convert_field_into_wnaf<plonk::TurboComposer>(
@@ -311,10 +318,10 @@ template point<plonk::TurboComposer> variable_base_mul<plonk::TurboComposer>(con
                                                                              const point<plonk::TurboComposer>&,
                                                                              const wnaf_record<plonk::TurboComposer>&);
 
-template void verify_signature<plonk::TurboComposer>(const byte_array<plonk::TurboComposer>&,
+template bool verify_signature<plonk::TurboComposer>(const byte_array<plonk::TurboComposer>&,
                                                      const point<plonk::TurboComposer>&,
                                                      const signature_bits<plonk::TurboComposer>&);
-template void verify_signature<plonk::UltraComposer>(const byte_array<plonk::UltraComposer>&,
+template bool verify_signature<plonk::UltraComposer>(const byte_array<plonk::UltraComposer>&,
                                                      const point<plonk::UltraComposer>&,
                                                      const signature_bits<plonk::UltraComposer>&);
 

--- a/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.hpp
+++ b/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.hpp
@@ -33,7 +33,7 @@ point<C> variable_base_mul(const point<C>& pub_key, const field_t<C>& low_bits, 
 template <typename C> signature_bits<C> convert_signature(C* context, const crypto::schnorr::signature& sig);
 
 template <typename C>
-bool verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig);
+bool_t<C> verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig);
 
 extern template point<plonk::TurboComposer> variable_base_mul<plonk::TurboComposer>(
     const point<plonk::TurboComposer>&, const point<plonk::TurboComposer>&, const wnaf_record<plonk::TurboComposer>&);
@@ -48,12 +48,14 @@ extern template wnaf_record<plonk::TurboComposer> convert_field_into_wnaf<plonk:
 extern template wnaf_record<plonk::UltraComposer> convert_field_into_wnaf<plonk::UltraComposer>(
     plonk::UltraComposer* context, const field_t<plonk::UltraComposer>& limb);
 
-extern template bool verify_signature<plonk::TurboComposer>(const byte_array<plonk::TurboComposer>&,
-                                                            const point<plonk::TurboComposer>&,
-                                                            const signature_bits<plonk::TurboComposer>&);
-extern template bool verify_signature<plonk::UltraComposer>(const byte_array<plonk::UltraComposer>&,
-                                                            const point<plonk::UltraComposer>&,
-                                                            const signature_bits<plonk::UltraComposer>&);
+extern template bool_t<plonk::TurboComposer> verify_signature<plonk::TurboComposer>(
+    const byte_array<plonk::TurboComposer>&,
+    const point<plonk::TurboComposer>&,
+    const signature_bits<plonk::TurboComposer>&);
+extern template bool_t<plonk::UltraComposer> verify_signature<plonk::UltraComposer>(
+    const byte_array<plonk::UltraComposer>&,
+    const point<plonk::UltraComposer>&,
+    const signature_bits<plonk::UltraComposer>&);
 
 extern template signature_bits<plonk::TurboComposer> convert_signature<plonk::TurboComposer>(
     plonk::TurboComposer*, const crypto::schnorr::signature&);

--- a/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.hpp
+++ b/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.hpp
@@ -33,7 +33,17 @@ point<C> variable_base_mul(const point<C>& pub_key, const field_t<C>& low_bits, 
 template <typename C> signature_bits<C> convert_signature(C* context, const crypto::schnorr::signature& sig);
 
 template <typename C>
-bool_t<C> verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig);
+std::array<field_t<C>, 2> verify_signature_internal(const byte_array<C>& message,
+                                                    const point<C>& pub_key,
+                                                    const signature_bits<C>& sig);
+
+template <typename C>
+void verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig);
+
+template <typename C>
+bool_t<C> signature_verification_result(const byte_array<C>& message,
+                                        const point<C>& pub_key,
+                                        const signature_bits<C>& sig);
 
 extern template point<plonk::TurboComposer> variable_base_mul<plonk::TurboComposer>(
     const point<plonk::TurboComposer>&, const point<plonk::TurboComposer>&, const wnaf_record<plonk::TurboComposer>&);
@@ -48,11 +58,27 @@ extern template wnaf_record<plonk::TurboComposer> convert_field_into_wnaf<plonk:
 extern template wnaf_record<plonk::UltraComposer> convert_field_into_wnaf<plonk::UltraComposer>(
     plonk::UltraComposer* context, const field_t<plonk::UltraComposer>& limb);
 
-extern template bool_t<plonk::TurboComposer> verify_signature<plonk::TurboComposer>(
+extern template std::array<field_t<plonk::TurboComposer>, 2> verify_signature_internal<plonk::TurboComposer>(
     const byte_array<plonk::TurboComposer>&,
     const point<plonk::TurboComposer>&,
     const signature_bits<plonk::TurboComposer>&);
-extern template bool_t<plonk::UltraComposer> verify_signature<plonk::UltraComposer>(
+extern template std::array<field_t<plonk::UltraComposer>, 2> verify_signature_internal<plonk::UltraComposer>(
+    const byte_array<plonk::UltraComposer>&,
+    const point<plonk::UltraComposer>&,
+    const signature_bits<plonk::UltraComposer>&);
+
+extern template void verify_signature<plonk::TurboComposer>(const byte_array<plonk::TurboComposer>&,
+                                                            const point<plonk::TurboComposer>&,
+                                                            const signature_bits<plonk::TurboComposer>&);
+extern template void verify_signature<plonk::UltraComposer>(const byte_array<plonk::UltraComposer>&,
+                                                            const point<plonk::UltraComposer>&,
+                                                            const signature_bits<plonk::UltraComposer>&);
+
+extern template bool_t<plonk::TurboComposer> signature_verification_result<plonk::TurboComposer>(
+    const byte_array<plonk::TurboComposer>&,
+    const point<plonk::TurboComposer>&,
+    const signature_bits<plonk::TurboComposer>&);
+extern template bool_t<plonk::UltraComposer> signature_verification_result<plonk::UltraComposer>(
     const byte_array<plonk::UltraComposer>&,
     const point<plonk::UltraComposer>&,
     const signature_bits<plonk::UltraComposer>&);

--- a/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.hpp
+++ b/cpp/src/aztec/stdlib/encryption/schnorr/schnorr.hpp
@@ -33,7 +33,7 @@ point<C> variable_base_mul(const point<C>& pub_key, const field_t<C>& low_bits, 
 template <typename C> signature_bits<C> convert_signature(C* context, const crypto::schnorr::signature& sig);
 
 template <typename C>
-void verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig);
+bool verify_signature(const byte_array<C>& message, const point<C>& pub_key, const signature_bits<C>& sig);
 
 extern template point<plonk::TurboComposer> variable_base_mul<plonk::TurboComposer>(
     const point<plonk::TurboComposer>&, const point<plonk::TurboComposer>&, const wnaf_record<plonk::TurboComposer>&);
@@ -48,10 +48,10 @@ extern template wnaf_record<plonk::TurboComposer> convert_field_into_wnaf<plonk:
 extern template wnaf_record<plonk::UltraComposer> convert_field_into_wnaf<plonk::UltraComposer>(
     plonk::UltraComposer* context, const field_t<plonk::UltraComposer>& limb);
 
-extern template void verify_signature<plonk::TurboComposer>(const byte_array<plonk::TurboComposer>&,
+extern template bool verify_signature<plonk::TurboComposer>(const byte_array<plonk::TurboComposer>&,
                                                             const point<plonk::TurboComposer>&,
                                                             const signature_bits<plonk::TurboComposer>&);
-extern template void verify_signature<plonk::UltraComposer>(const byte_array<plonk::UltraComposer>&,
+extern template bool verify_signature<plonk::UltraComposer>(const byte_array<plonk::UltraComposer>&,
                                                             const point<plonk::UltraComposer>&,
                                                             const signature_bits<plonk::UltraComposer>&);
 


### PR DESCRIPTION
# Description

Noir needs `verify_signature` in the schnorr stdlib to return a `bool_t` indicating whether the signature was valid or not.

Currently a draft because I tried to update @kevaundray's code to add a constraint but I have no idea if I did it correctly.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
