### PR TITLE
Switch to Turbo Temporarily.

### DIFF
--- a/cpp/src/aztec/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/cpp/src/aztec/join_split_example/proofs/join_split/join_split.test.cpp
@@ -700,7 +700,7 @@ TEST_F(join_split_tests, test_0_input_notes_and_detect_circuit_change)
     // The below part detects any changes in the join-split circuit
     constexpr uint32_t CIRCUIT_GATE_COUNT = 59175;
     constexpr uint32_t GATES_NEXT_POWER_OF_TWO = 65536;
-    const uint256_t VK_HASH("7c5f17b829f8a6b17292a998ec06b2481abb82923e838d7422c3aec5cd5edd95");
+    const uint256_t VK_HASH("476d4ccd2ee8355dc24bf2d0afcaeeea97e7ac5df736a4739035703f1666e926");
 
     auto number_of_gates_js = result.number_of_gates;
     auto vk_hash_js = get_verification_key()->sha256_hash();

--- a/cpp/src/aztec/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/cpp/src/aztec/join_split_example/proofs/join_split/join_split.test.cpp
@@ -698,7 +698,7 @@ TEST_F(join_split_tests, test_0_input_notes_and_detect_circuit_change)
     EXPECT_TRUE(result.valid);
 
     // The below part detects any changes in the join-split circuit
-    constexpr uint32_t CIRCUIT_GATE_COUNT = 59175;
+    constexpr uint32_t CIRCUIT_GATE_COUNT = 64000;
     constexpr uint32_t GATES_NEXT_POWER_OF_TWO = 65536;
     const uint256_t VK_HASH("476d4ccd2ee8355dc24bf2d0afcaeeea97e7ac5df736a4739035703f1666e926");
 

--- a/cpp/src/aztec/plonk/proof_system/constants.hpp
+++ b/cpp/src/aztec/plonk/proof_system/constants.hpp
@@ -13,7 +13,7 @@ enum ComposerType {
 // This variable sets the composer (TURBO or ULTRA) of the entire stdlib and rollup modules.
 // To switch to using a new composer, only changing this variable should activate the new composer
 // throughout the stdlib and circuits.
-static constexpr uint32_t SYSTEM_COMPOSER = ComposerType::PLOOKUP;
+static constexpr uint32_t SYSTEM_COMPOSER = ComposerType::TURBO;
 
 namespace merkle {
 enum HashType {

--- a/cpp/src/aztec/stdlib/merkle_tree/hash.hpp
+++ b/cpp/src/aztec/stdlib/merkle_tree/hash.hpp
@@ -15,7 +15,11 @@ namespace merkle_tree {
 
 inline barretenberg::fr compress_native(barretenberg::fr const& lhs, barretenberg::fr const& rhs)
 {
-    return crypto::pedersen_hash::lookup::hash_multiple({ lhs, rhs });
+    if (waffle::SYSTEM_COMPOSER == waffle::PLOOKUP) {
+        return crypto::pedersen_hash::lookup::hash_multiple({ lhs, rhs });
+    } else {
+        return crypto::pedersen_hash::hash_multiple({ lhs, rhs });
+    }
 }
 
 } // namespace merkle_tree

--- a/cpp/src/aztec/stdlib/merkle_tree/hash.test.cpp
+++ b/cpp/src/aztec/stdlib/merkle_tree/hash.test.cpp
@@ -12,6 +12,10 @@ TEST(stdlib_merkle_tree_hash, compress_native_vs_circuit)
     Composer composer = Composer();
     witness_ct y = witness_ct(&composer, x);
     field_ct z = plonk::stdlib::pedersen_hash<Composer>::hash_multiple({ y, y });
-    auto zz = crypto::pedersen_hash::lookup::hash_multiple({ x, x });
+    auto zz = crypto::pedersen_hash::hash_multiple({ x, x }); // uses fixed-base multiplication gate
+    if constexpr (Composer::type == waffle::ComposerType::PLOOKUP) {
+        zz = crypto::pedersen_hash::lookup::hash_multiple({ x, x }); // uses lookup tables
+    }
+
     EXPECT_EQ(z.get_value(), zz);
 }


### PR DESCRIPTION
# Description

The private kernel circuit in aztec3-circuits repository fails with UltraPlonk. So we are switching back to TurboComposer for testing and developing private kernel circuit. Parallely, I'm working to get that test working with ultraplonk so that we can move to ultraplonk sooner.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
