### PR TITLE
fix: Check for wasm-opt during configure & run on post_build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - clang >= 10 or gcc >= 10
 - clang-format
 - libomp (if multithreading is required. Multithreading can be disabled using the compiler flag `-DMULTITHREADING 0`)
+- wasm-opt (part of the [Binaryen](https://github.com/WebAssembly/binaryen) toolkit)
 
 ### Installing openMP (Linux)
 

--- a/cpp/src/aztec/CMakeLists.txt
+++ b/cpp/src/aztec/CMakeLists.txt
@@ -62,7 +62,7 @@ if(WASM)
     # that as functions in 'env' should be implemented in JS itself.
     # It turns out that just explicitly telling the wasm module which object files to include was easiest.
     add_executable(
-        barretenberg-step1.wasm
+        barretenberg.wasm
         $<TARGET_OBJECTS:srs_objects>
         $<TARGET_OBJECTS:numeric_objects>
         $<TARGET_OBJECTS:crypto_sha256_objects>
@@ -88,22 +88,23 @@ if(WASM)
     # Presumably the -O3 when compiling the object files is fine as it's llvms IR optimiser.
     # The backend optimiser is presumably triggered after linking.
     target_link_options(
-        barretenberg-step1.wasm
+        barretenberg.wasm
         PRIVATE
         -nostartfiles -O2 -Wl,--no-entry -Wl,--export-dynamic -Wl,--import-memory -Wl,--allow-undefined -Wl,--stack-first -Wl,-z,stack-size=1048576
     )
 
+    find_program(WASM_OPT wasm-opt)
+    if(NOT WASM_OPT)
+        message(FATAL_ERROR "wasm-opt executable not found. Please install binaryen.")
+    endif()
+
     add_custom_command(
-        OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/barretenberg.wasm
-        COMMAND wasm-opt ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/barretenberg-step1.wasm -O2 --asyncify -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/barretenberg.wasm
-        DEPENDS barretenberg-step1.wasm
+        TARGET barretenberg.wasm
+        POST_BUILD
+        COMMAND wasm-opt "$<TARGET_FILE:barretenberg.wasm>" -O2 --asyncify -o "$<TARGET_FILE:barretenberg.wasm>"
         VERBATIM
     )
 
-    add_custom_target(
-        barretenberg.wasm
-        DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/barretenberg.wasm
-    )
     # For use when compiling dependent cpp projects for WASM
     message(STATUS "Compiling all-in-one barretenberg WASM archive")
     add_library(


### PR DESCRIPTION
# Description

This PR makes the wasm-opt dependency more explicit. It is now referenced as a dependency since the wasm build fails without it. I've also added a `find_program` call to ensure it is installed during the configure phase for a wasm build; otherwise you'd get to the very end and it would crash.

I've changed the executable target to be `barretenberg.wasm` and then used the [`TARGET` variant](https://cmake.org/cmake/help/latest/command/add_custom_command.html#build-events) of `add_custom_command` so the wasm-opt command isn't run if `barretenberg.wasm` is already built. The previous way of doing this created a target that was always stale.

This should enable adding the wasm binary as an installation target, which is not possible with custom targets.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
