### PR TITLE
Reindex MLE variables

### DIFF
--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -338,7 +338,7 @@ template <typename settings> void Prover<settings>::execute_univariatization_rou
     using MLEOpeningClaim = pcs::MLEOpeningClaim<pcs::kzg::Params>;
 
     // Construct inputs for Gemini:
-    // - Multivariate opening point u = (u_1, ..., u_d)
+    // - Multivariate opening point u = (u_0, ..., u_{d-1})
     // - MLE opening claim = {commitment, eval} for each multivariate and shifted multivariate polynomial
     // - Pointers to multivariate and shifted multivariate polynomials
     std::vector<Fr> opening_point;
@@ -348,9 +348,8 @@ template <typename settings> void Prover<settings>::execute_univariatization_rou
     std::vector<std::span<Fr>> multivariate_polynomials_shifted;
 
     // Construct MLE opening point
-    // Note: for consistency the evaluation point must be constructed as u = (u_d,...,u_1)
     for (size_t round_idx = 0; round_idx < key->log_circuit_size; round_idx++) {
-        std::string label = "u_" + std::to_string(key->log_circuit_size - round_idx);
+        std::string label = "u_" + std::to_string(round_idx);
         opening_point.emplace_back(transcript.get_challenge_field_element(label));
     }
 

--- a/cpp/src/aztec/honk/proof_system/verifier.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.cpp
@@ -121,7 +121,7 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
     transcript.apply_fiat_shamir("beta");
     transcript.apply_fiat_shamir("alpha");
     for (size_t idx = 0; idx < log_n; idx++) {
-        transcript.apply_fiat_shamir("u_" + std::to_string(log_n - idx));
+        transcript.apply_fiat_shamir("u_" + std::to_string(idx));
     }
     transcript.apply_fiat_shamir("rho");
     transcript.apply_fiat_shamir("r");
@@ -142,16 +142,16 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
     // Execute Gemini/Shplonk verification:
 
     // Construct inputs for Gemini verifier:
-    // - Multivariate opening point u = (u_1, ..., u_d)
+    // - Multivariate opening point u = (u_0, ..., u_{d-1})
     // - MLE opening claim = {commitment, eval} for each multivariate and shifted multivariate polynomial
     std::vector<FF> opening_point;
     std::vector<MLEOpeningClaim> opening_claims;
     std::vector<MLEOpeningClaim> opening_claims_shifted;
 
     // Construct MLE opening point
-    // Note: for consistency the evaluation point must be constructed as u = (u_d,...,u_1)
+    // Note: for consistency the evaluation point must be constructed as u = (u_0,...,u_{d-1})
     for (size_t round_idx = 0; round_idx < key->log_circuit_size; round_idx++) {
-        std::string label = "u_" + std::to_string(key->log_circuit_size - round_idx);
+        std::string label = "u_" + std::to_string(round_idx);
         opening_point.emplace_back(transcript.get_challenge_field_element(label));
     }
 

--- a/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/multivariates.test.cpp
@@ -17,24 +17,30 @@ TYPED_TEST_SUITE(MultivariatesTests, FieldTypes);
 #define MULTIVARIATES_TESTS_TYPE_ALIASES using FF = TypeParam;
 
 /*
- * We represent a bivariate f0 as f0(X1, X2). The indexing starts from 1 to match with the round number in sumcheck.
- * The idea is variable X2 (lsb) will be folded at round 2 (the first sumcheck round),
+ * We represent a bivariate f0 as f0(X0, X1). The indexing starts from 0 to match with the round number in sumcheck.
+ * The idea is variable X0 (lsb) will be folded at round 2 (the first sumcheck round),
  * then the variable X1 (msb) will be folded at round 1 (the last rond in this case). Pictorially we have,
  *          v10 ------ v11
  *           |          |
- *   X1(msb) |          |
- *           |  X2(lsb) |
+ *   X0(lsb) |          |
+ *           |  X1(msb) |
  *          v00 ------ v01
- * f0(X1, X2) = v00 * (1-X1)(1-X2) + v01 * (1-X1) * X2 + v10 * X1)(1-X2) + v11 * X1 * X2.
+ * f0(X0, X1) = v00 * (1-X0) * (1-X1)
+ *            + v10 *   X0   * (1-X1)
+ *            + v01 * (1-X0) *   X1
+ *            + v11 *   X0   *   X1.
  *
  * To effectively represent folding we write,
- * f0(X1, X2) = [v00 * (1-X2) + v01 * X2] * (1-X1) + [v10 * (1-X2) + v11 * X2] * X1.
+ * f0(X0, X1) = [v00 * (1-X0) + v10 * X0] * (1-X1)
+ *            + [v01 * (1-X0) + v11 * X0] *   X1.
  *
- * After folding at round 2 (round challenge u2), we have,
- * f0(X1,u2) = (v00 * (1-u2) + v01 * u2) * (1-X1) + (v11 * u2 + v10 * (1-u2)) * X1.
+ * After folding at round 0 (round challenge u0), we have,
+ * f0(u0,X1) = (v00 * (1-u0) + v10 * u0) * (1-X1)
+ *           + (v01 * (1-u0) + v11 * u0) *   X1.
  *
  * After folding at round 1 (round challenge u1), we have,
- * f0(u1,u2) = (v00 * (1-u2) + v01 * u2) * (1-u1) + (v11 * u2 + v10 * (1-u2)) * u1.
+ * f0(u0,u1) = (v00 * (1-u0) + v10 * u0) * (1-u1)
+ *           + (v01 * (1-u0) + v11 * u0) *   u1.
  */
 TYPED_TEST(MultivariatesTests, FoldTwoRoundsSpecial)
 {
@@ -45,24 +51,24 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsSpecial)
     const size_t multivariate_n(1 << multivariate_d);
 
     FF v00 = 0;
-    FF v01 = 1;
-    FF v10 = 0;
+    FF v10 = 1;
+    FF v01 = 0;
     FF v11 = 0;
 
-    std::array<FF, 4> f0 = { v00, v01, v10, v11 };
+    std::array<FF, 4> f0 = { v00, v10, v01, v11 };
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript(transcript::Manifest());
     auto sumcheck = Sumcheck<FF, Transcript, ArithmeticRelation>(multivariate_n, transcript);
 
-    FF round_challenge_2 = { 0x6c7301b49d85a46c, 0x44311531e39c64f6, 0xb13d66d8d6c1a24c, 0x04410c360230a295 };
-    round_challenge_2.self_to_montgomery_form();
-    FF expected_lo = v00 * (FF(1) - round_challenge_2) + v01 * round_challenge_2;
-    FF expected_hi = v11 * round_challenge_2 + v10 * (FF(1) - round_challenge_2);
+    FF round_challenge_0 = { 0x6c7301b49d85a46c, 0x44311531e39c64f6, 0xb13d66d8d6c1a24c, 0x04410c360230a295 };
+    round_challenge_0.self_to_montgomery_form();
+    FF expected_lo = v00 * (FF(1) - round_challenge_0) + v10 * round_challenge_0;
+    FF expected_hi = v01 * (FF(1) - round_challenge_0) + v11 * round_challenge_0;
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_2);
+    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], round_challenge_2);
+    EXPECT_EQ(sumcheck.folded_polynomials[0][0], round_challenge_0);
     EXPECT_EQ(sumcheck.folded_polynomials[0][1], FF(0));
 
     FF round_challenge_1 = 2;
@@ -80,21 +86,21 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsGeneric)
     const size_t multivariate_n(1 << multivariate_d);
 
     FF v00 = FF::random_element();
-    FF v01 = FF::random_element();
     FF v10 = FF::random_element();
+    FF v01 = FF::random_element();
     FF v11 = FF::random_element();
 
-    std::array<FF, 4> f0 = { v00, v01, v10, v11 };
+    std::array<FF, 4> f0 = { v00, v10, v01, v11 };
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript(transcript::Manifest());
     auto sumcheck = Sumcheck<FF, Transcript, ArithmeticRelation>(multivariate_n, transcript);
 
-    FF round_challenge_2 = FF::random_element();
-    FF expected_lo = v00 * (FF(1) - round_challenge_2) + v01 * round_challenge_2;
-    FF expected_hi = v11 * round_challenge_2 + v10 * (FF(1) - round_challenge_2);
+    FF round_challenge_0 = FF::random_element();
+    FF expected_lo = v00 * (FF(1) - round_challenge_0) + v10 * round_challenge_0;
+    FF expected_hi = v01 * (FF(1) - round_challenge_0) + v11 * round_challenge_0;
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_2);
+    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
     EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_lo);
     EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_hi);
@@ -106,19 +112,26 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsGeneric)
 }
 
 /*
- * Similarly for a trivariate polynomial f0(X1, X2, X3), we have
- * f0(X1, X2, X3) = v000 * (1-X1) * (1-X2) * (1-X3) + v001 * (1-X1) * (1-X2) * X3 + v010 * (1-X1) * X2 * (1-X3) +
- * v011(1-X1)* X2 * X3 + v100 * X1 * (1-X2) * (1-X3) + v101 * X1 * (1-X2) * X3 + v110 * X1 * X2 * (1-X3) + v111 * X1 *
- * X2 * X3.
- * After the third round (round challenge u3), we have
- *  f0(X1, X2, u3) = [v000 * (1-u3) + v001 * u3] * (1-X1) * (1-X2) + [v010 * (1-u3) + v011 * u3] * (1-X1) * X2
- *                  + [v100 * (1-u3) + v101 * u3] * X1 * (1-X2) + [v110 * (1-u3) + v111 * u3] * X1 * X2.
- * After the second round (round challenge u2), we have
- * f0(X1, u2, u3) = [(v000 * (1-u3) + v001 * u3) * (1-u2) + (v010 * (1-u3) + v011 * u3) * u2] * (1-X1)
- *                  + [(v100 * (1-u3) + v101 * u3) * (1-u2) + (v110 * (1-u3) + v111 * u3) * u2] * X1.
- * After the first round (round challenge u1), we have
- * f0(u1, u2, u3) = [v000 * (1-u3) * (1-u2) + v001 * u3 * (1-u2) + v010 * (1-u3) * u2 + v011 * u3 * u2] * (1-u3)
- *                  + [v100 * (1-u3) * (1-u2) + v101 * u3 * (1-u2) + v110 * (1-u3) * u2 + v111 * u3 * u2] * u3.
+ * Similarly for a trivariate polynomial f0(X0, X1, X2), we have
+ * f0(X0, X1, X2) = v000 * (1-X0) * (1-X1) * (1-X2)
+ *                + v100 *   X0   * (1-X1) * (1-X2)
+ *                + v010 * (1-X0) *   X1   * (1-X2)
+ *                + v110 *   X0   *   X1   * (1-X2)
+ *                + v001 * (1-X0) * (1-X1) *   X2
+ *                + v101 *   X0   * (1-X1) *   X2
+ *                + v011 * (1-X0) *   X1   *   X2
+ *                + v111 *   X0   *   X1   *   X2.
+ * After round 0 (round challenge u0), we have
+ *  f0(u0, X1, X2) = [v000 * (1-u0) + v100 * u0] * (1-X1) * (1-X2)
+ *                 + [v010 * (1-u0) + v110 * u0] *   X1   * (1-X2)
+ *                 + [v001 * (1-u0) + v101 * u0] * (1-X1) *   X2
+ *                 + [v011 * (1-u0) + v111 * u0] *   X1   *   X2.
+ * After round 1 (round challenge u1), we have
+ * f0(u0, u1, X2) = [(v000 * (1-u0) + v100 * u0) * (1-u1) + (v010 * (1-u0) + v110 * u0) * u1] * (1-X2)
+ *                + [(v001 * (1-u0) + v101 * u0) * (1-u1) + (v011 * (1-u0) + v111 * u0) * u1] *   X2.
+ * After round 2 (round challenge u2), we have
+ * f0(u0, u1, u2) = [(v000 * (1-u0) + v100 * u0) * (1-u1) + (v010 * (1-u0) + v110 * u0) * u1] * (1-u2)
+ *                + [(v001 * (1-u0) + v101 * u0) * (1-u1) + (v011 * (1-u0) + v111 * u0) * u1] *   u2.
  */
 TYPED_TEST(MultivariatesTests, FoldThreeRoundsSpecial)
 {
@@ -128,44 +141,44 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsSpecial)
     const size_t multivariate_n(1 << multivariate_d);
 
     FF v000 = 1;
-    FF v001 = 2;
+    FF v100 = 2;
     FF v010 = 3;
-    FF v011 = 4;
-    FF v100 = 5;
+    FF v110 = 4;
+    FF v001 = 5;
     FF v101 = 6;
-    FF v110 = 7;
+    FF v011 = 7;
     FF v111 = 8;
 
-    std::array<FF, 8> f0 = { v000, v001, v010, v011, v100, v101, v110, v111 };
+    std::array<FF, 8> f0 = { v000, v100, v010, v110, v001, v101, v011, v111 };
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript(transcript::Manifest());
     auto sumcheck = Sumcheck<FF, Transcript, ArithmeticRelation>(multivariate_n, transcript);
 
-    FF round_challenge_3 = 1;
-    FF expected_q1 = v000 * (FF(1) - round_challenge_3) + v001 * round_challenge_3; // 2
-    FF expected_q2 = v010 * (FF(1) - round_challenge_3) + v011 * round_challenge_3; // 4
-    FF expected_q3 = v100 * (FF(1) - round_challenge_3) + v101 * round_challenge_3; // 6
-    FF expected_q4 = v110 * (FF(1) - round_challenge_3) + v111 * round_challenge_3; // 8
+    FF round_challenge_0 = 1;
+    FF expected_q1 = v000 * (FF(1) - round_challenge_0) + v100 * round_challenge_0; // 2
+    FF expected_q2 = v010 * (FF(1) - round_challenge_0) + v110 * round_challenge_0; // 4
+    FF expected_q3 = v001 * (FF(1) - round_challenge_0) + v101 * round_challenge_0; // 6
+    FF expected_q4 = v011 * (FF(1) - round_challenge_0) + v111 * round_challenge_0; // 8
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_3);
+    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
     EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_q1);
     EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_q2);
     EXPECT_EQ(sumcheck.folded_polynomials[0][2], expected_q3);
     EXPECT_EQ(sumcheck.folded_polynomials[0][3], expected_q4);
 
-    FF round_challenge_2 = 2;
-    FF expected_lo = expected_q1 * (FF(1) - round_challenge_2) + expected_q2 * round_challenge_2; // 6
-    FF expected_hi = expected_q3 * (FF(1) - round_challenge_2) + expected_q4 * round_challenge_2; // 10
+    FF round_challenge_1 = 2;
+    FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1; // 6
+    FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1; // 10
 
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_2);
+    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
     EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_lo);
     EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_hi);
 
-    FF round_challenge_1 = 3;
-    FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1; // 18
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_1);
+    FF round_challenge_2 = 3;
+    FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2; // 18
+    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_2);
     EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_val);
 }
 
@@ -177,44 +190,44 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGeneric)
     const size_t multivariate_n(1 << multivariate_d);
 
     FF v000 = FF::random_element();
-    FF v001 = FF::random_element();
-    FF v010 = FF::random_element();
-    FF v011 = FF::random_element();
     FF v100 = FF::random_element();
-    FF v101 = FF::random_element();
+    FF v010 = FF::random_element();
     FF v110 = FF::random_element();
+    FF v001 = FF::random_element();
+    FF v101 = FF::random_element();
+    FF v011 = FF::random_element();
     FF v111 = FF::random_element();
 
-    std::array<FF, 8> f0 = { v000, v001, v010, v011, v100, v101, v110, v111 };
+    std::array<FF, 8> f0 = { v000, v100, v010, v110, v001, v101, v011, v111 };
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript(transcript::Manifest());
     auto sumcheck = Sumcheck<FF, Transcript, ArithmeticRelation>(multivariate_n, transcript);
 
-    FF round_challenge_3 = FF::random_element();
-    FF expected_q1 = v000 * (FF(1) - round_challenge_3) + v001 * round_challenge_3;
-    FF expected_q2 = v010 * (FF(1) - round_challenge_3) + v011 * round_challenge_3;
-    FF expected_q3 = v100 * (FF(1) - round_challenge_3) + v101 * round_challenge_3;
-    FF expected_q4 = v110 * (FF(1) - round_challenge_3) + v111 * round_challenge_3;
+    FF round_challenge_0 = FF::random_element();
+    FF expected_q1 = v000 * (FF(1) - round_challenge_0) + v100 * round_challenge_0;
+    FF expected_q2 = v010 * (FF(1) - round_challenge_0) + v110 * round_challenge_0;
+    FF expected_q3 = v001 * (FF(1) - round_challenge_0) + v101 * round_challenge_0;
+    FF expected_q4 = v011 * (FF(1) - round_challenge_0) + v111 * round_challenge_0;
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_3);
+    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
     EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_q1);
     EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_q2);
     EXPECT_EQ(sumcheck.folded_polynomials[0][2], expected_q3);
     EXPECT_EQ(sumcheck.folded_polynomials[0][3], expected_q4);
 
-    FF round_challenge_2 = FF::random_element();
-    FF expected_lo = expected_q1 * (FF(1) - round_challenge_2) + expected_q2 * round_challenge_2;
-    FF expected_hi = expected_q3 * (FF(1) - round_challenge_2) + expected_q4 * round_challenge_2;
+    FF round_challenge_1 = FF::random_element();
+    FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1;
+    FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1;
 
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_2);
+    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
     EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_lo);
     EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_hi);
 
-    FF round_challenge_1 = FF::random_element();
-    FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_1);
+    FF round_challenge_2 = FF::random_element();
+    FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2;
+    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_2);
     EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_val);
 }
 
@@ -224,27 +237,27 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
     const size_t multivariate_d(3);
     const size_t multivariate_n(1 << multivariate_d);
     std::array<FF, 3> v000;
-    std::array<FF, 3> v001;
-    std::array<FF, 3> v010;
-    std::array<FF, 3> v011;
     std::array<FF, 3> v100;
-    std::array<FF, 3> v101;
+    std::array<FF, 3> v010;
     std::array<FF, 3> v110;
+    std::array<FF, 3> v001;
+    std::array<FF, 3> v101;
+    std::array<FF, 3> v011;
     std::array<FF, 3> v111;
 
     for (size_t i = 0; i < 3; i++) {
         v000[i] = FF::random_element();
-        v001[i] = FF::random_element();
-        v010[i] = FF::random_element();
-        v011[i] = FF::random_element();
         v100[i] = FF::random_element();
-        v101[i] = FF::random_element();
+        v010[i] = FF::random_element();
         v110[i] = FF::random_element();
+        v001[i] = FF::random_element();
+        v101[i] = FF::random_element();
+        v011[i] = FF::random_element();
         v111[i] = FF::random_element();
     }
-    std::array<FF, 8> f0 = { v000[0], v001[0], v010[0], v011[0], v100[0], v101[0], v110[0], v111[0] };
-    std::array<FF, 8> f1 = { v000[1], v001[1], v010[1], v011[1], v100[1], v101[1], v110[1], v111[1] };
-    std::array<FF, 8> f2 = { v000[2], v001[2], v010[2], v011[2], v100[2], v101[2], v110[2], v111[2] };
+    std::array<FF, 8> f0 = { v000[0], v100[0], v010[0], v110[0], v001[0], v101[0], v011[0], v111[0] };
+    std::array<FF, 8> f1 = { v000[1], v100[1], v010[1], v110[1], v001[1], v101[1], v011[1], v111[1] };
+    std::array<FF, 8> f2 = { v000[2], v100[2], v010[2], v110[2], v001[2], v101[2], v011[2], v111[2] };
 
     auto full_polynomials = std::array<std::span<FF>, 3>{ f0, f1, f2 };
     auto transcript = Transcript(transcript::Manifest());
@@ -254,15 +267,15 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
     std::array<FF, 3> expected_q2;
     std::array<FF, 3> expected_q3;
     std::array<FF, 3> expected_q4;
-    FF round_challenge_3 = FF::random_element();
+    FF round_challenge_0 = FF::random_element();
     for (size_t i = 0; i < 3; i++) {
-        expected_q1[i] = v000[i] * (FF(1) - round_challenge_3) + v001[i] * round_challenge_3;
-        expected_q2[i] = v010[i] * (FF(1) - round_challenge_3) + v011[i] * round_challenge_3;
-        expected_q3[i] = v100[i] * (FF(1) - round_challenge_3) + v101[i] * round_challenge_3;
-        expected_q4[i] = v110[i] * (FF(1) - round_challenge_3) + v111[i] * round_challenge_3;
+        expected_q1[i] = v000[i] * (FF(1) - round_challenge_0) + v100[i] * round_challenge_0;
+        expected_q2[i] = v010[i] * (FF(1) - round_challenge_0) + v110[i] * round_challenge_0;
+        expected_q3[i] = v001[i] * (FF(1) - round_challenge_0) + v101[i] * round_challenge_0;
+        expected_q4[i] = v011[i] * (FF(1) - round_challenge_0) + v111[i] * round_challenge_0;
     }
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_3);
+    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ(sumcheck.folded_polynomials[i][0], expected_q1[i]);
         EXPECT_EQ(sumcheck.folded_polynomials[i][1], expected_q2[i]);
@@ -270,24 +283,24 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
         EXPECT_EQ(sumcheck.folded_polynomials[i][3], expected_q4[i]);
     }
 
-    FF round_challenge_2 = FF::random_element();
+    FF round_challenge_1 = FF::random_element();
     std::array<FF, 3> expected_lo;
     std::array<FF, 3> expected_hi;
     for (size_t i = 0; i < 3; i++) {
-        expected_lo[i] = expected_q1[i] * (FF(1) - round_challenge_2) + expected_q2[i] * round_challenge_2;
-        expected_hi[i] = expected_q3[i] * (FF(1) - round_challenge_2) + expected_q4[i] * round_challenge_2;
+        expected_lo[i] = expected_q1[i] * (FF(1) - round_challenge_1) + expected_q2[i] * round_challenge_1;
+        expected_hi[i] = expected_q3[i] * (FF(1) - round_challenge_1) + expected_q4[i] * round_challenge_1;
     }
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_2);
+    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ(sumcheck.folded_polynomials[i][0], expected_lo[i]);
         EXPECT_EQ(sumcheck.folded_polynomials[i][1], expected_hi[i]);
     }
-    FF round_challenge_1 = FF::random_element();
+    FF round_challenge_2 = FF::random_element();
     std::array<FF, 3> expected_val;
     for (size_t i = 0; i < 3; i++) {
-        expected_val[i] = expected_lo[i] * (FF(1) - round_challenge_1) + expected_hi[i] * round_challenge_1;
+        expected_val[i] = expected_lo[i] * (FF(1) - round_challenge_2) + expected_hi[i] * round_challenge_2;
     }
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_1);
+    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_2);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ(sumcheck.folded_polynomials[i][0], expected_val[i]);
     }

--- a/cpp/src/aztec/honk/sumcheck/polynomials/pow.hpp
+++ b/cpp/src/aztec/honk/sumcheck/polynomials/pow.hpp
@@ -4,101 +4,107 @@ namespace honk::sumcheck {
 
 /**
  * @brief Succinct representation of the `pow` polynomial that can be partially evaluated variable-by-variable.
- * pow(X) = ∏_{0≤l<d} ((1−Xₗ) + Xₗ⋅ζₗ)
+ * pow(X) = ∏_{0≤l<d} ((1−X_l) + X_l⋅ζ_l)
  *
  * @details Let
  * - d be the number of variables
- * - l be the current Sumcheck round ( l ∈ {d-1, …, 0} )
- * - u_{d-1}, ..., u_{l+1} the challenges sent by the verifier in rounds d-1 to l+1.
+ * - l be the current Sumcheck round ( l ∈ {0, …, d-1} )
+ * - u_{0}, ..., u_{l-1} the challenges sent by the verifier in rounds 0 to l-1.
  *
  * We define
  *
- * - ζ_{0}, ..., ζ_{d-1}, as ζ_{l} = ζ^{ 2^{d-l-1} }.
+ * - ζ_{0}, ..., ζ_{d-1}, as ζ_{l} = ζ^{ 2^l }.
  *   When 0 ≤ i < 2^d is represented in bits [i_{0}, ..., i_{d-1}] where i_{0} is the MSB, we have
- *   ζ^{i} = ζ^{ ∑_{0≤l<d} i_{l}⋅2^{d-l-1} }
- *         =     ∏_{0≤l<d} ζ^{ i_{l}⋅2^{d-l-1} }
- *         =     ∏_{0≤l<d} ζ_{l}^{ i_{l} }
- *         =     ∏_{0≤l<d} ( (1-i_{l}) + i_{l}⋅ζ_{l} )
+ *   ζ^{i} = ζ^{ ∑_{0≤l<d} i_l ⋅ 2^l }
+ *         =     ∏_{0≤l<d} ζ^{ i_l ⋅ 2^l }
+ *         =     ∏_{0≤l<d} ζ_l^{ i_l }
+ *         =     ∏_{0≤l<d} { ( 1-i_l ) + i_l ⋅ ζ_l }
  *   Note that
- *   - ζ_{d-1} = ζ,
- *   - ζ_{l-1} = ζ_{l}^2,
- *   - ζ_{0}   = ζ^{ 2^{d-1} }
+ *   - ζ_{0} = ζ,
+ *   - ζ_{l+1} = ζ_{l}^2,
+ *   - ζ_{d-1}   = ζ^{ 2^{d-1} }
  *
- * - pow(X) = ∏_{0≤l<d} ((1−Xₗ) + Xₗ⋅ζₗ) is the multi-linear polynomial whose evaluation at the i-th index
+ * - pow(X) = ∏_{0≤l<d} ((1−X_l) + X_l⋅ζ_l) is the multi-linear polynomial whose evaluation at the i-th index
  *   of the full hypercube, equals ζⁱ.
  *   We can also see it as the multi-linear extension of the vector (1, ζ, ζ², ...).
  *
- * - powˡᵢ( X_{l} ) = pow( i_{0}, ..., i_{l-1},
+ * - At round l, we iterate over all remaining vertices (i_{l+1}, ..., i_{d-1}) ∈ {0,1}^{d-l-1}.
+ *   Let i = ∑_{l<k<d} i_k ⋅ 2^{k-(l+1)} be the index of the current edge over which we are evaluating the relation.
+ *   We define the edge univariate for the pow polynomial as powˡᵢ( X_l ) and it can be represented as:
+ *
+ *   powˡᵢ( X_{l} ) = pow( u_{0}, ..., u_{l-1},
  *                         X_{l},
- *                         u_{l+1}, ..., u_{d-1} )
- *                  = ∏_{0≤k<l} ( (1-iₖ) + iₖ⋅ζₖ )
- *                             ⋅( (1−Xₗ) + Xₗ⋅ζₗ )
- *                    ∏_{l<k<d} ( (1-uₖ) + uₖ⋅ζₖ )
- *                  = ζ^{2^{d-l}}^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ
- *                  = ζ_{  l-1  }^{i} ⋅ ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ cₗ,
+ *                         i_{l+1}, ..., i_{d-1})
+ *                  = ∏_{0≤k<l} ( (1-u_k) + u_k⋅ζ_k )
+ *                             ⋅( (1−X_l) + X_l⋅ζ_l )
+ *                    ∏_{l<k<d} ( (1-i_k) + i_k⋅ζ_k )
+ *                  = c_l ⋅ ( (1−X_l) + X_l⋅ζ^{2^l} ) ⋅ ∏_{l<k<d} ( (1-i_k) + i_k⋅ζ^{2^k} )
+ *                  = c_l ⋅ ( (1−X_l) + X_l⋅ζ^{2^l} ) ⋅ ζ^{ ∑_{l<k<d} i_k ⋅ 2^k }
+ *                  = c_l ⋅ ( (1−X_l) + X_l⋅ζ^{2^l} ) ⋅(ζ^2^{l+1})^{ ∑_{l<k<d} i_k ⋅ 2^{k-(l+1)} }
+ *                  = c_l ⋅ ( (1−X_l) + X_l⋅ζ^{2^l} ) ⋅ζ_{l+1}^{i}
  *
  *   This is the pow polynomial, partially evaluated in
- *     (X_{l+1}, ..., X_{d-1}) = (u_{l+1}, ..., u_{d-1}),
- *   at the index 0 ≤ i < 2ˡ of the dimension-l hypercube.
+ *     (X_{0}, ..., X_{l-1}) = (u_{0}, ..., u_{l-1}),
+ *   at the index 0 ≤ i < 2^{d-l-1} of the dimension-{d-l-1} hypercube.
  *
- * - Sˡᵢ( Xₗ ) is the univariate of the full relation at edge pair i
- * i.e. it is the alpha-linear-combination of the relations evaluated in the i-th edge.
+ * - Sˡᵢ( X_l ) is the univariate of the full relation at edge pair i
+ * i.e. it is the alpha-linear-combination of the relations evaluated in the edge at index i.
  * If our composed Sumcheck relation is a multi-variate polynomial P(X_{0}, ..., X_{d-1}),
- * Then Sˡᵢ( Xₗ ) = P( i_{0}, ..., i_{l-1}, X_{l}, u_{l+1}, ..., u_{d-1} ).
- * The l-th univariate would then be Sˡ( Xₗ ) = ∑_{0≤i<2ˡ} Sˡᵢ( Xₗ ) .
+ * Then Sˡᵢ( X_l ) = P( u_{0}, ..., u_{l-1}, X_{l}, i_{l+1}, ..., i_{d-1} ).
+ * The l-th univariate would then be Sˡ( X_l ) = ∑_{ 0 ≤ i < 2^{d-l-1} }  Sˡᵢ( X_l ) .
  *
- * We want to check that P(i)=0 for all i ∈ {0,1}ᵈ. So we use Sumcheck over the polynomial
+ * We want to check that P(i)=0 for all i ∈ {0,1}^d. So we use Sumcheck over the polynomial
  * P'(X) = pow(X)⋅P(X).
- * The claimed sum is 0 and is equal to ∑_{i ∈ {0,1}ᵈ} pow(i)⋅P(i) = ∑_{i ∈ {0,1}ᵈ} ζ^{i}⋅P(i)
+ * The claimed sum is 0 and is equal to ∑_{i ∈ {0,1}^d} pow(i)⋅P(i) = ∑_{i ∈ {0,1}^d} ζ^{i}⋅P(i)
  * If the Sumcheck passes, then with it must hold with high-probability that all P(i) are 0.
  *
  * The trivial implementation using P'(X) directly would increase the degree of our combined relation by 1.
  * Instead, we exploit the special structure of pow to preserve the same degree.
  *
  * In each round l, the prover should compute the univariate polynomial for the relation defined by P'(X)
- * S'ˡ(Xₗ) = ∑_{0≤i<2ˡ} powˡᵢ( Xₗ ) Sˡᵢ( Xₗ ) .
- *        = ∑_{0≤i<2ˡ} [ ζₗ₋₁ⁱ⋅( (1−Xₗ) + Xₗ⋅ζₗ )⋅cₗ ]⋅Sˡᵢ( Xₗ )
- *        = ( (1−Xₗ) + Xₗ⋅ζₗ ) ⋅ ∑_{0≤i<2ˡ} [ cₗ ⋅ ζₗ₋₁ⁱ ⋅ Sˡᵢ( Xₗ ) ]
+ * S'ˡ(X_l) = ∑_{ 0 ≤ i < 2^{d-l-1} } powˡᵢ( X_l ) Sˡᵢ( X_l ) .
+ *        = ∑_{ 0 ≤ i < 2^{d-l-1} } [ ζ_{l+1}ⁱ⋅( (1−X_l) + X_l⋅ζ_l )⋅c_l ]⋅Sˡᵢ( X_l )
+ *        = ( (1−X_l) + X_l⋅ζ_l ) ⋅ ∑_{ 0 ≤ i < 2^{d-l-1} } [ c_l ⋅ ζ_{l+1}ⁱ ⋅ Sˡᵢ( X_l ) ]
+ *        = ( (1−X_l) + X_l⋅ζ_l ) ⋅ ∑_{ 0 ≤ i < 2^{d-l-1} } [ c_l ⋅ ζ_{l+1}ⁱ ⋅ Sˡᵢ( X_l ) ]
  *
- * If we define Tˡ( Xₗ ) := ∑_{0≤i<2ˡ} [ cₗ ⋅ ζₗ₋₁ⁱ ⋅ Sˡᵢ( Xₗ ) ], then Tˡ has the same degree as the original Sˡ( Xₗ )
- * for the relation P(X) and is only slightly more expensive to compute than Sˡ( Xₗ ).
- * Moreover, given Tˡ( Xₗ ), the verifier can evaluate S'ˡ( uₗ ) by evaluating ( (1−uₗ) + uₗ⋅ζₗ )Tˡ( uₗ ).
- * When the verifier checks the claimed sum, the procedure is modified as follows
+ * If we define Tˡ( X_l ) := ∑_{0≤i<2ˡ} [ c_l ⋅ ζ_{l+1}ⁱ ⋅ Sˡᵢ( X_l ) ], then Tˡ has the same degree as the original Sˡ(
+ * X_l ) for the relation P(X) and is only slightly more expensive to compute than Sˡ( X_l ). Moreover, given Tˡ( X_l ),
+ * the verifier can evaluate S'ˡ( u_l ) by evaluating ( (1−u_l) + u_l⋅ζ_l )Tˡ( u_l ). When the verifier checks the
+ * claimed sum, the procedure is modified as follows
  *
  * Init:
- * - σ_{ d } <-- 0 // Claimed Sumcheck sum
- * - c_{d-1} <-- 1 // Partial evaluation constant, before any evaluation
- * - ζ_{d-1} <-- ζ // Initial power of ζ
+ * - σ_{ 0 } <-- 0 // Claimed Sumcheck sum
+ * - c_{ 0 } <-- 1 // Partial evaluation constant, before any evaluation
+ * - ζ_{ 0 } <-- ζ // Initial power of ζ
  *
- * Round l:
- * - σ_{l+1} =?= S'ˡ(0) + S'ˡ(1) = Tˡ(0) + ζ_{l}⋅Tˡ(1)  // Check partial sum
- * - σ_{ l } <-- ( (1−u_{l}) + u_{l}⋅ζ_{l} )⋅Tʲ(u_{l})  // Compute next partial sum
- * - c_{ l } <-- ( (1−u_{l}) + u_{l}⋅ζ_{l} )⋅c_{l-1}    // Partially evaluate pow in u_{l}
- * - ζ_{l-1} <-- ζ_{l}^2                                // Get next power of ζ
+ * Round 0≤l<d-1:
+ * - σ_{ l } =?= S'ˡ(0) + S'ˡ(1) = Tˡ(0) + ζ_{l}⋅Tˡ(1)  // Check partial sum
+ * - σ_{l+1} <-- ( (1−u_{l}) + u_{l}⋅ζ_{l} )⋅Tʲ(u_{l})  // Compute next partial sum
+ * - c_{l+1} <-- ( (1−u_{l}) + u_{l}⋅ζ_{l} )⋅c_{l}      // Partially evaluate pow in u_{l}
+ * - ζ_{l+1} <-- ζ_{l}^2                                // Get next power of ζ
  *
- * Final round l=0:
- * - σ_{1} =?= S'⁰(0) + S'⁰(1) = T⁰(0) + ζ_{0}⋅T⁰(1)    // Check partial sum
- * - σ_{0} <-- ( (1−u_{0}) + u_{0}⋅ζ_{0} )⋅T⁰(u_{0})    // Compute purported evaluation of P'(u)
- * - c_{0} <-- ∏_{0≤l<d} ( (1-u_{l}) + u_{l}⋅ζ_{l} )
- *           = pow(u_{0}, ..., u_{d-1})                 // Full evaluation of pow
- * - σ_{0} =?= c_{0}⋅P(u_{0}, ..., u_{d-1})             // Compare against real evaluation of P'(u)
- * @todo(Adrian): Eventually re-index polynomials with LSB first, and also rework the unicode symbols
+ * Final round l=d-1:
+ * - σ_{d-1} =?= S'ᵈ⁻¹(0) + S'ᵈ⁻¹(1) = Tᵈ⁻¹(0) + ζ_{d-1}⋅Tᵈ⁻¹(1)    // Check partial sum
+ * - σ_{ d } <-- ( (1−u_{d-1}) + u_{d-1}⋅ζ_{0} )⋅Tᵈ⁻¹(u_{d-1})      // Compute purported evaluation of P'(u)
+ * - c_{ d } <-- ∏_{0≤l<d} ( (1-u_{l}) + u_{l}⋅ζ_{l} )
+ *             = pow(u_{0}, ..., u_{d-1})                           // Full evaluation of pow
+ * - σ_{ d } =?= c_{d}⋅P(u_{0}, ..., u_{d-1})                       // Compare against real evaluation of P'(u)
  */
 template <typename FF> struct PowUnivariate {
-    // ζ_{l}, initialized as ζ_{d-1} = ζ
-    // At round l, equals ζ^{ 2^{d-l-1} }
+    // ζ_{l}, initialized as ζ_{0} = ζ
+    // At round l, equals ζ^{ 2^l }
     FF zeta_pow;
-    // ζ_{l-1}, initialized as ζ_{d-2} = ζ^2
+    // ζ_{l+1}, initialized as ζ_{1} = ζ^2
     // Always equal to zeta_pow^2
-    // At round l, equals ζ^{ 2^{d-l} }
+    // At round l, equals ζ^{ 2^{l+1} }
     FF zeta_pow_sqr;
-    // c_{l}, initialized as c_{d-1} = 1
-    // c_{l} = ∏_{l<k<d} ( (1-u_{k}) + u_{k}⋅ζ_{k} )
-    // At round 0, equals pow(u_{0}, ..., u_{d-1}).
+    // c_{l}, initialized as c_{0} = 1
+    // c_{l} = ∏_{0 ≤ k < l-1} ( (1-u_{k}) + u_{k}⋅ζ_{k} )
+    // At round d-1, equals pow(u_{0}, ..., u_{d-1}).
     FF partial_evaluation_constant = FF::one();
 
     // Initialize with the random zeta
-    PowUnivariate(FF zeta_pow)
+    explicit PowUnivariate(FF zeta_pow)
         : zeta_pow(zeta_pow)
         , zeta_pow_sqr(zeta_pow.sqr())
     {}
@@ -107,8 +113,8 @@ template <typename FF> struct PowUnivariate {
     FF univariate_eval(FF challenge) const { return (FF::one() + (challenge * (zeta_pow - FF::one()))); };
 
     /**
-     * @brief Parially evaluate the polynomial in the new challenge, by updating the constant c_{l} -> c_{l-1}.
-     * Also update (ζ_{l}, ζ_{l-1}) -> (ζ_{l-1}, ζ_{l-1}^2)
+     * @brief Parially evaluate the polynomial in the new challenge, by updating the constant c_{l} -> c_{l+1}.
+     * Also update (ζ_{l}, ζ_{l+1}) -> (ζ_{l+1}, ζ_{l+1}^2)
      *
      * @param challenge l-th verifier challenge u_{l}
      */

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
@@ -98,7 +98,7 @@ Transcript produce_mocked_transcript(size_t multivariate_d, size_t num_public_in
     );
 
     for (size_t i = 0; i < multivariate_d; i++) {
-        auto label = std::to_string(multivariate_d - i);
+        auto label = std::to_string(i);
         manifest_rounds.emplace_back(
             transcript::Manifest::RoundManifest({ { .name = "univariate_" + label,
                                                     .num_bytes = fr_size * honk::StandardHonk::MAX_RELATION_LENGTH,
@@ -189,29 +189,30 @@ TEST(Sumcheck, PolynomialNormalization)
 
     sumcheck.execute_prover(full_polynomials);
 
+    FF u_0 = transcript.get_challenge_field_element("u_0");
     FF u_1 = transcript.get_challenge_field_element("u_1");
     FF u_2 = transcript.get_challenge_field_element("u_2");
-    FF u_3 = transcript.get_challenge_field_element("u_3");
 
     /* sumcheck.execute_prover() terminates with sumcheck.multivariates.folded_polynoimals as an array such that
      * sumcheck.multivariates.folded_polynoimals[i][0] is the evaluatioin of the i'th multivariate at the vector of
      challenges u_i. What does this mean?
 
-     Here we show that if the multivariate is F(X1, X2, X3) defined as above, then what we get is F(u1, u2, u3) and not,
+     Here we show that if the multivariate is F(X0, X1, X2) defined as above, then what we get is F(u0, u1, u2) and not,
      say F(u3,u2,u1). This is in accordance with Adrian's thesis (cf page 9).
       */
 
     // Get the values of the Lagrange basis polys L_i defined
     // by: L_i(v) = 1 if i = v, 0 otherwise, for v from 0 to 7.
+    FF one{ 1 };
     // clang-format off
-    FF l_0 = (FF(1) - u_1) * (FF(1) - u_2) * (FF(1) - u_3);
-    FF l_1 = (FF(1) - u_1) * (FF(1) - u_2) * (        u_3);
-    FF l_2 = (FF(1) - u_1) * (        u_2) * (FF(1) - u_3);
-    FF l_3 = (FF(1) - u_1) * (        u_2) * (        u_3);
-    FF l_4 = (        u_1) * (FF(1) - u_2) * (FF(1) - u_3);
-    FF l_5 = (        u_1) * (FF(1) - u_2) * (        u_3);
-    FF l_6 = (        u_1) * (        u_2) * (FF(1) - u_3);
-    FF l_7 = (        u_1) * (        u_2) * (        u_3);
+    FF l_0 = (one - u_0) * (one - u_1) * (one - u_2);
+    FF l_1 = (      u_0) * (one - u_1) * (one - u_2);
+    FF l_2 = (one - u_0) * (      u_1) * (one - u_2);
+    FF l_3 = (      u_0) * (      u_1) * (one - u_2);
+    FF l_4 = (one - u_0) * (one - u_1) * (      u_2);
+    FF l_5 = (      u_0) * (one - u_1) * (      u_2);
+    FF l_6 = (one - u_0) * (      u_1) * (      u_2);
+    FF l_7 = (      u_0) * (      u_1) * (      u_2);
     // clang-format on
 
     FF hand_computed_value = l_0 * w_l[0] + l_1 * w_l[1] + l_2 * w_l[2] + l_3 * w_l[3] + l_4 * w_l[4] + l_5 * w_l[5] +
@@ -279,12 +280,12 @@ TEST(Sumcheck, Prover)
 
     sumcheck.execute_prover(full_polynomials);
 
+    FF u_0 = transcript.get_challenge_field_element("u_0");
     FF u_1 = transcript.get_challenge_field_element("u_1");
-    FF u_2 = transcript.get_challenge_field_element("u_2");
     std::vector<FF> expected_values;
     for (auto& polynomial : full_polynomials) {
         // using knowledge of inputs here to derive the evaluation
-        FF expected = polynomial[0] * (FF(1) - u_2) + polynomial[1] * u_2;
+        FF expected = polynomial[0] * (FF(1) - u_0) + polynomial[1] * u_0;
         expected *= (FF(1) - u_1);
         expected_values.emplace_back(expected);
     }

--- a/cpp/src/aztec/honk/utils/power_polynomial.hpp
+++ b/cpp/src/aztec/honk/utils/power_polynomial.hpp
@@ -65,7 +65,7 @@ template <typename Fr> Fr evaluate(Fr zeta, std::span<const Fr> variables)
 {
     Fr evaluation = Fr::one();
     for (size_t i = 0; i < variables.size(); i++) {
-        // evaulutaion *= (b^{2^i} - 1) * x_i + 1
+        // evaluation *= (b^{2^i} - 1) * x_i + 1
         evaluation *= (zeta - 1) * variables[i] + 1;
         zeta *= zeta;
     }

--- a/cpp/src/aztec/honk/utils/power_polynomial.hpp
+++ b/cpp/src/aztec/honk/utils/power_polynomial.hpp
@@ -65,7 +65,7 @@ template <typename Fr> Fr evaluate(Fr zeta, std::span<const Fr> variables)
 {
     Fr evaluation = Fr::one();
     for (size_t i = 0; i < variables.size(); i++) {
-        // evaulutaion *= b^{2^i} - 1) * x_i + 1
+        // evaulutaion *= (b^{2^i} - 1) * x_i + 1
         evaluation *= (zeta - 1) * variables[i] + 1;
         zeta *= zeta;
     }

--- a/cpp/src/aztec/polynomials/polynomial.hpp
+++ b/cpp/src/aztec/polynomials/polynomial.hpp
@@ -174,14 +174,14 @@ template <typename Fr> class Polynomial {
     Polynomial& operator*=(const Fr scaling_facor);
 
     /**
-     * @brief evaluates p(X) = ∑ᵢ aᵢ⋅Xⁱ considered as multi-linear extension p(X₁,…,Xₘ) = ∑ᵢ aᵢ⋅Lᵢ(X₁,…,Xₘ)
-     * at u = (u₁,…,uₘ)
+     * @brief evaluates p(X) = ∑ᵢ aᵢ⋅Xⁱ considered as multi-linear extension p(X₀,…,Xₘ₋₁) = ∑ᵢ aᵢ⋅Lᵢ(X₀,…,Xₘ₋₁)
+     * at u = (u₀,…,uₘ₋₁)
      *
      * @details this function allocates a temporary buffer of size n/2
      *
-     * @param evaluation_points an MLE evaluation point u = (u₁,…,uₘ)
-     * @param shift evaluates p'(X₁,…,Xₘ) = 1⋅L₀(X₁,…,Xₘ) + ∑ᵢ˲₁ aᵢ₋₁⋅Lᵢ(X₁,…,Xₘ) if true
-     * @return Fr p(u₁,…,uₘ)
+     * @param evaluation_points an MLE evaluation point u = (u₀,…,uₘ₋₁)
+     * @param shift evaluates p'(X₀,…,Xₘ₋₁) = 1⋅L₀(X₀,…,Xₘ₋₁) + ∑ᵢ˲₁ aᵢ₋₁⋅Lᵢ(X₀,…,Xₘ₋₁) if true
+     * @return Fr p(u₀,…,uₘ₋₁)
      */
     Fr evaluate_mle(std::span<const Fr> evaluation_points, bool shift = false) const;
 

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -123,7 +123,7 @@ struct StandardHonk {
 
         // Rounds 4, ... 4 + num_sumcheck_rounds-1
         for (size_t i = 0; i < num_sumcheck_rounds; i++) {
-            auto label = std::to_string(num_sumcheck_rounds - i);
+            auto label = std::to_string(i);
             manifest_rounds.emplace_back(
                 transcript::Manifest::RoundManifest(
             { 


### PR DESCRIPTION
# Description

Changes the default order of the multi-linear polynomials' variables from $X_1, \ldots, X_d$ to $X_0,\ldots,X_{d-1}$, and uses the LSB first ordering of the hypercube edges. We now always fold from $X_0$ up to $X_{d-1}$. This means that our Sumcheck rounds are also ordered from $0$ to $d-1$. All comments have been updated that referred to the old representation. 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
