### PR TITLE
fix: Wrap each use of filesystem library in `#ifndef __wasm__`

### DIFF
--- a/cpp/src/aztec/join_split_example/proofs/compute_circuit_data.hpp
+++ b/cpp/src/aztec/join_split_example/proofs/compute_circuit_data.hpp
@@ -6,7 +6,10 @@
 #include <sys/stat.h>
 #include <common/timer.hpp>
 #include <proof_system/proving_key/serialize.hpp>
+
+#ifndef __wasm__
 #include <filesystem>
+#endif
 
 namespace join_split_example {
 namespace proofs {
@@ -91,11 +94,13 @@ circuit_data get_circuit_data(std::string const& name,
         }
     }
 
+#ifndef __wasm__
     // If we're saving data, create the circuit data directory.
     if (save) {
         std::filesystem::create_directories(key_path.c_str());
         std::filesystem::create_directories(circuit_key_path.c_str());
     }
+#endif
 
     if (pk) {
         auto pk_dir = circuit_key_path + "/proving_key";
@@ -145,6 +150,7 @@ circuit_data get_circuit_data(std::string const& name,
                                                        name + name_suffix_for_benchmarks,
                                                        "Proving key computed in",
                                                        timer.toString());
+#ifndef __wasm__
             if (save) {
                 info(name, ": Saving proving key...");
                 std::filesystem::create_directories(pk_dir.c_str());
@@ -156,6 +162,7 @@ circuit_data get_circuit_data(std::string const& name,
                 }
                 info(name, ": Saved in ", write_timer.toString(), "s");
             }
+#endif
         }
     }
 

--- a/cpp/src/aztec/proof_system/proving_key/proving_key.test.cpp
+++ b/cpp/src/aztec/proof_system/proving_key/proving_key.test.cpp
@@ -3,7 +3,10 @@
 #include "proving_key.hpp"
 #include "serialize.hpp"
 #include "plonk/composer/standard_composer.hpp"
+
+#ifndef __wasm__
 #include <filesystem>
+#endif
 
 using namespace barretenberg;
 using namespace bonk;
@@ -45,6 +48,7 @@ TEST(proving_key, proving_key_from_serialized_key)
 }
 
 // Test that a proving key can be serialized/deserialized using mmap
+#ifndef __wasm__
 TEST(proving_key, proving_key_from_mmaped_key)
 {
     plonk::StandardComposer composer = plonk::StandardComposer();
@@ -109,3 +113,4 @@ TEST(proving_key, proving_key_from_mmaped_key)
     EXPECT_EQ(p_key.num_public_inputs, pk_data.num_public_inputs);
     EXPECT_EQ(p_key.contains_recursive_proof, pk_data.contains_recursive_proof);
 }
+#endif


### PR DESCRIPTION
# Description

Workaround that fixes #180 

As noted in the issue, the `<filesystem>` library can't be used in code that compiles to Wasm, even if we are targeting WASI. I just quickly wrapped all the usages in `#ifndef __wasm__` to verify this workaround solves the problem in Nix. I think the "more correct" way to solve this would be to use `mkdir` (on unix) and `_mkdir` (on Windows), but that seemed to receive pushback on the internal PR.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
