### PR TITLE
feat: Add installation targets for libbarretenberg, wasm & headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ cd cpp
 ./bootstrap.sh
 ```
 
+### Installing
+
+After the project has been built, such as with `./bootstrap.sh`, you can install the library on your system:
+
+```sh
+cmake --install build
+```
+
 ### Formatting
 
 Code is formatted using `clang-format` and the `./cpp/format.sh` script which is called via a git pre-commit hook.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ option(FUZZING "Build fuzzing harnesses" OFF)
 option(DISABLE_TBB "Intel Thread Building Blocks" ON)
 option(COVERAGE "Enable collecting coverage from tests" OFF)
 option(ENABLE_HEAVY_TESTS "Enable heavy tests when collecting coverage" OFF)
+option(INSTALL_BARRETENBERG "Enable installation of barretenberg. (Projects embedding barretenberg may want to turn this OFF.)" ON)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
     message(STATUS "Compiling for ARM.")

--- a/cpp/cmake/benchmark.cmake
+++ b/cpp/cmake/benchmark.cmake
@@ -13,6 +13,7 @@ if(BENCHMARKS)
     )
 
     set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Benchmark tests off")
+    set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Benchmark installation off")
 
     FetchContent_MakeAvailable(benchmark)
     if(NOT benchmark_FOUND)

--- a/cpp/cmake/gtest.cmake
+++ b/cpp/cmake/gtest.cmake
@@ -11,6 +11,7 @@ if(TESTING)
     )
 
     set(BUILD_GMOCK OFF CACHE BOOL "Build with gMock disabled")
+    set(INSTALL_GTEST OFF CACHE BOOL "gTest installation disabled")
 
     FetchContent_MakeAvailable(GTest)
 

--- a/cpp/cmake/module.cmake
+++ b/cpp/cmake/module.cmake
@@ -12,10 +12,28 @@
 # Then we declare executables/libraries that are to be built from these object files.
 # These assets will only be linked as their dependencies complete, but we can parallelise the compilation at least.
 
+# This is an interface library that can be used as an install target to include all header files
+# encountered by the `barretenberg_module` function. There is probably a better way to do this,
+# especially if we want to exclude some of the header files being installed
+add_library(barretenberg_headers INTERFACE)
+target_sources(
+    barretenberg_headers
+    INTERFACE
+    FILE_SET HEADERS
+    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
 function(barretenberg_module MODULE_NAME)
     file(GLOB_RECURSE SOURCE_FILES *.cpp)
     file(GLOB_RECURSE HEADER_FILES *.hpp)
     list(FILTER SOURCE_FILES EXCLUDE REGEX ".*\.(fuzzer|test|bench).cpp$")
+
+    target_sources(
+        barretenberg_headers
+        INTERFACE
+        FILE_SET HEADERS
+        FILES ${HEADER_FILES}
+    )
 
     if(SOURCE_FILES)
         add_library(

--- a/cpp/cmake/module.cmake
+++ b/cpp/cmake/module.cmake
@@ -25,7 +25,7 @@ target_sources(
 
 function(barretenberg_module MODULE_NAME)
     file(GLOB_RECURSE SOURCE_FILES *.cpp)
-    file(GLOB_RECURSE HEADER_FILES *.hpp)
+    file(GLOB_RECURSE HEADER_FILES *.hpp *.tcc)
     list(FILTER SOURCE_FILES EXCLUDE REGEX ".*\.(fuzzer|test|bench).cpp$")
 
     target_sources(

--- a/cpp/src/aztec/CMakeLists.txt
+++ b/cpp/src/aztec/CMakeLists.txt
@@ -55,6 +55,8 @@ if(BENCHMARKS)
     add_subdirectory(benchmark)
 endif()
 
+include(GNUInstallDirs)
+
 if(WASM)
     # Well, this is awkward. We can't build a wasm module by just linking to the libraries as that produces, nothing.
     # There are a couple of other ways to avoiding listing all the object files here and leveraging the dependency
@@ -105,6 +107,10 @@ if(WASM)
         VERBATIM
     )
 
+    if(INSTALL_BARRETENBERG)
+        install(TARGETS barretenberg.wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
+
     # For use when compiling dependent cpp projects for WASM
     message(STATUS "Compiling all-in-one barretenberg WASM archive")
     add_library(
@@ -131,7 +137,6 @@ if(WASM)
         $<TARGET_OBJECTS:stdlib_aes128_objects>
         $<TARGET_OBJECTS:stdlib_merkle_tree_objects>
     )
-
 else()
     # For use when compiling dependent cpp projects
     message(STATUS "Compiling all-in-one barretenberg archive")
@@ -160,4 +165,13 @@ else()
         $<TARGET_OBJECTS:stdlib_merkle_tree_objects>
         $<TARGET_OBJECTS:env_objects>
     )
+
+    if(INSTALL_BARRETENBERG)
+        install(
+            TARGETS barretenberg barretenberg_headers
+            EXPORT barretenbergTargets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
+    endif()
 endif()

--- a/cpp/src/aztec/CMakeLists.txt
+++ b/cpp/src/aztec/CMakeLists.txt
@@ -37,6 +37,7 @@ else()
     message(STATUS "Using optimized assembly for field arithmetic.")
 endif()
 
+add_subdirectory(common)
 add_subdirectory(env)
 add_subdirectory(numeric)
 add_subdirectory(srs)

--- a/cpp/src/aztec/common/CMakeLists.txt
+++ b/cpp/src/aztec/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Collect our common/*.hpp files and include in installation
+file(GLOB_RECURSE HEADER_FILES *.hpp)
+target_sources(
+    barretenberg_headers
+    INTERFACE
+    FILE_SET HEADERS
+    FILES ${HEADER_FILES}
+)


### PR DESCRIPTION
# Description

Closes #176

This adds install targets for `libbarretenberg.a`, `barretenberg.wasm` and all the headers. It uses an "interface library" to collect headers as the subdirectories call the `barretenberg_module` function. I couldn't come up with a better way to collect the headers for installation because they exist in the subdirectories (instead of something like an `include/` directory where the public headers exist, such as https://github.com/google/benchmark/tree/main/include/benchmark), which means that we promote *all* header files instead of just public ones.

We should open a follow up issue to differentiate public from private headers.

With installation targets, we can now do `cmake --install build --prefix "/usr/local"` and it'll install like a normal C++ library.

I also added the `INSTALL_BARRETENBERG` option in emulation of googletest and benchmark because using `FetchContent_MakeAvailable` will add them as install targets. You can see how the `BENCHMARK_ENABLE_INSTALL` and `INSTALL_GTEST` are turned off now too.

This is the minimal setup we need to have installation targets, but many more improvements can be made so projects can consume this via other CMake builds, pkg-config, etc. These improvements are currently unnecessary for Noir to use barretenberg, but I can create follow up issues.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
