### PR TITLE
Adds ECDSA signature types

### DIFF
--- a/cpp/src/aztec/crypto/ecdsa/ecdsa.hpp
+++ b/cpp/src/aztec/crypto/ecdsa/ecdsa.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #include "../hashers/hashers.hpp"
 #include <array>
 #include <string>
+#include <ecc/curves/secp256k1/secp256k1.hpp>
 
 namespace crypto {
 namespace ecdsa {
@@ -21,6 +23,42 @@ template <typename Hash, typename Fq, typename Fr, typename G1>
 bool verify_signature(const std::string& message,
                       const typename G1::affine_element& public_key,
                       const signature& signature);
+
+inline bool operator==(signature const& lhs, signature const& rhs)
+{
+    return lhs.r == rhs.r && lhs.s == rhs.s;
+}
+
+inline std::ostream& operator<<(std::ostream& os, signature const& sig)
+{
+    os << "{ " << sig.r << ", " << sig.s << " }";
+    return os;
+}
+
+template <typename B> inline void read(B& it, signature& sig)
+{
+    read(it, sig.r);
+    read(it, sig.s);
+}
+
+template <typename B> inline void write(B& buf, signature const& sig)
+{
+    write(buf, sig.r);
+    write(buf, sig.s);
+}
+
+template <typename B> inline void read(B& it, key_pair<secp256k1::fr, secp256k1::g1>& keypair)
+{
+    read(it, keypair.private_key);
+    read(it, keypair.public_key);
+}
+
+template <typename B> inline void write(B& buf, key_pair<secp256k1::fr, secp256k1::g1> const& keypair)
+{
+    write(buf, keypair.private_key);
+    write(buf, keypair.public_key);
+}
+
 } // namespace ecdsa
 } // namespace crypto
 

--- a/cpp/src/aztec/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/cpp/src/aztec/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <crypto/ecdsa/ecdsa.hpp>
 #include "../../primitives/byte_array/byte_array.hpp"
 #include "../../primitives/composers/composers_fwd.hpp"
 
@@ -16,6 +17,16 @@ template <typename Composer, typename Curve, typename Fq, typename Fr, typename 
 bool_t<Composer> verify_signature(const stdlib::byte_array<Composer>& message,
                                   const G1& public_key,
                                   const signature<Composer>& sig);
+
+template <typename Composer>
+static signature<Composer> from_witness(Composer* ctx, const crypto::ecdsa::signature& input)
+{
+    byte_array x(ctx, input.r);
+    byte_array y(ctx, input.s);
+    signature<Composer> out(x, y);
+    return out;
+}
+
 } // namespace ecdsa
 } // namespace stdlib
 } // namespace plonk

--- a/cpp/src/aztec/stdlib/types/circuit_types.hpp
+++ b/cpp/src/aztec/stdlib/types/circuit_types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdlib/primitives/address/address.hpp>
 #include <stdlib/encryption/schnorr/schnorr.hpp>
+#include <stdlib/encryption/ecdsa/ecdsa.hpp>
 #include <stdlib/primitives/bigfield/bigfield.hpp>
 #include <stdlib/primitives/biggroup/biggroup.hpp>
 #include <stdlib/primitives/bit_array/bit_array.hpp>
@@ -53,6 +54,7 @@ template <typename Composer> struct CircuitTypes {
     // typedef packed_byte_array<Composer> packed_byte_array;
 
     // typedef stdlib::schnorr::signature_bits<Composer> signature;
+    typedef stdlib::ecdsa::signature<Composer> ecdsa_signature;
 
     typedef stdlib::recursion::recursion_output<bn254> AggregationObject;
     typedef stdlib::recursion::verification_key<bn254> VK;

--- a/cpp/src/aztec/stdlib/types/convert.hpp
+++ b/cpp/src/aztec/stdlib/types/convert.hpp
@@ -57,6 +57,12 @@ typename CT<Composer>::bn254_point to_ct(Composer& composer, typename NT::bn254_
 };
 
 template <typename Composer>
+typename CT<Composer>::ecdsa_signature to_ct(Composer& composer, typename NT::ecdsa_signature const& e)
+{
+    return CT<Composer>::ecdsa_signature::from_witness<Composer>(&composer, e);
+};
+
+template <typename Composer>
 std::optional<typename CT<Composer>::boolean> to_ct(Composer& composer, std::optional<typename NT::boolean> const& e)
 {
     return e ? std::make_optional<typename CT<Composer>::boolean>(to_ct(composer, *e)) : std::nullopt;
@@ -79,6 +85,13 @@ std::optional<typename CT<Composer>::grumpkin_point> to_ct(Composer& composer,
                                                            std::optional<typename NT::grumpkin_point> const& e)
 {
     return e ? std::make_optional<typename CT<Composer>::grumpkin_point>(to_ct(composer, *e)) : std::nullopt;
+};
+
+template <typename Composer>
+std::optional<typename CT<Composer>::ecdsa_signature> to_ct(Composer& composer,
+                                                            std::optional<typename NT::ecdsa_signature> const& e)
+{
+    return e ? std::make_optional<typename CT<Composer>::ecdsa_signature>(to_ct(&composer, e)) : std::nullopt;
 };
 
 template <typename Composer>
@@ -155,6 +168,13 @@ template <typename Composer> typename NT::bn254_point to_nt(typename CT<Composer
     return e.get_value();
 };
 
+template <typename Composer> typename NT::ecdsa_signature to_nt(typename CT<Composer>::ecdsa_signature const& e)
+{
+    std::vector<uint8_t> r_bytes = e.r.get_value();
+    std::vector<uint8_t> s_bytes = e.s.get_value();
+    return NT::ecdsa_signature{ r_bytes, s_bytes };
+};
+
 template <typename Composer>
 std::optional<typename NT::boolean> to_nt(std::optional<typename CT<Composer>::boolean> const& e)
 {
@@ -176,6 +196,12 @@ template <typename Composer>
 std::optional<typename NT::grumpkin_point> to_nt(std::optional<typename CT<Composer>::grumpkin_point> const& e)
 {
     return e ? std::make_optional<typename NT::grumpkin_point>(to_nt<Composer>(*e)) : std::nullopt;
+};
+
+template <typename Composer>
+std::optional<typename NT::ecdsa_signature> to_nt(std::optional<typename CT<Composer>::ecdsa_signature> const& e)
+{
+    return e ? std::make_optional<typename NT::ecdsa_signature>(to_nt<Composer>(*e)) : std::nullopt;
 };
 
 template <typename Composer> std::vector<typename NT::fr> to_nt(std::vector<typename CT<Composer>::fr> const& vec)

--- a/cpp/src/aztec/stdlib/types/native_types.hpp
+++ b/cpp/src/aztec/stdlib/types/native_types.hpp
@@ -3,13 +3,14 @@
 #include <crypto/pedersen_commitment/pedersen.hpp>
 #include <crypto/generators/generator_data.hpp>
 #include <crypto/schnorr/schnorr.hpp>
+#include <crypto/ecdsa/ecdsa.hpp>
 #include <ecc/curves/bn254/fq.hpp>
 #include <ecc/curves/bn254/fr.hpp>
 #include <ecc/curves/bn254/g1.hpp>
 #include <ecc/curves/grumpkin/grumpkin.hpp>
 #include <numeric/uint256/uint256.hpp>
 #include <proof_system/verification_key/verification_key.hpp>
-#include <plonk/proof_system/types/plonk_proof.hpp>
+#include <plonk/proof_system/types/proof.hpp>
 #include <stdlib/recursion/verifier/verifier.hpp>
 
 // #include <stdlib/primitives/bit_array/bit_array.hpp>
@@ -54,6 +55,7 @@ struct NativeTypes {
     // typedef packed_byte_array packed_byte_array;
 
     // typedef crypto::schnorr::signature signature;
+    typedef crypto::ecdsa::signature ecdsa_signature;
 
     typedef stdlib::recursion::native_recursion_output AggregationObject;
     typedef bonk::verification_key_data VKData;


### PR DESCRIPTION
# Description

Since we are only going to use ecdsa signatures in Aztec3, we need to include the ECDSA signature type in NT and CT. This PR adds it as `ecdsa_signature` and also adds a few missing functions the ecdsa modules (native and stdlib).

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
