### PR TITLE
feat: Add Noir DSL with acir_format and turbo_proofs namespaces

### DIFF
--- a/cpp/src/aztec/CMakeLists.txt
+++ b/cpp/src/aztec/CMakeLists.txt
@@ -51,6 +51,7 @@ add_subdirectory(honk)
 add_subdirectory(plonk)
 add_subdirectory(stdlib)
 add_subdirectory(join_split_example)
+add_subdirectory(dsl)
 
 if(BENCHMARKS)
     add_subdirectory(benchmark)
@@ -83,6 +84,8 @@ if(WASM)
         $<TARGET_OBJECTS:stdlib_pedersen_objects>
         $<TARGET_OBJECTS:stdlib_blake2s_objects>
         $<TARGET_OBJECTS:stdlib_blake3s_objects>
+        $<TARGET_OBJECTS:acir_format_objects>
+        $<TARGET_OBJECTS:turbo_proofs_objects>
     )
 
     # With binaryen installed, it seems its wasm backend optimiser gets invoked automatically.
@@ -138,6 +141,8 @@ if(WASM)
         $<TARGET_OBJECTS:stdlib_sha256_objects>
         $<TARGET_OBJECTS:stdlib_aes128_objects>
         $<TARGET_OBJECTS:stdlib_merkle_tree_objects>
+        $<TARGET_OBJECTS:acir_format_objects>
+        $<TARGET_OBJECTS:turbo_proofs_objects>
     )
 else()
     # For use when compiling dependent cpp projects
@@ -165,6 +170,8 @@ else()
         $<TARGET_OBJECTS:stdlib_sha256_objects>
         $<TARGET_OBJECTS:stdlib_aes128_objects>
         $<TARGET_OBJECTS:stdlib_merkle_tree_objects>
+        $<TARGET_OBJECTS:acir_format_objects>
+        $<TARGET_OBJECTS:turbo_proofs_objects>
         $<TARGET_OBJECTS:env_objects>
     )
 

--- a/cpp/src/aztec/dsl/CMakeLists.txt
+++ b/cpp/src/aztec/dsl/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(acir_format)
+add_subdirectory(turbo_proofs)

--- a/cpp/src/aztec/dsl/acir_format/CMakeLists.txt
+++ b/cpp/src/aztec/dsl/acir_format/CMakeLists.txt
@@ -1,0 +1,11 @@
+barretenberg_module(
+    acir_format
+    plonk
+    stdlib_primitives
+    stdlib_sha256
+    stdlib_blake2s
+    stdlib_pedersen
+    stdlib_merkle_tree
+    stdlib_schnorr
+    crypto_sha256
+)

--- a/cpp/src/aztec/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/aztec/dsl/acir_format/acir_format.cpp
@@ -1,0 +1,410 @@
+#include "acir_format.hpp"
+
+namespace acir_format {
+
+void read_witness(TurboComposer& composer, std::vector<barretenberg::fr> witness)
+{
+    composer.variables[0] = 0;
+    for (size_t i = 0; i < witness.size(); ++i) {
+        composer.variables[i + 1] = witness[i];
+    }
+}
+
+void create_circuit(TurboComposer& composer, const acir_format& constraint_system)
+{
+    if (constraint_system.public_inputs.size() > constraint_system.varnum) {
+        std::cout << "too many public inputs!" << std::endl;
+    }
+
+    for (size_t i = 1; i < constraint_system.varnum; ++i) {
+        // If the index is in the public inputs vector, then we add it as a public input
+
+        if (std::find(constraint_system.public_inputs.begin(), constraint_system.public_inputs.end(), i) !=
+            constraint_system.public_inputs.end()) {
+            composer.add_public_variable(0);
+
+        } else {
+            composer.add_variable(0);
+        }
+    }
+
+    // Add arithmetic gates
+    for (const auto& constraint : constraint_system.constraints) {
+        composer.create_poly_gate(constraint);
+    }
+
+    // Add and constraint
+    for (const auto& constraint : constraint_system.logic_constraints) {
+        create_logic_gate(
+            composer, constraint.a, constraint.b, constraint.result, constraint.num_bits, constraint.is_xor_gate);
+    }
+
+    // Add range constraint
+    for (const auto& constraint : constraint_system.range_constraints) {
+        composer.decompose_into_base4_accumulators(constraint.witness, constraint.num_bits, "");
+    }
+
+    // Add sha256 constraints
+    for (const auto& constraint : constraint_system.sha256_constraints) {
+        create_sha256_constraints(composer, constraint);
+    }
+
+    // Add merkle membership constraints
+    for (const auto& constraint : constraint_system.merkle_membership_constraints) {
+        create_merkle_check_membership_constraint(composer, constraint);
+    }
+
+    // Add schnorr constraints
+    for (const auto& constraint : constraint_system.schnorr_constraints) {
+        create_schnorr_verify_constraints(composer, constraint);
+    }
+
+    // Add ECDSA constraints
+    for (const auto& constraint : constraint_system.ecdsa_constraints) {
+        create_ecdsa_verify_constraints(composer, constraint);
+    }
+
+    // Add blake2s constraints
+    for (const auto& constraint : constraint_system.blake2s_constraints) {
+        create_blake2s_constraints(composer, constraint);
+    }
+
+    // Add pedersen constraints
+    for (const auto& constraint : constraint_system.pedersen_constraints) {
+        create_pedersen_constraint(composer, constraint);
+    }
+
+    // Add fixed base scalar mul constraints
+    for (const auto& constraint : constraint_system.fixed_base_scalar_mul_constraints) {
+        create_fixed_base_constraint(composer, constraint);
+    }
+
+    // Add hash to field constraints
+    for (const auto& constraint : constraint_system.hash_to_field_constraints) {
+        create_hash_to_field_constraints(composer, constraint);
+    }
+}
+
+TurboComposer create_circuit(const acir_format& constraint_system,
+                             std::unique_ptr<bonk::ReferenceStringFactory>&& crs_factory)
+{
+    if (constraint_system.public_inputs.size() > constraint_system.varnum) {
+        std::cout << "too many public inputs!" << std::endl;
+    }
+
+    TurboComposer composer(std::move(crs_factory));
+
+    for (size_t i = 1; i < constraint_system.varnum; ++i) {
+        // If the index is in the public inputs vector, then we add it as a public input
+
+        if (std::find(constraint_system.public_inputs.begin(), constraint_system.public_inputs.end(), i) !=
+            constraint_system.public_inputs.end()) {
+
+            composer.add_public_variable(0);
+
+        } else {
+            composer.add_variable(0);
+        }
+    }
+    // Add arithmetic gates
+    for (const auto& constraint : constraint_system.constraints) {
+        composer.create_poly_gate(constraint);
+    }
+
+    // Add logic constraint
+    for (const auto& constraint : constraint_system.logic_constraints) {
+        create_logic_gate(
+            composer, constraint.a, constraint.b, constraint.result, constraint.num_bits, constraint.is_xor_gate);
+    }
+
+    // Add range constraint
+    for (const auto& constraint : constraint_system.range_constraints) {
+        composer.decompose_into_base4_accumulators(constraint.witness, constraint.num_bits, "");
+    }
+
+    // Add sha256 constraints
+    for (const auto& constraint : constraint_system.sha256_constraints) {
+        create_sha256_constraints(composer, constraint);
+    }
+
+    // Add merkle membership constraints
+    for (const auto& constraint : constraint_system.merkle_membership_constraints) {
+        create_merkle_check_membership_constraint(composer, constraint);
+    }
+
+    // Add schnorr constraints
+    for (const auto& constraint : constraint_system.schnorr_constraints) {
+        create_schnorr_verify_constraints(composer, constraint);
+    }
+
+    // Add ECDSA constraints
+    for (const auto& constraint : constraint_system.ecdsa_constraints) {
+        create_ecdsa_verify_constraints(composer, constraint);
+    }
+
+    // Add blake2s constraints
+    for (const auto& constraint : constraint_system.blake2s_constraints) {
+        create_blake2s_constraints(composer, constraint);
+    }
+
+    // Add pedersen constraints
+    for (const auto& constraint : constraint_system.pedersen_constraints) {
+        create_pedersen_constraint(composer, constraint);
+    }
+
+    // Add fixed base scalar mul constraints
+    for (const auto& constraint : constraint_system.fixed_base_scalar_mul_constraints) {
+        create_fixed_base_constraint(composer, constraint);
+    }
+
+    // Add hash to field constraints
+    for (const auto& constraint : constraint_system.hash_to_field_constraints) {
+        create_hash_to_field_constraints(composer, constraint);
+    }
+
+    return composer;
+}
+
+TurboComposer create_circuit_with_witness(const acir_format& constraint_system,
+                                          std::vector<fr> witness,
+                                          std::unique_ptr<ReferenceStringFactory>&& crs_factory)
+{
+    if (constraint_system.public_inputs.size() > constraint_system.varnum) {
+        std::cout << "too many public inputs!" << std::endl;
+    }
+
+    TurboComposer composer(std::move(crs_factory));
+
+    for (size_t i = 1; i < constraint_system.varnum; ++i) {
+        // If the index is in the public inputs vector, then we add it as a public input
+
+        if (std::find(constraint_system.public_inputs.begin(), constraint_system.public_inputs.end(), i) !=
+            constraint_system.public_inputs.end()) {
+
+            composer.add_public_variable(0);
+
+        } else {
+            composer.add_variable(0);
+        }
+    }
+
+    read_witness(composer, witness);
+
+    // Add arithmetic gates
+    for (const auto& constraint : constraint_system.constraints) {
+        composer.create_poly_gate(constraint);
+    }
+
+    // Add logic constraint
+    for (const auto& constraint : constraint_system.logic_constraints) {
+        create_logic_gate(
+            composer, constraint.a, constraint.b, constraint.result, constraint.num_bits, constraint.is_xor_gate);
+    }
+
+    // Add range constraint
+    for (const auto& constraint : constraint_system.range_constraints) {
+        composer.decompose_into_base4_accumulators(constraint.witness, constraint.num_bits, "");
+    }
+
+    // Add sha256 constraints
+    for (const auto& constraint : constraint_system.sha256_constraints) {
+        create_sha256_constraints(composer, constraint);
+    }
+
+    // Add merkle membership constraints
+    for (const auto& constraint : constraint_system.merkle_membership_constraints) {
+        create_merkle_check_membership_constraint(composer, constraint);
+    }
+
+    // Add schnorr constraints
+    for (const auto& constraint : constraint_system.schnorr_constraints) {
+        create_schnorr_verify_constraints(composer, constraint);
+    }
+
+    // Add ECDSA constraints
+    for (const auto& constraint : constraint_system.ecdsa_constraints) {
+        create_ecdsa_verify_constraints(composer, constraint);
+    }
+
+    // Add blake2s constraints
+    for (const auto& constraint : constraint_system.blake2s_constraints) {
+        create_blake2s_constraints(composer, constraint);
+    }
+
+    // Add pedersen constraints
+    for (const auto& constraint : constraint_system.pedersen_constraints) {
+        create_pedersen_constraint(composer, constraint);
+    }
+
+    // Add fixed base scalar mul constraints
+    for (const auto& constraint : constraint_system.fixed_base_scalar_mul_constraints) {
+        create_fixed_base_constraint(composer, constraint);
+    }
+
+    // Add hash to field constraints
+    for (const auto& constraint : constraint_system.hash_to_field_constraints) {
+        create_hash_to_field_constraints(composer, constraint);
+    }
+
+    return composer;
+}
+TurboComposer create_circuit_with_witness(const acir_format& constraint_system, std::vector<fr> witness)
+{
+    if (constraint_system.public_inputs.size() > constraint_system.varnum) {
+        std::cout << "too many public inputs!" << std::endl;
+    }
+
+    auto composer = TurboComposer();
+
+    for (size_t i = 1; i < constraint_system.varnum; ++i) {
+        // If the index is in the public inputs vector, then we add it as a public input
+
+        if (std::find(constraint_system.public_inputs.begin(), constraint_system.public_inputs.end(), i) !=
+            constraint_system.public_inputs.end()) {
+
+            composer.add_public_variable(0);
+
+        } else {
+            composer.add_variable(0);
+        }
+    }
+
+    read_witness(composer, witness);
+
+    // Add arithmetic gates
+    for (const auto& constraint : constraint_system.constraints) {
+        composer.create_poly_gate(constraint);
+    }
+
+    // Add logic constraint
+    for (const auto& constraint : constraint_system.logic_constraints) {
+        create_logic_gate(
+            composer, constraint.a, constraint.b, constraint.result, constraint.num_bits, constraint.is_xor_gate);
+    }
+
+    // Add range constraint
+    for (const auto& constraint : constraint_system.range_constraints) {
+        composer.decompose_into_base4_accumulators(constraint.witness, constraint.num_bits, "");
+    }
+
+    // Add sha256 constraints
+    for (const auto& constraint : constraint_system.sha256_constraints) {
+        create_sha256_constraints(composer, constraint);
+    }
+
+    // Add merkle membership constraints
+    for (const auto& constraint : constraint_system.merkle_membership_constraints) {
+        create_merkle_check_membership_constraint(composer, constraint);
+    }
+
+    // Add schnorr constraints
+    for (const auto& constraint : constraint_system.schnorr_constraints) {
+        create_schnorr_verify_constraints(composer, constraint);
+    }
+
+    // Add ECDSA constraints
+    for (const auto& constraint : constraint_system.ecdsa_constraints) {
+        create_ecdsa_verify_constraints(composer, constraint);
+    }
+
+    // Add blake2s constraints
+    for (const auto& constraint : constraint_system.blake2s_constraints) {
+        create_blake2s_constraints(composer, constraint);
+    }
+
+    // Add pedersen constraints
+    for (const auto& constraint : constraint_system.pedersen_constraints) {
+        create_pedersen_constraint(composer, constraint);
+    }
+
+    // Add fixed base scalar mul constraints
+    for (const auto& constraint : constraint_system.fixed_base_scalar_mul_constraints) {
+        create_fixed_base_constraint(composer, constraint);
+    }
+
+    // Add hash to field constraints
+    for (const auto& constraint : constraint_system.hash_to_field_constraints) {
+        create_hash_to_field_constraints(composer, constraint);
+    }
+
+    return composer;
+}
+void create_circuit_with_witness(TurboComposer& composer, const acir_format& constraint_system, std::vector<fr> witness)
+{
+    if (constraint_system.public_inputs.size() > constraint_system.varnum) {
+        std::cout << "too many public inputs!" << std::endl;
+    }
+
+    for (size_t i = 1; i < constraint_system.varnum; ++i) {
+        // If the index is in the public inputs vector, then we add it as a public input
+
+        if (std::find(constraint_system.public_inputs.begin(), constraint_system.public_inputs.end(), i) !=
+            constraint_system.public_inputs.end()) {
+
+            composer.add_public_variable(0);
+
+        } else {
+            composer.add_variable(0);
+        }
+    }
+
+    read_witness(composer, witness);
+
+    // Add arithmetic gates
+    for (const auto& constraint : constraint_system.constraints) {
+        composer.create_poly_gate(constraint);
+    }
+
+    // Add logic constraint
+    for (const auto& constraint : constraint_system.logic_constraints) {
+        create_logic_gate(
+            composer, constraint.a, constraint.b, constraint.result, constraint.num_bits, constraint.is_xor_gate);
+    }
+
+    // Add range constraint
+    for (const auto& constraint : constraint_system.range_constraints) {
+        composer.decompose_into_base4_accumulators(constraint.witness, constraint.num_bits, "");
+    }
+
+    // Add sha256 constraints
+    for (const auto& constraint : constraint_system.sha256_constraints) {
+        create_sha256_constraints(composer, constraint);
+    }
+
+    // Add merkle membership constraints
+    for (const auto& constraint : constraint_system.merkle_membership_constraints) {
+        create_merkle_check_membership_constraint(composer, constraint);
+    }
+
+    // Add schnorr constraints
+    for (const auto& constraint : constraint_system.schnorr_constraints) {
+        create_schnorr_verify_constraints(composer, constraint);
+    }
+
+    // Add ECDSA constraints
+    for (const auto& constraint : constraint_system.ecdsa_constraints) {
+        create_ecdsa_verify_constraints(composer, constraint);
+    }
+
+    // Add blake2s constraints
+    for (const auto& constraint : constraint_system.blake2s_constraints) {
+        create_blake2s_constraints(composer, constraint);
+    }
+
+    // Add pedersen constraints
+    for (const auto& constraint : constraint_system.pedersen_constraints) {
+        create_pedersen_constraint(composer, constraint);
+    }
+
+    // Add fixed base scalar mul constraints
+    for (const auto& constraint : constraint_system.fixed_base_scalar_mul_constraints) {
+        create_fixed_base_constraint(composer, constraint);
+    }
+
+    // Add hash to field constraints
+    for (const auto& constraint : constraint_system.hash_to_field_constraints) {
+        create_hash_to_field_constraints(composer, constraint);
+    }
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/acir_format.hpp
+++ b/cpp/src/aztec/dsl/acir_format/acir_format.hpp
@@ -1,0 +1,92 @@
+#pragma once
+#include "logic_constraint.hpp"
+#include "range_constraint.hpp"
+#include "sha256_constraint.hpp"
+#include "blake2s_constraint.hpp"
+#include "fixed_base_scalar_mul.hpp"
+#include "schnorr_verify.hpp"
+#include "ecdsa_secp256k1.hpp"
+#include "merkle_membership_constraint.hpp"
+#include "pedersen.hpp"
+#include "hash_to_field.hpp"
+
+namespace acir_format {
+
+struct acir_format {
+    // The number of witnesses in the circuit
+    uint32_t varnum;
+
+    std::vector<uint32_t> public_inputs;
+
+    std::vector<FixedBaseScalarMul> fixed_base_scalar_mul_constraints;
+    std::vector<LogicConstraint> logic_constraints;
+    std::vector<RangeConstraint> range_constraints;
+    std::vector<SchnorrConstraint> schnorr_constraints;
+    std::vector<EcdsaSecp256k1Constraint> ecdsa_constraints;
+    std::vector<Sha256Constraint> sha256_constraints;
+    std::vector<Blake2sConstraint> blake2s_constraints;
+    std::vector<HashToFieldConstraint> hash_to_field_constraints;
+    std::vector<PedersenConstraint> pedersen_constraints;
+    std::vector<MerkleMembershipConstraint> merkle_membership_constraints;
+    // A standard plonk arithmetic constraint, as defined in the poly_triple struct, consists of selector values
+    // for q_M,q_L,q_R,q_O,q_C and indices of three variables taking the role of left, right and output wire
+    std::vector<poly_triple> constraints;
+
+    friend bool operator==(acir_format const& lhs, acir_format const& rhs) = default;
+};
+
+void read_witness(TurboComposer& composer, std::vector<barretenberg::fr> witness);
+
+void create_circuit(TurboComposer& composer, const acir_format& constraint_system);
+
+TurboComposer create_circuit(const acir_format& constraint_system,
+                             std::unique_ptr<bonk::ReferenceStringFactory>&& crs_factory);
+
+TurboComposer create_circuit_with_witness(const acir_format& constraint_system,
+                                          std::vector<fr> witness,
+                                          std::unique_ptr<ReferenceStringFactory>&& crs_factory);
+
+TurboComposer create_circuit_with_witness(const acir_format& constraint_system, std::vector<fr> witness);
+
+void create_circuit_with_witness(TurboComposer& composer,
+                                 const acir_format& constraint_system,
+                                 std::vector<fr> witness);
+
+// Serialisation
+template <typename B> inline void read(B& buf, acir_format& data)
+{
+    using serialize::read;
+    read(buf, data.varnum);
+    read(buf, data.public_inputs);
+    read(buf, data.logic_constraints);
+    read(buf, data.range_constraints);
+    read(buf, data.sha256_constraints);
+    read(buf, data.merkle_membership_constraints);
+    read(buf, data.schnorr_constraints);
+    read(buf, data.ecdsa_constraints);
+    read(buf, data.blake2s_constraints);
+    read(buf, data.pedersen_constraints);
+    read(buf, data.hash_to_field_constraints);
+    read(buf, data.fixed_base_scalar_mul_constraints);
+    read(buf, data.constraints);
+}
+
+template <typename B> inline void write(B& buf, acir_format const& data)
+{
+    using serialize::write;
+    write(buf, data.varnum);
+    write(buf, data.public_inputs);
+    write(buf, data.logic_constraints);
+    write(buf, data.range_constraints);
+    write(buf, data.sha256_constraints);
+    write(buf, data.merkle_membership_constraints);
+    write(buf, data.schnorr_constraints);
+    write(buf, data.ecdsa_constraints);
+    write(buf, data.blake2s_constraints);
+    write(buf, data.pedersen_constraints);
+    write(buf, data.hash_to_field_constraints);
+    write(buf, data.fixed_base_scalar_mul_constraints);
+    write(buf, data.constraints);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/blake2s_constraint.cpp
+++ b/cpp/src/aztec/dsl/acir_format/blake2s_constraint.cpp
@@ -1,0 +1,40 @@
+#include "blake2s_constraint.hpp"
+#include "round.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace acir_format {
+
+void create_blake2s_constraints(plonk::TurboComposer& composer, const Blake2sConstraint& constraint)
+{
+
+    // Create byte array struct
+    byte_array_ct arr(&composer);
+
+    // Get the witness assignment for each witness index
+    // Write the witness assignment to the byte_array
+    for (const auto& witness_index_num_bits : constraint.inputs) {
+        auto witness_index = witness_index_num_bits.witness;
+        auto num_bits = witness_index_num_bits.num_bits;
+
+        // XXX: The implementation requires us to truncate the element to the nearest byte and not bit
+        auto num_bytes = round_to_nearest_byte(num_bits);
+
+        field_ct element = field_ct::from_witness_index(&composer, witness_index);
+        byte_array_ct element_bytes(element, num_bytes);
+
+        arr.write(element_bytes);
+    }
+
+    byte_array_ct output_bytes = plonk::stdlib::blake2s<plonk::TurboComposer>(arr);
+
+    // Convert byte array to vector of field_t
+    auto bytes = output_bytes.bytes();
+
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        composer.assert_equal(bytes[i].normalize().witness_index, constraint.result[i]);
+    }
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/blake2s_constraint.hpp
+++ b/cpp/src/aztec/dsl/acir_format/blake2s_constraint.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct Blake2sInput {
+    uint32_t witness;
+    uint32_t num_bits;
+
+    friend bool operator==(Blake2sInput const& lhs, Blake2sInput const& rhs) = default;
+};
+
+struct Blake2sConstraint {
+    std::vector<Blake2sInput> inputs;
+    std::vector<uint32_t> result;
+
+    friend bool operator==(Blake2sConstraint const& lhs, Blake2sConstraint const& rhs) = default;
+};
+
+void create_blake2s_constraints(plonk::TurboComposer& composer, const Blake2sConstraint& constraint);
+
+template <typename B> inline void read(B& buf, Blake2sInput& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.witness);
+    read(buf, constraint.num_bits);
+}
+
+template <typename B> inline void write(B& buf, Blake2sInput const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.witness);
+    write(buf, constraint.num_bits);
+}
+
+template <typename B> inline void read(B& buf, Blake2sConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.inputs);
+    read(buf, constraint.result);
+}
+
+template <typename B> inline void write(B& buf, Blake2sConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.inputs);
+    write(buf, constraint.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -1,0 +1,111 @@
+#include "ecdsa_secp256k1.hpp"
+#include "crypto/ecdsa/ecdsa.hpp"
+#include "stdlib/encryption/ecdsa/ecdsa.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace acir_format {
+
+crypto::ecdsa::signature ecdsa_convert_signature(plonk::TurboComposer& composer, std::vector<uint32_t> signature)
+{
+
+    crypto::ecdsa::signature signature_cr;
+
+    // Get the witness assignment for each witness index
+    // Write the witness assignment to the byte_array
+
+    for (unsigned int i = 0; i < 32; i++) {
+        auto witness_index = signature[i];
+
+        std::vector<uint8_t> fr_bytes(sizeof(fr));
+
+        fr value = composer.get_variable(witness_index);
+
+        fr::serialize_to_buffer(value, &fr_bytes[0]);
+
+        signature_cr.r[i] = fr_bytes.back();
+    }
+
+    for (unsigned int i = 32; i < 64; i++) {
+        auto witness_index = signature[i];
+
+        std::vector<uint8_t> fr_bytes(sizeof(fr));
+
+        fr value = composer.get_variable(witness_index);
+
+        fr::serialize_to_buffer(value, &fr_bytes[0]);
+
+        signature_cr.s[i - 32] = fr_bytes.back();
+    }
+
+    return signature_cr;
+}
+
+// fq, fr, g1
+
+secp256k1_ct::g1_ct ecdsa_convert_inputs(plonk::TurboComposer* ctx, const secp256k1::g1::affine_element& input)
+{
+    uint256_t x_u256(input.x);
+    uint256_t y_u256(input.y);
+    secp256k1_ct::fq_ct x(witness_ct(ctx, barretenberg::fr(x_u256.slice(0, secp256k1_ct::fq_ct::NUM_LIMB_BITS * 2))),
+                          witness_ct(ctx,
+                                     barretenberg::fr(x_u256.slice(secp256k1_ct::fq_ct::NUM_LIMB_BITS * 2,
+                                                                   secp256k1_ct::fq_ct::NUM_LIMB_BITS * 4))));
+    secp256k1_ct::fq_ct y(witness_ct(ctx, barretenberg::fr(y_u256.slice(0, secp256k1_ct::fq_ct::NUM_LIMB_BITS * 2))),
+                          witness_ct(ctx,
+                                     barretenberg::fr(y_u256.slice(secp256k1_ct::fq_ct::NUM_LIMB_BITS * 2,
+                                                                   secp256k1_ct::fq_ct::NUM_LIMB_BITS * 4))));
+
+    return { x, y };
+}
+
+// vector of bytes here, assumes that the witness indices point to a field element which can be represented
+// with just a byte.
+// notice that this function truncates each field_element to a byte
+byte_array_ct ecdsa_vector_of_bytes_to_byte_array(plonk::TurboComposer& composer, std::vector<uint32_t> vector_of_bytes)
+{
+    byte_array_ct arr(&composer);
+
+    // Get the witness assignment for each witness index
+    // Write the witness assignment to the byte_array
+    for (const auto& witness_index : vector_of_bytes) {
+
+        field_ct element = field_ct::from_witness_index(&composer, witness_index);
+        size_t num_bytes = 1;
+
+        byte_array_ct element_bytes(element, num_bytes);
+        arr.write(element_bytes);
+    }
+    return arr;
+}
+witness_ct ecdsa_index_to_witness(plonk::TurboComposer& composer, uint32_t index)
+{
+    fr value = composer.get_variable(index);
+    return { &composer, value };
+}
+
+void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const EcdsaSecp256k1Constraint& input)
+{
+
+    auto new_sig = ecdsa_convert_signature(composer, input.signature);
+
+    auto message = ecdsa_vector_of_bytes_to_byte_array(composer, input.message);
+    auto pub_key_x_byte_arr = ecdsa_vector_of_bytes_to_byte_array(composer, input.pub_x_indices);
+    auto pub_key_y_byte_arr = ecdsa_vector_of_bytes_to_byte_array(composer, input.pub_y_indices);
+
+    auto pub_key_x_fq = secp256k1_ct::fq_ct(pub_key_x_byte_arr);
+    auto pub_key_y_fq = secp256k1_ct::fq_ct(pub_key_y_byte_arr);
+
+    std::vector<uint8_t> rr(new_sig.r.begin(), new_sig.r.end());
+    std::vector<uint8_t> ss(new_sig.s.begin(), new_sig.s.end());
+
+    stdlib::ecdsa::signature<plonk::TurboComposer> sig{ stdlib::byte_array<plonk::TurboComposer>(&composer, rr),
+                                                        stdlib::byte_array<plonk::TurboComposer>(&composer, ss) };
+
+    auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
+
+    composer.assert_equal(false, input.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -103,7 +103,18 @@ void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const Ecdsa
     stdlib::ecdsa::signature<plonk::TurboComposer> sig{ stdlib::byte_array<plonk::TurboComposer>(&composer, rr),
                                                         stdlib::byte_array<plonk::TurboComposer>(&composer, ss) };
 
-    auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
+    pub_key_x_fq.assert_is_in_field();
+    pub_key_y_fq.assert_is_in_field();
+
+    // TODO: crypto-dev to fix calculation and constraining of the signature result is correct
+    // the above line is currently a placeholder as unused variabels are not allowed in the build
+    // auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
+    // bool_ct signature_result = stdlib::ecdsa::
+    //     verify_signature<plonk::TurboComposer, secp256k1_ct::fq_ct, secp256k1_ct::bigfr_ct,
+    //     secp256k1_ct::g1_bigfr_ct>(
+    //         message, pub_key, sig);
+
+    // auto result_bool = composer.add_variable(signature_result.get_value() == true);
 
     composer.assert_equal(false, input.result);
 }

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.hpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <vector>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct EcdsaSecp256k1Constraint {
+    // This is just a bunch of bytes
+    // which need to be interpreted as a string
+    // Note this must be a bunch of bytes
+    std::vector<uint32_t> message;
+
+    // This is the supposed public key which signed the
+    // message, giving rise to the signature.
+    // Since Fr does not have enough bits to represent
+    // the prime field in secp256k1, a byte array is used.
+    // Can also use low and hi where lo=128 bits
+    std::vector<uint32_t> pub_x_indices;
+    std::vector<uint32_t> pub_y_indices;
+
+    // This is the result of verifying the signature
+    uint32_t result;
+
+    // This is the computed signature
+    //
+    std::vector<uint32_t> signature;
+
+    friend bool operator==(EcdsaSecp256k1Constraint const& lhs, EcdsaSecp256k1Constraint const& rhs) = default;
+};
+
+void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const EcdsaSecp256k1Constraint& input);
+
+template <typename B> inline void read(B& buf, EcdsaSecp256k1Constraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.message);
+    read(buf, constraint.signature);
+    read(buf, constraint.pub_x_indices);
+    read(buf, constraint.pub_y_indices);
+    read(buf, constraint.result);
+}
+
+template <typename B> inline void write(B& buf, EcdsaSecp256k1Constraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.message);
+    write(buf, constraint.signature);
+    write(buf, constraint.pub_x_indices);
+    write(buf, constraint.pub_y_indices);
+    write(buf, constraint.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/fixed_base_scalar_mul.cpp
+++ b/cpp/src/aztec/dsl/acir_format/fixed_base_scalar_mul.cpp
@@ -1,0 +1,18 @@
+#include "fixed_base_scalar_mul.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace acir_format {
+
+void create_fixed_base_constraint(plonk::TurboComposer& composer, const FixedBaseScalarMul& input)
+{
+
+    field_ct scalar_as_field = field_ct::from_witness_index(&composer, input.scalar);
+    auto public_key = group_ct::fixed_base_scalar_mul_g1<254>(scalar_as_field);
+
+    composer.assert_equal(public_key.x.witness_index, input.pub_key_x);
+    composer.assert_equal(public_key.y.witness_index, input.pub_key_y);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/fixed_base_scalar_mul.hpp
+++ b/cpp/src/aztec/dsl/acir_format/fixed_base_scalar_mul.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <cstdint>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct FixedBaseScalarMul {
+    uint32_t scalar;
+    uint32_t pub_key_x;
+    uint32_t pub_key_y;
+
+    friend bool operator==(FixedBaseScalarMul const& lhs, FixedBaseScalarMul const& rhs) = default;
+};
+
+void create_fixed_base_constraint(plonk::TurboComposer& composer, const FixedBaseScalarMul& input);
+
+template <typename B> inline void read(B& buf, FixedBaseScalarMul& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.scalar);
+    read(buf, constraint.pub_key_x);
+    read(buf, constraint.pub_key_y);
+}
+
+template <typename B> inline void write(B& buf, FixedBaseScalarMul const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.scalar);
+    write(buf, constraint.pub_key_x);
+    write(buf, constraint.pub_key_y);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/hash_to_field.cpp
+++ b/cpp/src/aztec/dsl/acir_format/hash_to_field.cpp
@@ -1,0 +1,42 @@
+#include "hash_to_field.hpp"
+#include "round.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace acir_format {
+
+void create_hash_to_field_constraints(plonk::TurboComposer& composer, const HashToFieldConstraint constraint)
+{
+
+    // Create byte array struct
+    byte_array_ct arr(&composer);
+
+    // Get the witness assignment for each witness index
+    // Write the witness assignment to the byte_array
+    for (const auto& witness_index_num_bits : constraint.inputs) {
+        auto witness_index = witness_index_num_bits.witness;
+        auto num_bits = witness_index_num_bits.num_bits;
+
+        // XXX: The implementation requires us to truncate the element to the nearest byte and not bit
+        auto num_bytes = round_to_nearest_byte(num_bits);
+
+        field_ct element = field_ct::from_witness_index(&composer, witness_index);
+        byte_array_ct element_bytes(element, num_bytes);
+        byte_array_ct reversed_bytes = element_bytes.reverse();
+
+        arr.write(reversed_bytes);
+    }
+
+    // Hash To Field using blake2s.
+    // Note: It does not need to be blake2s in the future
+
+    byte_array_ct out_bytes = plonk::stdlib::blake2s<plonk::TurboComposer>(arr);
+
+    field_ct out(out_bytes);
+    field_ct normalised_out = out.normalize();
+
+    composer.assert_equal(normalised_out.witness_index, constraint.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/hash_to_field.hpp
+++ b/cpp/src/aztec/dsl/acir_format/hash_to_field.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct HashToFieldInput {
+    uint32_t witness;
+    uint32_t num_bits;
+
+    friend bool operator==(HashToFieldInput const& lhs, HashToFieldInput const& rhs) = default;
+};
+
+struct HashToFieldConstraint {
+    std::vector<HashToFieldInput> inputs;
+    uint32_t result;
+
+    friend bool operator==(HashToFieldConstraint const& lhs, HashToFieldConstraint const& rhs) = default;
+};
+
+void create_hash_to_field_constraints(plonk::TurboComposer& composer, HashToFieldConstraint constraint);
+
+template <typename B> inline void read(B& buf, HashToFieldInput& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.witness);
+    read(buf, constraint.num_bits);
+}
+
+template <typename B> inline void write(B& buf, HashToFieldInput const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.witness);
+    write(buf, constraint.num_bits);
+}
+
+template <typename B> inline void read(B& buf, HashToFieldConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.inputs);
+    read(buf, constraint.result);
+}
+
+template <typename B> inline void write(B& buf, HashToFieldConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.inputs);
+    write(buf, constraint.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/logic_constraint.cpp
+++ b/cpp/src/aztec/dsl/acir_format/logic_constraint.cpp
@@ -1,0 +1,24 @@
+#include "logic_constraint.hpp"
+
+namespace acir_format {
+
+void create_logic_gate(TurboComposer& composer,
+                       const uint32_t a,
+                       const uint32_t b,
+                       const uint32_t result,
+                       const size_t num_bits,
+                       const bool is_xor_gate)
+{
+    auto accumulators = composer.create_logic_constraint(a, b, num_bits, is_xor_gate);
+    composer.assert_equal(accumulators.out.back(), result);
+}
+void xor_gate(TurboComposer& composer, const uint32_t a, const uint32_t b, const uint32_t result, const size_t num_bits)
+{
+    create_logic_gate(composer, a, b, result, num_bits, true);
+}
+void and_gate(TurboComposer& composer, const uint32_t a, const uint32_t b, const uint32_t result, const size_t num_bits)
+{
+    create_logic_gate(composer, a, b, result, num_bits, false);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/logic_constraint.hpp
+++ b/cpp/src/aztec/dsl/acir_format/logic_constraint.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <cstdint>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct LogicConstraint {
+    uint32_t a;
+    uint32_t b;
+    uint32_t result;
+    uint32_t num_bits;
+    uint32_t is_xor_gate;
+
+    friend bool operator==(LogicConstraint const& lhs, LogicConstraint const& rhs) = default;
+};
+
+void create_logic_gate(
+    TurboComposer& composer, uint32_t a, uint32_t b, uint32_t result, size_t num_bits, bool is_xor_gate);
+
+void xor_gate(TurboComposer& composer, uint32_t a, uint32_t b, uint32_t result, size_t num_bits);
+
+void and_gate(TurboComposer& composer, uint32_t a, uint32_t b, uint32_t result, size_t num_bits);
+
+template <typename B> inline void read(B& buf, LogicConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.a);
+    read(buf, constraint.b);
+    read(buf, constraint.result);
+    read(buf, constraint.num_bits);
+    read(buf, constraint.is_xor_gate);
+}
+
+template <typename B> inline void write(B& buf, LogicConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.a);
+    write(buf, constraint.b);
+    write(buf, constraint.result);
+    write(buf, constraint.num_bits);
+    write(buf, constraint.is_xor_gate);
+}
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/merkle_membership_constraint.cpp
+++ b/cpp/src/aztec/dsl/acir_format/merkle_membership_constraint.cpp
@@ -1,0 +1,47 @@
+#include "merkle_membership_constraint.hpp"
+#include "stdlib/merkle_tree/membership.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+using namespace plonk::stdlib::merkle_tree;
+
+namespace acir_format {
+
+void create_merkle_check_membership_constraint(plonk::TurboComposer& composer, const MerkleMembershipConstraint& input)
+{
+    // Convert value from a witness index into a field element.
+    // This is the hash of the message. In Barretenberg, this would be input.value = hash_value(message)
+    field_ct leaf = field_ct::from_witness_index(&composer, input.leaf);
+
+    // Convert index from a witness index into a byte array
+    field_ct index_field = field_ct::from_witness_index(&composer, input.index);
+    auto index_bits = index_field.decompose_into_bits();
+
+    // Convert root into a field_ct
+    field_ct root = field_ct::from_witness_index(&composer, input.root);
+
+    // We are given the HashPath as a Vec<fr>
+    // We want to first convert it into a Vec<(fr, fr)> then cast this to hash_path
+    // struct which requires the method create_witness_hashpath
+    hash_path<plonk::TurboComposer> hash_path;
+
+    // In Noir we accept a hash path that only contains one hash per tree level
+    // It is ok to reuse the leaf as it will be overridden in check_subtree_membership when computing the current root
+    // at each tree level
+    for (size_t i = 0; i < input.hash_path.size(); i++) {
+        if (!index_bits[i].get_value()) {
+            field_ct left = leaf;
+            field_ct right = field_ct::from_witness_index(&composer, input.hash_path[i]);
+            hash_path.push_back(std::make_pair(left, right));
+        } else {
+            field_ct left = field_ct::from_witness_index(&composer, input.hash_path[i]);
+            field_ct right = leaf;
+            hash_path.push_back(std::make_pair(left, right));
+        }
+    }
+
+    auto exists = check_subtree_membership(root, hash_path, leaf, index_bits, 0);
+    composer.assert_equal_constant(exists.witness_index, fr::one());
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/merkle_membership_constraint.hpp
+++ b/cpp/src/aztec/dsl/acir_format/merkle_membership_constraint.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <vector>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct MerkleMembershipConstraint {
+    std::vector<uint32_t> hash_path; // Vector of pairs of hashpaths. eg indices 0,1 denotes the pair (0,1)
+    uint32_t root;                   // Single field element -- field_t
+    uint32_t leaf;                   // Single field element -- field_t
+    uint32_t result;                 // Single field element -- bool_t
+    uint32_t index;
+
+    friend bool operator==(MerkleMembershipConstraint const& lhs, MerkleMembershipConstraint const& rhs) = default;
+};
+
+void create_merkle_check_membership_constraint(plonk::TurboComposer& composer, const MerkleMembershipConstraint& input);
+
+template <typename B> inline void read(B& buf, MerkleMembershipConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.hash_path);
+    read(buf, constraint.root);
+    read(buf, constraint.leaf);
+    read(buf, constraint.result);
+    read(buf, constraint.index);
+}
+
+template <typename B> inline void write(B& buf, MerkleMembershipConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.hash_path);
+    write(buf, constraint.root);
+    write(buf, constraint.leaf);
+    write(buf, constraint.result);
+    write(buf, constraint.index);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/pedersen.cpp
+++ b/cpp/src/aztec/dsl/acir_format/pedersen.cpp
@@ -1,0 +1,23 @@
+#include "pedersen.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace acir_format {
+
+void create_pedersen_constraint(plonk::TurboComposer& composer, const PedersenConstraint& input)
+{
+    std::vector<field_ct> scalars;
+
+    for (const auto& scalar : input.scalars) {
+        // convert input indices to field_ct
+        field_ct scalar_as_field = field_ct::from_witness_index(&composer, scalar);
+        scalars.push_back(scalar_as_field);
+    }
+    auto point = pedersen::commit(scalars);
+
+    composer.assert_equal(point.x.witness_index, input.result_x);
+    composer.assert_equal(point.y.witness_index, input.result_y);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/pedersen.hpp
+++ b/cpp/src/aztec/dsl/acir_format/pedersen.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <vector>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+// P = xG + bH
+struct PedersenConstraint {
+    std::vector<uint32_t> scalars;
+    uint32_t result_x;
+    uint32_t result_y;
+
+    friend bool operator==(PedersenConstraint const& lhs, PedersenConstraint const& rhs) = default;
+};
+
+void create_pedersen_constraint(plonk::TurboComposer& composer, const PedersenConstraint& input);
+
+template <typename B> inline void read(B& buf, PedersenConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.scalars);
+    read(buf, constraint.result_x);
+    read(buf, constraint.result_y);
+}
+
+template <typename B> inline void write(B& buf, PedersenConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.scalars);
+    read(buf, constraint.result_x);
+    read(buf, constraint.result_y);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/range_constraint.hpp
+++ b/cpp/src/aztec/dsl/acir_format/range_constraint.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <cstdint>
+#include "common/serialize.hpp"
+
+namespace acir_format {
+
+struct RangeConstraint {
+    uint32_t witness;
+    uint32_t num_bits;
+
+    friend bool operator==(RangeConstraint const& lhs, RangeConstraint const& rhs) = default;
+};
+
+template <typename B> inline void read(B& buf, RangeConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.witness);
+    read(buf, constraint.num_bits);
+}
+
+template <typename B> inline void write(B& buf, RangeConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.witness);
+    write(buf, constraint.num_bits);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/round.cpp
+++ b/cpp/src/aztec/dsl/acir_format/round.cpp
@@ -1,0 +1,22 @@
+#include "round.hpp"
+
+namespace acir_format {
+
+// Rounds a number to the nearest multiple of 8
+uint32_t round_to_nearest_mul_8(uint32_t num_bits)
+{
+    uint32_t remainder = num_bits % 8;
+    if (remainder == 0) {
+        return num_bits;
+    }
+
+    return num_bits + 8 - remainder;
+}
+
+// Rounds the number of bits to the nearest byte
+uint32_t round_to_nearest_byte(uint32_t num_bits)
+{
+    return round_to_nearest_mul_8(num_bits) / 8;
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/round.hpp
+++ b/cpp/src/aztec/dsl/acir_format/round.hpp
@@ -1,0 +1,11 @@
+#include <cstdint>
+
+namespace acir_format {
+
+// Rounds a number to the nearest multiple of 8
+uint32_t round_to_nearest_mul_8(uint32_t num_bits);
+
+// Rounds the number of bits to the nearest byte
+uint32_t round_to_nearest_byte(uint32_t num_bits);
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/schnorr_verify.cpp
+++ b/cpp/src/aztec/dsl/acir_format/schnorr_verify.cpp
@@ -1,0 +1,95 @@
+#include "schnorr_verify.hpp"
+#include "crypto/schnorr/schnorr.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace acir_format {
+
+crypto::schnorr::signature convert_signature(plonk::TurboComposer& composer, std::vector<uint32_t> signature)
+{
+
+    crypto::schnorr::signature signature_cr;
+
+    // Get the witness assignment for each witness index
+    // Write the witness assignment to the byte_array
+
+    for (unsigned int i = 0; i < 32; i++) {
+        auto witness_index = signature[i];
+
+        std::vector<uint8_t> fr_bytes(sizeof(fr));
+
+        fr value = composer.get_variable(witness_index);
+
+        fr::serialize_to_buffer(value, &fr_bytes[0]);
+
+        signature_cr.s[i] = fr_bytes.back();
+    }
+
+    for (unsigned int i = 32; i < 64; i++) {
+        auto witness_index = signature[i];
+
+        std::vector<uint8_t> fr_bytes(sizeof(fr));
+
+        fr value = composer.get_variable(witness_index);
+
+        fr::serialize_to_buffer(value, &fr_bytes[0]);
+
+        signature_cr.e[i - 32] = fr_bytes.back();
+    }
+
+    return signature_cr;
+}
+// vector of bytes here, assumes that the witness indices point to a field element which can be represented
+// with just a byte.
+// notice that this function truncates each field_element to a byte
+byte_array_ct vector_of_bytes_to_byte_array(plonk::TurboComposer& composer, std::vector<uint32_t> vector_of_bytes)
+{
+    byte_array_ct arr(&composer);
+
+    // Get the witness assignment for each witness index
+    // Write the witness assignment to the byte_array
+    for (const auto& witness_index : vector_of_bytes) {
+
+        field_ct element = field_ct::from_witness_index(&composer, witness_index);
+        size_t num_bytes = 1;
+
+        byte_array_ct element_bytes(element, num_bytes);
+        arr.write(element_bytes);
+    }
+    return arr;
+}
+witness_ct index_to_witness(plonk::TurboComposer& composer, uint32_t index)
+{
+    fr value = composer.get_variable(index);
+    return { &composer, value };
+}
+
+void create_schnorr_verify_constraints(plonk::TurboComposer& composer, const SchnorrConstraint& input)
+{
+
+    auto new_sig = convert_signature(composer, input.signature);
+    // From ignorance, you will see me convert a bunch of witnesses from ByteArray -> BitArray
+    // This may not be the most efficient way to do it. It is being used as it is known to work,
+    // optimisations are welcome!
+
+    // First convert the message of u8 witnesses into a byte_array
+    // Do this by taking each element as a u8 and writing it to the byte array
+
+    auto message = vector_of_bytes_to_byte_array(composer, input.message);
+
+    fr pubkey_value_x = composer.get_variable(input.public_key_x);
+    fr pubkey_value_y = composer.get_variable(input.public_key_y);
+
+    point_ct pub_key{ witness_ct(&composer, pubkey_value_x), witness_ct(&composer, pubkey_value_y) };
+
+    schnorr::signature_bits sig = stdlib::schnorr::convert_signature(&composer, new_sig);
+
+    bool_ct signature_result = stdlib::schnorr::signature_verification_result(message, pub_key, sig);
+
+    bool_ct signature_result_normalized = signature_result.normalize();
+
+    composer.assert_equal(signature_result_normalized.witness_index, input.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/schnorr_verify.hpp
+++ b/cpp/src/aztec/dsl/acir_format/schnorr_verify.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include <vector>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct SchnorrConstraint {
+    // This is just a bunch of bytes
+    // which need to be interpreted as a string
+    // Note this must be a bunch of bytes
+    std::vector<uint32_t> message;
+
+    // This is the supposed public key which signed the
+    // message, giving rise to the signature
+    uint32_t public_key_x;
+    uint32_t public_key_y;
+
+    // This is the result of verifying the signature
+    uint32_t result;
+
+    // This is the computed signature
+    //
+    std::vector<uint32_t> signature;
+
+    friend bool operator==(SchnorrConstraint const& lhs, SchnorrConstraint const& rhs) = default;
+};
+
+void create_schnorr_verify_constraints(plonk::TurboComposer& composer, const SchnorrConstraint& input);
+
+template <typename B> inline void read(B& buf, SchnorrConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.message);
+    read(buf, constraint.signature);
+    read(buf, constraint.public_key_x);
+    read(buf, constraint.public_key_y);
+    read(buf, constraint.result);
+}
+
+template <typename B> inline void write(B& buf, SchnorrConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.message);
+    write(buf, constraint.signature);
+    write(buf, constraint.public_key_x);
+    write(buf, constraint.public_key_y);
+    write(buf, constraint.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/sha256_constraint.cpp
+++ b/cpp/src/aztec/dsl/acir_format/sha256_constraint.cpp
@@ -1,0 +1,44 @@
+#include "sha256_constraint.hpp"
+#include "round.hpp"
+#include "stdlib/hash/sha256/sha256.hpp"
+#include "stdlib/types/types.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace acir_format {
+
+// This function does not work (properly) because the stdlib:sha256 function is not working correctly for 512 bits
+// pair<witness_index, bits>
+void create_sha256_constraints(plonk::TurboComposer& composer, const Sha256Constraint& constraint)
+{
+
+    // Create byte array struct
+    byte_array_ct arr(&composer);
+
+    // Get the witness assignment for each witness index
+    // Write the witness assignment to the byte_array
+    for (const auto& witness_index_num_bits : constraint.inputs) {
+        auto witness_index = witness_index_num_bits.witness;
+        auto num_bits = witness_index_num_bits.num_bits;
+
+        // XXX: The implementation requires us to truncate the element to the nearest byte and not bit
+        auto num_bytes = round_to_nearest_byte(num_bits);
+
+        field_ct element = field_ct::from_witness_index(&composer, witness_index);
+        byte_array_ct element_bytes(element, num_bytes);
+
+        arr.write(element_bytes);
+    }
+
+    // Compute sha256
+    byte_array_ct output_bytes = plonk::stdlib::sha256<plonk::TurboComposer>(arr);
+
+    // Convert byte array to vector of field_t
+    auto bytes = output_bytes.bytes();
+
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        composer.assert_equal(bytes[i].normalize().witness_index, constraint.result[i]);
+    }
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/sha256_constraint.hpp
+++ b/cpp/src/aztec/dsl/acir_format/sha256_constraint.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "plonk/composer/turbo_composer.hpp"
+
+namespace acir_format {
+
+struct Sha256Input {
+    uint32_t witness;
+    uint32_t num_bits;
+
+    friend bool operator==(Sha256Input const& lhs, Sha256Input const& rhs) = default;
+};
+
+struct Sha256Constraint {
+    std::vector<Sha256Input> inputs;
+    std::vector<uint32_t> result;
+
+    friend bool operator==(Sha256Constraint const& lhs, Sha256Constraint const& rhs) = default;
+};
+
+// This function does not work (properly) because the stdlib:sha256 function is not working correctly for 512 bits
+// pair<witness_index, bits>
+void create_sha256_constraints(plonk::TurboComposer& composer, const Sha256Constraint& constraint);
+
+template <typename B> inline void read(B& buf, Sha256Input& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.witness);
+    read(buf, constraint.num_bits);
+}
+
+template <typename B> inline void write(B& buf, Sha256Input const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.witness);
+    write(buf, constraint.num_bits);
+}
+
+template <typename B> inline void read(B& buf, Sha256Constraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.inputs);
+    read(buf, constraint.result);
+}
+
+template <typename B> inline void write(B& buf, Sha256Constraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.inputs);
+    write(buf, constraint.result);
+}
+
+} // namespace acir_format

--- a/cpp/src/aztec/dsl/turbo_proofs/CMakeLists.txt
+++ b/cpp/src/aztec/dsl/turbo_proofs/CMakeLists.txt
@@ -1,0 +1,5 @@
+barretenberg_module(
+    turbo_proofs
+    acir_format
+    plonk
+)

--- a/cpp/src/aztec/dsl/turbo_proofs/c_bind.cpp
+++ b/cpp/src/aztec/dsl/turbo_proofs/c_bind.cpp
@@ -1,0 +1,43 @@
+#include "c_bind.hpp"
+#include "turbo_proofs.hpp"
+#include <cstdint>
+
+#define WASM_EXPORT __attribute__((visibility("default")))
+
+extern "C" {
+
+// Get the exact circuit size for the constraint system.
+WASM_EXPORT uint32_t turbo_get_exact_circuit_size(uint8_t const* constraint_system_buf)
+{
+    return turbo_proofs::turbo_get_exact_circuit_size(constraint_system_buf);
+}
+
+WASM_EXPORT size_t turbo_init_proving_key(uint8_t const* constraint_system_buf, uint8_t const** pk_buf)
+{
+    return turbo_proofs::turbo_init_proving_key(constraint_system_buf, pk_buf);
+}
+
+WASM_EXPORT size_t turbo_init_verification_key(void* pippenger,
+                                               uint8_t const* g2x,
+                                               uint8_t const* pk_buf,
+                                               uint8_t const** vk_buf)
+{
+    return turbo_proofs::turbo_init_verification_key(pippenger, g2x, pk_buf, vk_buf);
+}
+
+WASM_EXPORT size_t turbo_new_proof(void* pippenger,
+                                   uint8_t const* g2x,
+                                   uint8_t const* pk_buf,
+                                   uint8_t const* constraint_system_buf,
+                                   uint8_t const* witness_buf,
+                                   uint8_t** proof_data_buf)
+{
+    return turbo_proofs::turbo_new_proof(pippenger, g2x, pk_buf, constraint_system_buf, witness_buf, proof_data_buf);
+}
+
+WASM_EXPORT bool turbo_verify_proof(
+    uint8_t const* g2x, uint8_t const* vk_buf, uint8_t const* constraint_system_buf, uint8_t* proof, uint32_t length)
+{
+    return turbo_proofs::turbo_verify_proof(g2x, vk_buf, constraint_system_buf, proof, length);
+}
+}

--- a/cpp/src/aztec/dsl/turbo_proofs/c_bind.hpp
+++ b/cpp/src/aztec/dsl/turbo_proofs/c_bind.hpp
@@ -1,0 +1,24 @@
+#include <cstdint>
+#include <cstddef>
+
+#define WASM_EXPORT __attribute__((visibility("default")))
+
+extern "C" {
+
+WASM_EXPORT uint32_t turbo_get_exact_circuit_size(uint8_t const* constraint_system_buf);
+
+// Construct composer using prover and verifier key buffers
+WASM_EXPORT size_t turbo_init_proving_key(uint8_t const* constraint_system_buf, uint8_t const** pk_buf);
+WASM_EXPORT size_t turbo_init_verification_key(void* pippenger,
+                                               uint8_t const* g2x,
+                                               uint8_t const* pk_buf,
+                                               uint8_t const** vk_buf);
+WASM_EXPORT size_t turbo_new_proof(void* pippenger,
+                                   uint8_t const* g2x,
+                                   uint8_t const* pk_buf,
+                                   uint8_t const* constraint_system_buf,
+                                   uint8_t const* witness_buf,
+                                   uint8_t** proof_data_buf);
+WASM_EXPORT bool turbo_verify_proof(
+    uint8_t const* g2x, uint8_t const* vk_buf, uint8_t const* constraint_system_buf, uint8_t* proof, uint32_t length);
+}

--- a/cpp/src/aztec/dsl/turbo_proofs/turbo_proofs.cpp
+++ b/cpp/src/aztec/dsl/turbo_proofs/turbo_proofs.cpp
@@ -1,0 +1,136 @@
+
+#include "turbo_proofs.hpp"
+#include "proof_system/proving_key/serialize.hpp"
+#include "dsl/acir_format/acir_format.hpp"
+#include "stdlib/types/types.hpp"
+#include "srs/reference_string/pippenger_reference_string.hpp"
+
+using namespace plonk::stdlib::types;
+
+namespace turbo_proofs {
+
+uint32_t turbo_get_exact_circuit_size(uint8_t const* constraint_system_buf)
+{
+    auto constraint_system = from_buffer<acir_format::acir_format>(constraint_system_buf);
+    auto crs_factory = std::make_unique<bonk::ReferenceStringFactory>();
+    auto composer = create_circuit(constraint_system, std::move(crs_factory));
+
+    auto num_gates = composer.get_num_gates();
+    return static_cast<uint32_t>(num_gates);
+}
+
+size_t turbo_init_proving_key(uint8_t const* constraint_system_buf, uint8_t const** pk_buf)
+{
+    auto constraint_system = from_buffer<acir_format::acir_format>(constraint_system_buf);
+    // We know that we don't actually need any CRS to create a proving key, so just feed in a nothing.
+    // Hacky, but, right now it needs *something*.
+    auto crs_factory = std::make_unique<ReferenceStringFactory>();
+    auto composer = create_circuit(constraint_system, std::move(crs_factory));
+    auto proving_key = composer.compute_proving_key();
+
+    // Computing the size of the serialized key is non trivial. We know it's ~331mb.
+    // Allocate a buffer large enough to hold it, and abort if we overflow.
+    // This is to keep memory usage down.
+    size_t total_buf_len = 350 * 1024 * 1024;
+    auto raw_buf = (uint8_t*)malloc(total_buf_len);
+    auto raw_buf_end = raw_buf;
+    write(raw_buf_end, *proving_key);
+    *pk_buf = raw_buf;
+    auto len = static_cast<uint32_t>(raw_buf_end - raw_buf);
+    if (len > total_buf_len) {
+        info("Buffer overflow serializing proving key.");
+        std::abort();
+    }
+    return len;
+}
+
+size_t turbo_init_verification_key(void* pippenger, uint8_t const* g2x, uint8_t const* pk_buf, uint8_t const** vk_buf)
+{
+    std::shared_ptr<ProverReferenceString> crs;
+    bonk::proving_key_data pk_data;
+    read(pk_buf, pk_data);
+    auto proving_key = std::make_shared<bonk::proving_key>(std::move(pk_data), crs);
+
+    auto crs_factory = std::make_unique<PippengerReferenceStringFactory>(
+        reinterpret_cast<scalar_multiplication::Pippenger*>(pippenger), g2x);
+    proving_key->reference_string = crs_factory->get_prover_crs(proving_key->circuit_size);
+
+    TurboComposer composer(proving_key, nullptr);
+    auto verification_key =
+        plonk::stdlib::types::Composer::compute_verification_key_base(proving_key, crs_factory->get_verifier_crs());
+
+    // The composer_type has not yet been set. We need to set the composer_type for when we later read in and
+    // construct the verification key so that we have the correct polynomial manifest
+    verification_key->composer_type = ComposerType::TURBO;
+
+    auto buffer = to_buffer(*verification_key);
+    auto raw_buf = (uint8_t*)malloc(buffer.size());
+    memcpy(raw_buf, (void*)buffer.data(), buffer.size());
+    *vk_buf = raw_buf;
+
+    return buffer.size();
+}
+
+size_t turbo_new_proof(void* pippenger,
+                       uint8_t const* g2x,
+                       uint8_t const* pk_buf,
+                       uint8_t const* constraint_system_buf,
+                       uint8_t const* witness_buf,
+                       uint8_t** proof_data_buf)
+{
+    auto constraint_system = from_buffer<acir_format::acir_format>(constraint_system_buf);
+
+    std::shared_ptr<ProverReferenceString> crs;
+    bonk::proving_key_data pk_data;
+    read(pk_buf, pk_data);
+    auto proving_key = std::make_shared<bonk::proving_key>(std::move(pk_data), crs);
+
+    auto witness = from_buffer<std::vector<fr>>(witness_buf);
+
+    auto crs_factory = std::make_unique<PippengerReferenceStringFactory>(
+        reinterpret_cast<scalar_multiplication::Pippenger*>(pippenger), g2x);
+    proving_key->reference_string = crs_factory->get_prover_crs(proving_key->circuit_size);
+
+    TurboComposer composer(proving_key, nullptr);
+    create_circuit_with_witness(composer, constraint_system, witness);
+
+    auto prover = composer.create_prover();
+    auto heapProver = new TurboProver(std::move(prover));
+    auto& proof_data = heapProver->construct_proof().proof_data;
+    *proof_data_buf = proof_data.data();
+
+    return proof_data.size();
+}
+
+bool turbo_verify_proof(
+    uint8_t const* g2x, uint8_t const* vk_buf, uint8_t const* constraint_system_buf, uint8_t* proof, uint32_t length)
+{
+    bool verified = false;
+
+#ifndef __wasm__
+    try {
+#endif
+        auto constraint_system = from_buffer<acir_format::acir_format>(constraint_system_buf);
+
+        auto crs = std::make_shared<VerifierMemReferenceString>(g2x);
+        bonk::verification_key_data vk_data;
+        read(vk_buf, vk_data);
+        auto verification_key = std::make_shared<bonk::verification_key>(std::move(vk_data), crs);
+
+        TurboComposer composer(nullptr, verification_key);
+        create_circuit(composer, constraint_system);
+        plonk::proof pp = { std::vector<uint8_t>(proof, proof + length) };
+
+        auto verifier = composer.create_verifier();
+
+        verified = verifier.verify_proof(pp);
+#ifndef __wasm__
+    } catch (const std::exception& e) {
+        verified = false;
+        info(e.what());
+    }
+#endif
+    return verified;
+}
+
+} // namespace turbo_proofs

--- a/cpp/src/aztec/dsl/turbo_proofs/turbo_proofs.hpp
+++ b/cpp/src/aztec/dsl/turbo_proofs/turbo_proofs.hpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <cstddef>
+
+namespace turbo_proofs {
+
+uint32_t turbo_get_exact_circuit_size(uint8_t const* constraint_system_buf);
+size_t turbo_init_proving_key(uint8_t const* constraint_system_buf, uint8_t const** pk_buf);
+size_t turbo_init_verification_key(void* pippenger, uint8_t const* g2x, uint8_t const* pk_buf, uint8_t const** vk_buf);
+size_t turbo_new_proof(void* pippenger,
+                       uint8_t const* g2x,
+                       uint8_t const* pk_buf,
+                       uint8_t const* constraint_system_buf,
+                       uint8_t const* witness_buf,
+                       uint8_t** proof_data_buf);
+bool turbo_verify_proof(
+    uint8_t const* g2x, uint8_t const* vk_buf, uint8_t const* constraint_system_buf, uint8_t* proof, uint32_t length);
+
+} // namespace turbo_proofs


### PR DESCRIPTION
# Description

This upstreams the Noir DSL as developed in https://github.com/noir-lang/aztec-connect and attempts to align with the upstream changes (such as passing a nullptr as pippenger_lagrange). I also tried to apply various refactoring and cleanup where possible but my C++ is terrible—so please let me know where things should be better.

~~This is currently a draft because I think we are going to cleanup some of the turbo_proofs APIs but I need to catch @vezenovm when he is back from EthDenver.~~

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
