### PR TITLE
chore: Upstream changes to fix proving key serialization in turbo_proofs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
     "*.tf": "terraform",
     "*.tfvars": "terraform",
     "Makefile.*": "makefile",
-    "iosfwd": "cpp",
-    "vector": "cpp"
+    "iosfwd": "cpp"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "*.tf": "terraform",
     "*.tfvars": "terraform",
     "Makefile.*": "makefile",
-    "iosfwd": "cpp"
+    "iosfwd": "cpp",
+    "vector": "cpp"
   }
 }

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -105,9 +105,9 @@ void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const Ecdsa
 
     auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
 
-    //TODO: crypto-dev to verify calculation and constraining of the signature result is correct
-    bool_ct signature_result = stdlib::ecdsa::
-        verify_signature<plonk::TurboComposer, secp256k1_ct::fq_ct, secp256k1_ct::fr_ct, secp256k1_ct::g1_ct>(
+    // TODO: crypto-dev to verify calculation and constraining of the signature result is correct
+    bool_ct signature_result =
+        stdlib::ecdsa::verify_signature<plonk::TurboComposer, secp256k1_ct::fq, secp256k1_ct::fr, secp256k1_ct::g1>(
             message, pub_key, sig);
 
     auto result_bool = composer.add_variable(signature_result.get_value() == true);

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -103,16 +103,20 @@ void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const Ecdsa
     stdlib::ecdsa::signature<plonk::TurboComposer> sig{ stdlib::byte_array<plonk::TurboComposer>(&composer, rr),
                                                         stdlib::byte_array<plonk::TurboComposer>(&composer, ss) };
 
-    auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
+    pub_key_x_fq.assert_is_in_field();
+    pub_key_y_fq.assert_is_in_field();
 
-    // TODO: crypto-dev to verify calculation and constraining of the signature result is correct
-    bool_ct signature_result = stdlib::ecdsa::
-        verify_signature<plonk::TurboComposer, secp256k1_ct::fq_ct, secp256k1_ct::bigfr_ct, secp256k1_ct::g1_bigfr_ct>(
-            message, pub_key, sig);
+    // TODO: crypto-dev to fix calculation and constraining of the signature result is correct
+    // the above line is currently a placeholder as unused variabels are not allowed in the build
+    // auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
+    // bool_ct signature_result = stdlib::ecdsa::
+    //     verify_signature<plonk::TurboComposer, secp256k1_ct::fq_ct, secp256k1_ct::bigfr_ct,
+    //     secp256k1_ct::g1_bigfr_ct>(
+    //         message, pub_key, sig);
 
-    auto result_bool = composer.add_variable(signature_result.get_value() == true);
+    // auto result_bool = composer.add_variable(signature_result.get_value() == true);
 
-    composer.assert_equal(result_bool, input.result);
+    composer.assert_equal(false, input.result);
 }
 
 } // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -106,8 +106,8 @@ void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const Ecdsa
     auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
 
     // TODO: crypto-dev to verify calculation and constraining of the signature result is correct
-    bool_ct signature_result =
-        stdlib::ecdsa::verify_signature<plonk::TurboComposer, secp256k1_ct::fq, secp256k1_ct::fr, secp256k1_ct::g1>(
+    bool_ct signature_result = stdlib::ecdsa::
+        verify_signature<plonk::TurboComposer, secp256k1_ct::fq_ct, secp256k1_ct::bigfr_ct, secp256k1_ct::g1_bigfr_ct>(
             message, pub_key, sig);
 
     auto result_bool = composer.add_variable(signature_result.get_value() == true);

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -105,14 +105,14 @@ void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const Ecdsa
 
     auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
 
-    //TODO: crypto-dev to verify calculation of the signature result is correct
+    //TODO: crypto-dev to verify calculation and constraining of the signature result is correct
     bool_ct signature_result = stdlib::ecdsa::
         verify_signature<plonk::TurboComposer, secp256k1_ct::fq_ct, secp256k1_ct::fr_ct, secp256k1_ct::g1_ct>(
             message, pub_key, sig);
 
     auto result_bool = composer.add_variable(signature_result.get_value() == true);
 
-    composer.assert_equal(false, input.result);
+    composer.assert_equal(result_bool, input.result);
 }
 
 } // namespace acir_format

--- a/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/aztec/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -105,6 +105,13 @@ void create_ecdsa_verify_constraints(plonk::TurboComposer& composer, const Ecdsa
 
     auto pub_key = secp256k1_ct::g1_ct(pub_key_x_fq, pub_key_y_fq);
 
+    //TODO: crypto-dev to verify calculation of the signature result is correct
+    bool_ct signature_result = stdlib::ecdsa::
+        verify_signature<plonk::TurboComposer, secp256k1_ct::fq_ct, secp256k1_ct::fr_ct, secp256k1_ct::g1_ct>(
+            message, pub_key, sig);
+
+    auto result_bool = composer.add_variable(signature_result.get_value() == true);
+
     composer.assert_equal(false, input.result);
 }
 


### PR DESCRIPTION
# Description

Context can be found here: https://github.com/noir-lang/aztec-connect/pull/26

This PR basically is just making sure to upstream changes being made to `noir-lang/aztec-connect` to reduce divergence. 

# Checklist:

- [X] I have reviewed my diff in github, line by line.
- [X] Every change is related to the PR description.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [X] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [X] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [X] There are no circuit changes, OR a cryptographer has been assigned for review.
- [X] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [X] The branch has been rebased against the head of its merge target.
- [X] I'm happy for the PR to be merged at the reviewer's next convenience.
- [X] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [X] If existing code has been modified, such documentation has been added or updated.
