### PR TITLE
feat: Add pkgconfig output for installed target

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,10 +3,12 @@
 
 cmake_minimum_required(VERSION 3.24)
 
-set(PROJECT_VERSION 0.1.0)
-project(Barretenberg
+project(
+    Barretenberg
     DESCRIPTION "BN254 elliptic curve library, and PLONK SNARK prover"
-    LANGUAGES CXX C)
+    VERSION 0.1.0
+    LANGUAGES CXX C
+)
 
 option(DISABLE_ASM "Disable custom assembly" OFF)
 option(DISABLE_ADX "Disable ADX assembly variant" OFF)

--- a/cpp/cmake/barretenberg.pc.in
+++ b/cpp/cmake/barretenberg.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: Optimized elliptic curve library for the bn128 curve, and PLONK SNARK prover
+Version: @PROJECT_VERSION@
+
+Libs: -L${libdir}
+Libs.private: -lomp
+Cflags: -I${includedir}

--- a/cpp/src/aztec/CMakeLists.txt
+++ b/cpp/src/aztec/CMakeLists.txt
@@ -168,10 +168,17 @@ else()
     )
 
     if(INSTALL_BARRETENBERG)
+        # The `install` function takes targets to install in different destinations on the system.
         install(
             TARGETS barretenberg barretenberg_headers
+            # We also give it an optional export name in case something wants to target the install.
             EXPORT barretenbergTargets
+            # The ARCHIVE output signifies static libraries that should be installed
+            # and we use the GNUInstallDirs location to install into the standard system library location
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            # The FILE_SET output is used instead of PUBLIC_HEADER & PRIVATE_HEADER outputs because
+            # our headers don't have a clear delineation between public & private, but we still use
+            # the GNUInstallDirs location to install into the standard system header location
             FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 

--- a/cpp/src/aztec/CMakeLists.txt
+++ b/cpp/src/aztec/CMakeLists.txt
@@ -174,5 +174,18 @@ else()
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
+
+        set(pkg_config "${PROJECT_BINARY_DIR}/barretenberg.pc")
+
+        configure_file(
+            "${PROJECT_SOURCE_DIR}/cmake/barretenberg.pc.in"
+            "${pkg_config}"
+            @ONLY
+        )
+
+        install(
+            FILES "${pkg_config}"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        )
     endif()
 endif()

--- a/cpp/src/aztec/common/CMakeLists.txt
+++ b/cpp/src/aztec/common/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Collect our common/*.hpp files and include in installation
+# This is only necessary because nothing in `common/` has an
+# implementation and doesn't use the `barretenberg_module` function
 file(GLOB_RECURSE HEADER_FILES *.hpp)
 target_sources(
     barretenberg_headers


### PR DESCRIPTION
# Description

Closes #203

This adds a pkg-config install target so we can provide details for consuming barretenberg via pkg-config. I also needed to fix the `PROJECT_VERSION` variable so we output the correct version in pkg-config file. And I added comments that @dbanks12 asked for in #185

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
