### PR TITLE
Fixed a misleading typo

### DIFF
--- a/cpp/src/aztec/plonk/proof_system/widgets/transition_widgets/plookup_arithmetic_widget.hpp
+++ b/cpp/src/aztec/plonk/proof_system/widgets/transition_widgets/plookup_arithmetic_widget.hpp
@@ -12,7 +12,7 @@ namespace widget {
  * without alpha scaling is:
  *
  * q_arith * ( ( (-1/2) * (q_arith - 3) * q_m * w_1 * w_2 + q_1 * w_1 + q_2 * w_2 + q_3 * w_3 + q_4 * w_4 + q_c ) +
- * (q_arith - 1)*( α² * (q_arith - 2) * (w_1 + w_4 - w_1_omega + q_m) + w_4_omega) ) = 0
+ * (q_arith - 1)*( α * (q_arith - 2) * (w_1 + w_4 - w_1_omega + q_m) + w_4_omega) ) = 0
  *
  * This formula results in several cases depending on q_arith:
  * 1. q_arith == 0: Arithmetic gate is completely disabled


### PR DESCRIPTION
# Description

Fixed a misleading typo in the description of plookup arithemtic widget
# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
