### PR TITLE
Lde/work queue

### DIFF
--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -80,7 +80,7 @@ class CommitmentKey {
             .work_type = bonk::work_queue::WorkType::SCALAR_MULTIPLICATION,
             .mul_scalars = coefficients,
             .tag = commitment_tag,
-            .constant = bonk::work_queue::MSMType::MONOMIAL_N,
+            .constant = polynomial.size(),
             .index = 0,
         });
     };

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -65,10 +65,9 @@ class CommitmentKey {
     };
 
     /**
-     * @brief Add computation of a polynomial commitment to the provided work queue
+     * @brief Add computation of commitment C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁ to the provided work queue
      *
      * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
-     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁
      */
     void queue_commitment(Polynomial& polynomial, std::string& commitment_tag, bonk::work_queue& work_queue)
     {

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -64,6 +64,27 @@ class CommitmentKey {
             const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
     };
 
+    /**
+     * @brief Add computation of a polynomial commitment to the provided work queue
+     *
+     * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
+     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁
+     */
+    void queue_commitment(Polynomial& polynomial, std::string& commitment_tag, bonk::work_queue& work_queue)
+    {
+        ASSERT(polynomial.size() <= srs.get_monomial_size());
+
+        Fr* coefficients = const_cast<Fr*>(polynomial.data());
+
+        work_queue.add_to_queue({
+            .work_type = bonk::work_queue::WorkType::SCALAR_MULTIPLICATION,
+            .mul_scalars = coefficients,
+            .tag = commitment_tag,
+            .constant = bonk::work_queue::MSMType::MONOMIAL_N,
+            .index = 0,
+        });
+    };
+
   private:
     barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
     bonk::FileReferenceString srs;

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -11,6 +11,7 @@
 #include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/ecc/curves/bn254/pairing.hpp"
 #include "barretenberg/numeric/bitop/pow.hpp"
+#include "barretenberg/proof_system/work_queue/work_queue.hpp"
 
 #include <string_view>
 #include <memory>

--- a/cpp/src/barretenberg/honk/pcs/gemini/gemini.hpp
+++ b/cpp/src/barretenberg/honk/pcs/gemini/gemini.hpp
@@ -111,10 +111,8 @@ template <typename Params> class MultilinearReductionScheme {
     {
         const size_t num_variables = mle_opening_point.size(); // m
 
-        // F(X) = ∑ⱼ ρʲ   fⱼ(X)
-        Polynomial& batched_F = fold_polynomials[0];
-        // G(X) = ∑ⱼ ρᵏ⁺ʲ gⱼ(X)
-        Polynomial& batched_G = fold_polynomials[1];
+        Polynomial& batched_F = fold_polynomials[0]; // F(X) = ∑ⱼ ρʲ   fⱼ(X)
+        Polynomial& batched_G = fold_polynomials[1]; // G(X) = ∑ⱼ ρᵏ⁺ʲ gⱼ(X)
 
         // A₀(X) = F(X) + G↺(X) = F(X) + G(X)/X.
         Polynomial A_0(batched_F);
@@ -153,6 +151,12 @@ template <typename Params> class MultilinearReductionScheme {
     /**
      * @brief Computes/aggragates d+1 Fold polynomials and their opening pairs (query, evaluation)
      *
+     * @details This function assumes that, upon input, last d-1 entries in fold_polynomials are Fold_i.
+     * The first two entries are assumed to be, respectively, the batched unshifted and batched to-be-shifted
+     * polynomials F(X) = ∑ⱼ ρʲfⱼ(X) and G(X) = ∑ⱼ ρᵏ⁺ʲ gⱼ(X). This function completes the computation
+     * of the first two Fold polynomials as F + G/r and F - G/r. It then evaluates each of the d+1
+     * fold polynomials at, respectively, the points r, rₗ = r^{2ˡ} for l = 0, 1, ..., d-1.
+     *
      * @param mle_opening_point u = (u₀,...,uₘ₋₁) is the MLE opening point
      * @param fold_polynomials vector of polynomials whose first two elements are F(X) = ∑ⱼ ρʲfⱼ(X)
      * and G(X) = ∑ⱼ ρᵏ⁺ʲ gⱼ(X), and the next d-1 elements are Fold_i, i = 1, ..., d-1.
@@ -164,14 +168,10 @@ template <typename Params> class MultilinearReductionScheme {
     {
         const size_t num_variables = mle_opening_point.size(); // m
 
-        // F(X) = ∑ⱼ ρʲ   fⱼ(X)
-        Polynomial& batched_F = fold_polynomials[0];
-        // G(X) = ∑ⱼ ρᵏ⁺ʲ gⱼ(X)
-        Polynomial& batched_G = fold_polynomials[1];
+        Polynomial& batched_F = fold_polynomials[0]; // F(X) = ∑ⱼ ρʲ   fⱼ(X)
+        Polynomial& batched_G = fold_polynomials[1]; // G(X) = ∑ⱼ ρᵏ⁺ʲ gⱼ(X)
 
-        /*
-         * Compute univariate opening queries rₗ = r^{2ˡ} for l = 0, 1, ..., m-1
-         */
+        // Compute univariate opening queries rₗ = r^{2ˡ} for l = 0, 1, ..., m-1
         std::vector<Fr> r_squares = squares_of_r(r_challenge, num_variables);
 
         // 2 simulated polynomials and (m-1) polynomials from this round
@@ -213,150 +213,6 @@ template <typename Params> class MultilinearReductionScheme {
         for (size_t l = 0; l < num_variables; ++l) {
             fold_poly_opening_pairs.emplace_back(
                 OpeningPair<Params>{ -r_squares[l], fold_polynomials[l + 1].evaluate(-r_squares[l]) });
-        }
-
-        return { fold_poly_opening_pairs, std::move(fold_polynomials) };
-    };
-
-    /**
-     * @brief reduces claims about multiple (shifted) MLE evaluation
-     *
-     * @param ck is the commitment key for creating the new commitments
-     * @param mle_opening_point u = (u₀,...,uₘ₋₁) is the MLE opening point
-     * @param batched_shifted batch polynomial constructed from the unshifted multivariates
-     * @param batched_to_be_shifted batch polynomial constructed from the to-be-shifted multivariates
-     * @param transcript
-     * @return Output (opening pairs, folded_witness_polynomials)
-     *
-     */
-    static ProverOutput<Params> reduce_prove(std::shared_ptr<CK> ck,
-                                             std::span<const Fr> mle_opening_point,
-                                             const Polynomial&& batched_shifted,       /* unshifted */
-                                             const Polynomial&& batched_to_be_shifted, /* to-be-shifted */
-                                             const auto& transcript)
-    {
-        const size_t num_variables = mle_opening_point.size(); // m
-
-        // Allocate space for m+1 Fold polynomials
-        //
-        // At the end, the first two will contain the batched polynomial
-        // partially evaluated at the challenges r,-r.
-        // The other m-1 polynomials correspond to the foldings of A₀
-        std::vector<Polynomial> fold_polynomials;
-        fold_polynomials.reserve(num_variables + 1);
-        // F(X) = ∑ⱼ ρʲ   fⱼ(X)
-        Polynomial& batched_F = fold_polynomials.emplace_back(batched_shifted);
-        // G(X) = ∑ⱼ ρᵏ⁺ʲ gⱼ(X)
-        Polynomial& batched_G = fold_polynomials.emplace_back(batched_to_be_shifted);
-
-        // A₀(X) = F(X) + G↺(X) = F(X) + G(X)/X.
-        Polynomial A_0(batched_F);
-        A_0 += batched_G.shifted();
-
-        // Create the folded polynomials A₁(X),…,Aₘ₋₁(X)
-        //
-        // A_l = Aₗ(X) is the polynomial being folded
-        // in the first iteration, we take the batched polynomial
-        // in the next iteration, it is the previously folded one
-        Fr* A_l = A_0.get_coefficients();
-        for (size_t l = 0; l < num_variables - 1; ++l) {
-            const Fr u_l = mle_opening_point[l];
-
-            // size of the previous polynomial/2
-            const size_t n_l = 1 << (num_variables - l - 1);
-
-            // A_l_fold = Aₗ₊₁(X) = (1-uₗ)⋅even(Aₗ)(X) + uₗ⋅odd(Aₗ)(X)
-            Fr* A_l_fold = fold_polynomials.emplace_back(Polynomial(n_l)).get_coefficients();
-
-            // fold the previous polynomial with odd and even parts
-            for (size_t i = 0; i < n_l; ++i) {
-                // TODO(#219)(Adrian) parallelize
-
-                // fold(Aₗ)[i] = (1-uₗ)⋅even(Aₗ)[i] + uₗ⋅odd(Aₗ)[i]
-                //            = (1-uₗ)⋅Aₗ[2i]      + uₗ⋅Aₗ[2i+1]
-                //            = Aₗ₊₁[i]
-                A_l_fold[i] = A_l[i << 1] + u_l * (A_l[(i << 1) + 1] - A_l[i << 1]);
-            }
-
-            // set Aₗ₊₁ = Aₗ for the next iteration
-            A_l = A_l_fold;
-        }
-
-        /*
-         * Create commitments C₁,…,Cₘ₋₁ to polynomials FOLD_i, i = 1,...,d-1 and add to transcript
-         */
-        std::vector<Commitment> commitments;
-        commitments.reserve(num_variables - 1);
-        for (size_t l = 0; l < num_variables - 1; ++l) {
-            commitments.emplace_back(ck->commit(fold_polynomials[l + 2]));
-            transcript->add_element("FOLD_" + std::to_string(l + 1),
-                                    static_cast<CommitmentAffine>(commitments[l]).to_buffer());
-        }
-
-        /*
-         * Generate evaluation challenge r, and compute rₗ = r^{2ˡ} for l = 0, 1, ..., m-1
-         */
-        transcript->apply_fiat_shamir("r");
-        const Fr r_challenge = Fr::serialize_from_buffer(transcript->get_challenge("r").begin());
-        std::vector<Fr> r_squares = squares_of_r(r_challenge, num_variables);
-
-        /*
-         * Compute the witness polynomials for the resulting claim
-         *
-         *
-         * We are batching all polynomials together, and linearly combining them with
-         * powers of ρ
-         */
-
-        // 2 simulated polynomials and (m-1) polynomials from this round
-        Fr r_inv = r_challenge.invert();
-        // G(X) *= r⁻¹
-        batched_G *= r_inv;
-
-        // To avoid an extra allocation, we reuse the following polynomials
-        // but rename them to represent the result.
-        // tmp     = A₀(X) (&tmp     == &A_0)
-        // A_0_pos = F(X)  (&A_0_pos == &batched_F)
-        Polynomial& tmp = A_0;
-        Polynomial& A_0_pos = fold_polynomials[0];
-
-        tmp = batched_F;
-        // A₀₊(X) = F(X) + G(X)/r, s.t. A₀₊(r) = A₀(r)
-        A_0_pos += batched_G;
-
-        std::swap(tmp, batched_G);
-        // After the swap, we have
-        // tmp = G(X)/r
-        // A_0_neg = F(X) (since &batched_F == &A_0_neg)
-        Polynomial& A_0_neg = fold_polynomials[1];
-
-        // A₀₋(X) = F(X) - G(X)/r, s.t. A₀₋(-r) = A₀(-r)
-        A_0_neg -= tmp;
-
-        /*
-         * Compute the m+1 evaluations Aₗ(−r^{2ˡ}), l = 0, ..., m-1.
-         * Add them to the transcript
-         */
-        std::vector<Fr> fold_polynomial_evals;
-        fold_polynomial_evals.reserve(num_variables);
-        for (size_t l = 0; l < num_variables; ++l) {
-            const Polynomial& A_l = fold_polynomials[l + 1];
-
-            fold_polynomial_evals.emplace_back(A_l.evaluate(-r_squares[l]));
-            transcript->add_element("a_" + std::to_string(l), fold_polynomial_evals[l].to_buffer());
-        }
-
-        // Compute evaluation A₀(r)
-        auto a_0_pos = fold_polynomials[0].evaluate(r_challenge);
-
-        std::vector<OpeningPair<Params>> fold_poly_opening_pairs;
-        fold_poly_opening_pairs.reserve(num_variables + 1);
-
-        // ( r, A₀(r) )
-        fold_poly_opening_pairs.emplace_back(OpeningPair<Params>{ r_challenge, a_0_pos });
-        // (-r, Aₗ(−r^{2ˡ}) )
-        for (size_t l = 0; l < num_variables; ++l) {
-            fold_poly_opening_pairs.emplace_back(OpeningPair<Params>{ -r_squares[l], fold_polynomial_evals[l] });
         }
 
         return { fold_poly_opening_pairs, std::move(fold_polynomials) };

--- a/cpp/src/barretenberg/honk/pcs/gemini/gemini.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/gemini/gemini.test.cpp
@@ -39,25 +39,25 @@ template <class Params> class GeminiTest : public CommitmentTest<Params> {
             batched_evaluation += multilinear_evaluations[i] * rhos[i];
         }
 
-        Polynomial batched_poly_unshifted(1 << log_n);
-        Polynomial batched_poly_to_be_shifted(1 << log_n);
+        Polynomial batched_unshifted(1 << log_n);
+        Polynomial batched_to_be_shifted(1 << log_n);
         Commitment batched_commitment_unshifted = Commitment::zero();
         Commitment batched_commitment_to_be_shifted = Commitment::zero();
         const size_t num_unshifted = multilinear_polynomials.size();
         const size_t num_shifted = multilinear_polynomials_to_be_shifted.size();
         for (size_t i = 0; i < num_unshifted; ++i) {
-            batched_poly_unshifted.add_scaled(multilinear_polynomials[i], rhos[i]);
+            batched_unshifted.add_scaled(multilinear_polynomials[i], rhos[i]);
             batched_commitment_unshifted += multilinear_commitments[i] * rhos[i];
         }
         for (size_t i = 0; i < num_shifted; ++i) {
             size_t rho_idx = num_unshifted + i;
-            batched_poly_to_be_shifted.add_scaled(multilinear_polynomials_to_be_shifted[i], rhos[rho_idx]);
+            batched_to_be_shifted.add_scaled(multilinear_polynomials_to_be_shifted[i], rhos[rho_idx]);
             batched_commitment_to_be_shifted += multilinear_commitments_to_be_shifted[i] * rhos[rho_idx];
         }
 
         std::vector<Polynomial> fold_polynomials;
-        fold_polynomials.emplace_back(batched_poly_unshifted);
-        fold_polynomials.emplace_back(batched_poly_to_be_shifted);
+        fold_polynomials.emplace_back(batched_unshifted);
+        fold_polynomials.emplace_back(batched_to_be_shifted);
 
         // Compute:
         // - (d+1) opening pairs: {r, \hat{a}_0}, {-r^{2^i}, a_i}, i = 0, ..., d-1

--- a/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
@@ -32,8 +32,7 @@ TYPED_TEST(ShplonkTest, ShplonkSimple)
     transcript->mock_inputs_prior_to_challenge("nu");
 
     // Generate two random (unrelated) polynomials of two different sizes, as well as their evaluations at a (single but
-    // different) random point and their commitments. In the real Honk protocol, these polynomials and commitments would
-    // come from the Gemini prover and verifier respectively.
+    // different) random point and their commitments.
     const auto r1 = Fr::random_element();
     auto poly1 = this->random_polynomial(n);
     const auto eval1 = poly1.evaluate(r1);

--- a/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
@@ -5,6 +5,7 @@
 #include <random>
 #include <iterator>
 #include <algorithm>
+#include <vector>
 
 #include "../commitment_key.test.hpp"
 #include "barretenberg/honk/pcs/claim.hpp"
@@ -14,68 +15,56 @@ template <class Params> class ShplonkTest : public CommitmentTest<Params> {};
 
 TYPED_TEST_SUITE(ShplonkTest, CommitmentSchemeParams);
 
-// Test of Shplonk prover/verifier using real Gemini claim
-TYPED_TEST(ShplonkTest, GeminiShplonk)
+// Test of Shplonk prover/verifier for two polynomials of different size, each opened at a single (different) point
+TYPED_TEST(ShplonkTest, ShplonkSimple)
 {
     using Shplonk = SingleBatchOpeningScheme<TypeParam>;
-    using Gemini = gemini::MultilinearReductionScheme<TypeParam>;
     using Fr = typename TypeParam::Fr;
-    using Commitment = typename TypeParam::Commitment;
     using Polynomial = typename barretenberg::Polynomial<Fr>;
+    using OpeningPair = OpeningPair<TypeParam>;
+    using OpeningClaim = OpeningClaim<TypeParam>;
 
     const size_t n = 16;
     const size_t log_n = 4;
 
     using Transcript = transcript::StandardTranscript;
     auto transcript = std::make_shared<Transcript>(StandardHonk::create_manifest(0, log_n));
-    transcript->mock_inputs_prior_to_challenge("rho");
-    transcript->apply_fiat_shamir("rho");
-    const Fr rho = Fr::serialize_from_buffer(transcript->get_challenge("rho").begin());
+    transcript->mock_inputs_prior_to_challenge("nu");
 
-    const auto u = this->random_evaluation_point(log_n);
-    auto poly = this->random_polynomial(n);
-    const auto commitment = this->commit(poly);
-    const auto eval = poly.evaluate_mle(u);
+    // Generate two random (unrelated) polynomials of two different sizes, as well as their evaluations at a (single but
+    // different) random point and their commitments. In the real Honk protocol, these polynomials and commitments would
+    // come from the Gemini prover and verifier respectively.
+    const auto r1 = Fr::random_element();
+    auto poly1 = this->random_polynomial(n);
+    const auto eval1 = poly1.evaluate(r1);
+    const auto commitment1 = this->commit(poly1);
 
-    // Collect multilinear polynomials evaluations, and commitments for input to prover/verifier
-    std::vector<Fr> multilinear_evaluations = { eval };
+    const auto r2 = Fr::random_element();
+    auto poly2 = this->random_polynomial(n / 2);
+    const auto eval2 = poly2.evaluate(r2);
+    const auto commitment2 = this->commit(poly2);
 
-    std::vector<Fr> rhos = Gemini::powers_of_rho(rho, multilinear_evaluations.size());
+    // Aggregate polynomials and their opening pairs
+    std::vector<OpeningPair> opening_pairs = { { r1, eval1 }, { r2, eval2 } };
+    std::vector<Polynomial> polynomials = { poly1, poly2 };
 
-    // Compute batched multivariate evaluation
-    Fr batched_evaluation = multilinear_evaluations[0] * rhos[0];
+    // Execute the shplonk prover functionality
+    const auto [prover_opening_pair, shplonk_prover_witness] =
+        Shplonk::reduce_prove(this->ck(), opening_pairs, polynomials, transcript);
 
-    Polynomial batched_unshifted(n);
-    Polynomial batched_to_be_shifted(n);
-    batched_unshifted.add_scaled(poly, rhos[0]);
-
-    Commitment batched_commitment_unshifted = commitment * rhos[0];
-    Commitment batched_commitment_to_be_shifted = Commitment::zero();
-
-    auto gemini_prover_output =
-        Gemini::reduce_prove(this->ck(), u, std::move(batched_unshifted), std::move(batched_to_be_shifted), transcript);
-
-    const auto [prover_opening_pair, shplonk_prover_witness] = Shplonk::reduce_prove(
-        this->ck(), gemini_prover_output.opening_pairs, gemini_prover_output.witnesses, transcript);
-
+    // An intermediate check to confirm the opening of the shplonk prover witness Q
     this->verify_opening_pair(prover_opening_pair, shplonk_prover_witness);
 
-    // Reconstruct a Gemini proof object consisting of
-    // - d Fold poly evaluations a_0, ..., a_{d-1}
-    // - (d-1) Fold polynomial commitments [Fold^(1)], ..., [Fold^(d-1)]
-    auto gemini_proof = Gemini::reconstruct_proof_from_transcript(transcript, log_n);
-
-    auto gemini_verifier_claim = Gemini::reduce_verify(u,
-                                                       batched_evaluation,
-                                                       batched_commitment_unshifted,
-                                                       batched_commitment_to_be_shifted,
-                                                       gemini_proof,
-                                                       transcript);
+    // Aggregate polynomial commitments and their opening pairs
+    std::vector<OpeningClaim> opening_claims;
+    opening_claims.emplace_back(OpeningClaim{ opening_pairs[0], commitment1 });
+    opening_claims.emplace_back(OpeningClaim{ opening_pairs[1], commitment2 });
 
     // Reconstruct the Shplonk Proof (commitment [Q]) from the transcript
     auto shplonk_proof = transcript->get_group_element("Q");
 
-    const auto verifier_claim = Shplonk::reduce_verify(gemini_verifier_claim, shplonk_proof, transcript);
+    // Execute the shplonk verifier functionality
+    const auto verifier_claim = Shplonk::reduce_verify(opening_claims, shplonk_proof, transcript);
 
     this->verify_opening_claim(verifier_claim, shplonk_prover_witness);
 }

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -43,11 +43,10 @@ Prover<settings>::Prover(std::vector<barretenberg::polynomial>&& wire_polys,
     : transcript(input_manifest, settings::hash_type, settings::num_challenge_bytes)
     , wire_polynomials(wire_polys)
     , key(input_key)
-    , queue(input_key.get(), &transcript) // TODO(Adrian): explore whether it's needed
     , commitment_key(std::make_unique<pcs::kzg::CommitmentKey>(
           input_key->circuit_size,
           "../srs_db/ignition")) // TODO(Cody): Need better constructors for prover.
-// , queue(proving_key.get(), &transcript)
+    , queue(input_key.get(), &transcript)
 {
     // Note(luke): This could be done programmatically with some hacks but this isnt too bad and its nice to see the
     // polys laid out explicitly.
@@ -323,11 +322,9 @@ template <typename settings> void Prover<settings>::execute_univariatization_rou
     Polynomial batched_poly_to_be_shifted(key->circuit_size); // batched to-be-shifted polynomials
     batched_poly_to_be_shifted.add_scaled(prover_polynomials[POLYNOMIAL::Z_PERM], rhos[NUM_UNSHIFTED_POLYS]);
 
-    // Reserve space for d+1 Fold polynomials
-    //
-    // At the end, the first two will contain the batched polynomial
-    // partially evaluated at the challenges r,-r.
-    // The other d-1 polynomials correspond to the foldings of A₀
+    // Reserve space for d+1 Fold polynomials. At the end of this round, the last d-1 polynomials will
+    // correspond to Fold^(i). At the end of the full Gemini prover protocol, the first two will
+    // be the partially evaluated Fold polynomials Fold_{r}^(0) and Fold_{-r}^(0).
     fold_polynomials.reserve(key->log_circuit_size + 1);
     fold_polynomials.emplace_back(batched_poly_unshifted);
     fold_polynomials.emplace_back(batched_poly_to_be_shifted);

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -221,7 +221,7 @@ template <typename settings> void Prover<settings>::execute_preamble_round()
  * */
 template <typename settings> void Prover<settings>::execute_wire_commitments_round()
 {
-    queue.flush_queue(); // NOTE: Don't remove; we may reinstate the queue
+    queue.flush_queue();
     compute_wire_commitments();
 
     // Add public inputs to transcript from the second wire polynomial
@@ -296,7 +296,7 @@ template <typename settings> void Prover<settings>::execute_relation_check_round
  * */
 template <typename settings> void Prover<settings>::execute_univariatization_round()
 {
-    queue.flush_queue(); // not necessary?
+    queue.flush_queue();
 
     const size_t NUM_POLYNOMIALS = bonk::StandardArithmetization::NUM_POLYNOMIALS;
     const size_t NUM_UNSHIFTED_POLYS = bonk::StandardArithmetization::NUM_UNSHIFTED_POLYNOMIALS;
@@ -310,7 +310,6 @@ template <typename settings> void Prover<settings>::execute_univariatization_rou
     // Generate batching challenge ρ and powers 1,ρ,…,ρᵐ⁻¹
     transcript.apply_fiat_shamir("rho");
     Fr rho = Fr::serialize_from_buffer(transcript.get_challenge("rho").begin());
-    info("rho = ", rho);
     std::vector<Fr> rhos = Gemini::powers_of_rho(rho, NUM_POLYNOMIALS);
 
     // Get vector of multivariate evaluations produced by Sumcheck
@@ -333,7 +332,7 @@ template <typename settings> void Prover<settings>::execute_univariatization_rou
     fold_polynomials.emplace_back(batched_poly_unshifted);
     fold_polynomials.emplace_back(batched_poly_to_be_shifted);
 
-    // Compute d+1 Fold polynomials and their evaluations
+    // Compute d-1 polynomials Fold^(i), i = 1, ..., d-1.
     Gemini::compute_fold_polynomials(opening_point, fold_polynomials);
 
     for (size_t l = 0; l < key->log_circuit_size - 1; ++l) {
@@ -395,7 +394,7 @@ template <typename settings> plonk::proof& Prover<settings>::construct_proof()
 
     // Compute wire commitments; Add PI to transcript
     execute_wire_commitments_round();
-    queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
+    queue.process_queue();
 
     // Currently a no-op; may execute some "random widgets", commit to W_4, do RAM/ROM stuff
     // if this prover structure is kept when we bring tables to Honk.

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -59,6 +59,8 @@ template <typename settings> class Prover {
 
     std::shared_ptr<bonk::proving_key> key;
 
+    std::shared_ptr<pcs::kzg::CommitmentKey> commitment_key;
+
     // Container for spans of all polynomials required by the prover (i.e. all multivariates evaluated by Sumcheck).
     std::array<std::span<Fr>, bonk::StandardArithmetization::POLYNOMIAL::COUNT> prover_polynomials;
 
@@ -66,8 +68,6 @@ template <typename settings> class Prover {
     std::vector<Fr> opening_point;            // MLE opening point 'u'
 
     work_queue queue;
-
-    std::shared_ptr<pcs::kzg::CommitmentKey> commitment_key;
 
     // This makes 'settings' accesible from Prover
     using settings_ = settings;

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -29,7 +29,7 @@ template <typename settings> class Prover {
 
   public:
     Prover(std::vector<barretenberg::polynomial>&& wire_polys,
-           std::shared_ptr<bonk::proving_key> input_key = nullptr,
+           const std::shared_ptr<bonk::proving_key>& input_key = nullptr,
            const transcript::Manifest& manifest = transcript::Manifest());
 
     void execute_preamble_round();
@@ -58,15 +58,13 @@ template <typename settings> class Prover {
 
     std::shared_ptr<bonk::proving_key> key;
 
-    std::shared_ptr<pcs::kzg::CommitmentKey> commitment_key;
-
     // Container for spans of all polynomials required by the prover (i.e. all multivariates evaluated by Sumcheck).
     std::array<std::span<Fr>, bonk::StandardArithmetization::POLYNOMIAL::COUNT> prover_polynomials;
 
     // Honk only needs a small portion of the functionality but may be fine to use existing work_queue
     // NOTE: this is not currently in use, but it may well be used in the future.
     // TODO(Adrian): Uncomment when we need this again.
-    // bonk::work_queue queue;
+    work_queue queue;
     // void flush_queued_work_items() { queue.flush_queue(); }
     // bonk::work_queue::work_item_info get_queued_work_item_info() const {
     //     return queue.get_queued_work_item_info();
@@ -75,6 +73,8 @@ template <typename settings> class Prover {
     // {
     //     return queue.get_scalar_multiplication_size(work_item_number);
     // }
+
+    std::shared_ptr<pcs::kzg::CommitmentKey> commitment_key;
 
     // This makes 'settings' accesible from Prover
     using settings_ = settings;

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -62,21 +62,10 @@ template <typename settings> class Prover {
     // Container for spans of all polynomials required by the prover (i.e. all multivariates evaluated by Sumcheck).
     std::array<std::span<Fr>, bonk::StandardArithmetization::POLYNOMIAL::COUNT> prover_polynomials;
 
-    std::vector<Polynomial> fold_polynomials;
-    std::vector<Fr> opening_point; // MLE opening point 'u'
+    std::vector<Polynomial> fold_polynomials; // Storage for d+1 Fold polynomials produced by Gemini
+    std::vector<Fr> opening_point;            // MLE opening point 'u'
 
-    // Honk only needs a small portion of the functionality but may be fine to use existing work_queue
-    // NOTE: this is not currently in use, but it may well be used in the future.
-    // TODO(Adrian): Uncomment when we need this again.
     work_queue queue;
-    // void flush_queued_work_items() { queue.flush_queue(); }
-    // bonk::work_queue::work_item_info get_queued_work_item_info() const {
-    //     return queue.get_queued_work_item_info();
-    // }
-    // size_t get_scalar_multiplication_size(const size_t work_item_number) const
-    // {
-    //     return queue.get_scalar_multiplication_size(work_item_number);
-    // }
 
     std::shared_ptr<pcs::kzg::CommitmentKey> commitment_key;
 

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -24,6 +24,7 @@
 namespace honk {
 
 using Fr = barretenberg::fr;
+using Polynomial = barretenberg::Polynomial<Fr>;
 
 template <typename settings> class Prover {
 
@@ -60,6 +61,9 @@ template <typename settings> class Prover {
 
     // Container for spans of all polynomials required by the prover (i.e. all multivariates evaluated by Sumcheck).
     std::array<std::span<Fr>, bonk::StandardArithmetization::POLYNOMIAL::COUNT> prover_polynomials;
+
+    std::vector<Polynomial> fold_polynomials;
+    std::vector<Fr> opening_point; // MLE opening point 'u'
 
     // Honk only needs a small portion of the functionality but may be fine to use existing work_queue
     // NOTE: this is not currently in use, but it may well be used in the future.

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
@@ -116,7 +116,7 @@ TEST(commitment_scheme, kate_batch_open)
     for (size_t k = 0; k < t; ++k) {
         challenges[k] = fr::random_element();
         tags[k] = "W_" + std::to_string(k + 1);
-        item_constants[k] = fr(n);
+        item_constants[k] = n;
     }
 
     // compute opening polynomials W_1, W_2, ..., W_t

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
@@ -41,7 +41,7 @@ TEST(commitment_scheme, kate_open)
     auto circuit_proving_key = std::make_shared<proving_key>(n, 0, crs, plonk::STANDARD);
     work_queue queue(circuit_proving_key.get(), &inp_tx);
 
-    newKate.commit(&coeffs[0], "F_COMM", 0, queue);
+    newKate.commit(&coeffs[0], "F_COMM", n, queue);
     queue.process_queue();
 
     fr y = fr::random_element();
@@ -49,7 +49,7 @@ TEST(commitment_scheme, kate_open)
     fr f = polynomial_arithmetic::evaluate(&coeffs[0], z, n);
 
     newKate.compute_opening_polynomial(&coeffs[0], &W[0], z, n);
-    newKate.commit(&W[0], "W_COMM", fr(0), queue);
+    newKate.commit(&W[0], "W_COMM", n, queue);
     queue.process_queue();
 
     // check if W(y)(y - z) = F(y) - F(z)
@@ -103,7 +103,7 @@ TEST(commitment_scheme, kate_batch_open)
         for (size_t j = 0; j < m; ++j) {
             newKate.commit(&coeffs[k * m * n + j * n],
                            "F_{" + std::to_string(k + 1) + ", " + std::to_string(j + 1) + "}",
-                           0,
+                           n,
                            queue);
         }
     }
@@ -116,7 +116,7 @@ TEST(commitment_scheme, kate_batch_open)
     for (size_t k = 0; k < t; ++k) {
         challenges[k] = fr::random_element();
         tags[k] = "W_" + std::to_string(k + 1);
-        item_constants[k] = fr(0);
+        item_constants[k] = fr(n);
     }
 
     // compute opening polynomials W_1, W_2, ..., W_t

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
@@ -224,9 +224,11 @@ void KateCommitmentScheme<settings>::batch_open(const transcript::StandardTransc
 
     // Commit to the opening and shifted opening polynomials
     KateCommitmentScheme::commit(
-        input_key->polynomial_cache.get("opening_poly").get_coefficients(), "PI_Z", fr(0), queue);
-    KateCommitmentScheme::commit(
-        input_key->polynomial_cache.get("shifted_opening_poly").get_coefficients(), "PI_Z_OMEGA", fr(0), queue);
+        input_key->polynomial_cache.get("opening_poly").get_coefficients(), "PI_Z", input_key->circuit_size, queue);
+    KateCommitmentScheme::commit(input_key->polynomial_cache.get("shifted_opening_poly").get_coefficients(),
+                                 "PI_Z_OMEGA",
+                                 input_key->circuit_size,
+                                 queue);
 }
 
 template <typename settings>

--- a/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
@@ -79,7 +79,7 @@ template <typename settings> void ProverBase<settings>::compute_wire_commitments
         barretenberg::fr* coefficients = key->polynomial_cache.get(wire_tag).get_coefficients();
 
         // This automatically saves the computed point to the transcript
-        fr domain_size_flag = i > 2 ? work_queue::MSMType::MONOMIAL_N : work_queue::MSMType::MONOMIAL_N_PLUS_ONE;
+        fr domain_size_flag = i > 2 ? key->circuit_size : (key->circuit_size + 1);
         commitment_scheme->commit(coefficients, commit_tag, domain_size_flag, queue);
     }
 
@@ -137,7 +137,7 @@ template <typename settings> void ProverBase<settings>::compute_quotient_commitm
         std::string quotient_tag = "T_" + std::to_string(i + 1);
         // Set flag that determines domain size (currently n or n+1) in pippenger (see process_queue()).
         // Note: After blinding, all t_i have size n+1 representation (degree n) except t_4 in Turbo/Ultra.
-        fr domain_size_flag = i > 2 ? work_queue::MSMType::MONOMIAL_N : work_queue::MSMType::MONOMIAL_N_PLUS_ONE;
+        fr domain_size_flag = i > 2 ? key->circuit_size : (key->circuit_size + 1);
         commitment_scheme->commit(coefficients, quotient_tag, domain_size_flag, queue);
     }
 }
@@ -311,7 +311,7 @@ template <typename settings> void ProverBase<settings>::execute_second_round()
             .work_type = work_queue::WorkType::SCALAR_MULTIPLICATION,
             .mul_scalars = key->polynomial_cache.get(wire_tag).get_coefficients(),
             .tag = "W_4",
-            .constant = work_queue::MSMType::MONOMIAL_N_PLUS_ONE,
+            .constant = key->circuit_size + 1,
             .index = 0,
         });
     }

--- a/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
@@ -326,7 +326,7 @@ void ProverPermutationWidget<program_width, idpolys, num_roots_cut_out_of_vanish
         work_queue::WorkType::SCALAR_MULTIPLICATION,
         z_perm.get_coefficients(),
         "Z_PERM",
-        barretenberg::fr(0),
+        key->circuit_size,
         0,
     });
 

--- a/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
@@ -358,7 +358,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_rou
             .work_type = work_queue::WorkType::SCALAR_MULTIPLICATION,
             .mul_scalars = s.get_coefficients(),
             .tag = "S",
-            .constant = barretenberg::fr(0),
+            .constant = key->circuit_size,
             .index = 0,
         });
 
@@ -382,7 +382,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_rou
             .work_type = work_queue::WorkType::SCALAR_MULTIPLICATION,
             .mul_scalars = z.get_coefficients(),
             .tag = "Z_LOOKUP",
-            .constant = barretenberg::fr(0),
+            .constant = key->circuit_size,
             .index = 0,
         });
 

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
@@ -1,6 +1,6 @@
 #include "work_queue.hpp"
-#include "common/assert.hpp"
-#include "numeric/uint256/uint256.hpp"
+#include "barretenberg/common/assert.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
 
 #include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
@@ -197,7 +197,7 @@ void work_queue::process_queue()
         // most expensive op
         case WorkType::SCALAR_MULTIPLICATION: {
 
-            auto msm_size = static_cast<size_t>(item.constant);
+            auto msm_size = static_cast<size_t>(static_cast<uint256_t>(item.constant));
 
             ASSERT(msm_size <= key->reference_string->get_monomial_size());
 

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
@@ -196,17 +196,12 @@ void work_queue::process_queue()
         switch (item.work_type) {
         // most expensive op
         case WorkType::SCALAR_MULTIPLICATION: {
-            // We use the variable work_item::constant to set the size of the multi-scalar multiplication.
-            // Note that a size (n+1) MSM is always needed to commit to the quotient polynomial parts t_1, t_2
-            // and t_3 for Standard/Turbo/Ultra due to the addition of blinding factors
-            size_t msm_size = static_cast<size_t>(uint256_t(item.constant));
-            info("msm_size = ", msm_size);
-            info("monomial_size = ", key->reference_string->get_monomial_size());
-            ASSERT(msm_size > 0);
+
+            auto msm_size = static_cast<size_t>(item.constant);
+
             ASSERT(msm_size <= key->reference_string->get_monomial_size());
 
             barretenberg::g1::affine_element* srs_points = key->reference_string->get_monomial_points();
-            ;
 
             // Run pippenger multi-scalar multiplication.
             auto runtime_state = barretenberg::scalar_multiplication::pippenger_runtime_state(msm_size);

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
@@ -1,5 +1,6 @@
 #include "work_queue.hpp"
 #include "common/assert.hpp"
+#include "numeric/uint256/uint256.hpp"
 
 #include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
@@ -51,7 +52,7 @@ size_t work_queue::get_scalar_multiplication_size(const size_t work_item_number)
     for (const auto& item : work_item_queue) {
         if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
             if (count == work_item_number) {
-                return (item.constant == MSMType::MONOMIAL_N_PLUS_ONE) ? key->circuit_size + 1 : key->circuit_size;
+                return static_cast<size_t>(static_cast<uint256_t>(item.constant));
             }
             ++count;
         }

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.hpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.hpp
@@ -8,7 +8,6 @@ class work_queue {
 
   public:
     enum WorkType { FFT, SMALL_FFT, IFFT, SCALAR_MULTIPLICATION };
-    enum MSMType { MONOMIAL_N, MONOMIAL_N_PLUS_ONE };
 
     struct work_item_info {
         uint32_t num_scalar_multiplications;


### PR DESCRIPTION
# Description

Reinstate the work queue for Honk, i.e. perform all MSMs in the work queue. Changes include:
- Commitments are now two stage operations: `add_to_queue` + `process_queue` (instead the more direct `commitment = ck.commit(poly)` type approach) 
- Gemini `reduce_prove` is split into two stages to allow computation of commitments [Fold_i] prior to generation of challenge `r` which assumes those commitments have been added to the transcript
- The sizing for MSMs in the work queue is now flexible (rather than n or n+1 as determined by an enum). This was necessary to accommodate commitments to Fold_i which have power-of-2 size <= n. The MSM size is still set via the `constant` field of a `work_item`.
- Update the standalone Shplonk test to be independent of Gemini. (This makes the test more clear/illustrative. There is another test that illustrates the full Gemini-Shplonk-KZG interaction).

Note: the MSM size change leads to some confusing looking diffs where, e.g., `fr(0)` has been changed to `key->circuit_size` in the `constant` input for a `work_item`. These are equivalent after the change since `fr(0)` was previously being equated to the enum value `MONOMIAL_N`, which then indicated a size `n` MSM.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
