### PR TITLE
feat(pkg-config): Add a bindir variable

### DIFF
--- a/cpp/cmake/barretenberg.pc.in
+++ b/cpp/cmake/barretenberg.pc.in
@@ -2,6 +2,7 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+bindir=@CMAKE_INSTALL_FULL_BINDIR@
 
 Name: @PROJECT_NAME@
 Description: Optimized elliptic curve library for the bn128 curve, and PLONK SNARK prover


### PR DESCRIPTION
# Description

This adds a `bindir` variable to the pkg-config file, so we can use the tool to find the location where the wasm file will be installed—such that you can do `ls $(pkg-config --variable bindir barretenberg)/barretenberg.wasm` to locate the wasm file.

This is useful for rust build scripts to locate the wasm file.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
