### PR TITLE
fix(wasm): Remove the CMAKE_STAGING_PREFIX variable from wasm preset

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -104,7 +104,6 @@
       },
       "cacheVariables": {
         "CMAKE_SYSROOT": "$env{WASI_SDK_PREFIX}/share/wasi-sysroot",
-        "CMAKE_STAGING_PREFIX": "$env{WASI_SDK_PREFIX}/share/wasi-sysroot",
         "CMAKE_FIND_ROOT_PATH_MODE_PROGRAM": "NEVER",
         "CMAKE_FIND_ROOT_PATH_MODE_LIBRARY": "ONLY",
         "CMAKE_FIND_ROOT_PATH_MODE_INCLUDE": "ONLY",


### PR DESCRIPTION
# Description

This removes the `CMAKE_STAGING_PREFIX` variable from the wasm prefix. This was a holdover from the wasi-sdk toolchain file. I originally left it in because I didn't know what it did; however, I've discovered that this value is used as the install prefix if it is set (see https://discourse.cmake.org/t/cmake-staging-prefix-vs-cmake-install-prefix/6485) and that makes the wasm file install into the wasi-sdk sysroot, which is wrong for our project.

Removing this allows the wasm file to install into the same prefix as the rest of the project.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
