### PR TITLE
Split Sumcheck

### DIFF
--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -1,34 +1,33 @@
 #pragma once
-#include "barretenberg/ecc/curves/bn254/fr.hpp"
-#include "barretenberg/honk/pcs/shplonk/shplonk.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
-#include "barretenberg/proof_system/flavor/flavor.hpp"
-#include <array>
-#include "barretenberg/proof_system/proving_key/proving_key.hpp"
+#include "barretenberg/honk/sumcheck/sumcheck.hpp"
+#include "barretenberg/honk/sumcheck/relations/relation.hpp"
 #include "barretenberg/honk/pcs/commitment_key.hpp"
-#include "barretenberg/plonk/proof_system/types/proof.hpp"
-#include "barretenberg/plonk/proof_system/types/program_settings.hpp"
 #include "barretenberg/honk/pcs/gemini/gemini.hpp"
 #include "barretenberg/honk/pcs/shplonk/shplonk_single.hpp"
+#include "barretenberg/honk/pcs/shplonk/shplonk.hpp"
 #include "barretenberg/honk/pcs/kzg/kzg.hpp"
+#include "barretenberg/transcript/transcript_wrappers.hpp"
+#include "barretenberg/plonk/proof_system/types/proof.hpp"
+#include "barretenberg/proof_system/proving_key/proving_key.hpp"
+#include "barretenberg/proof_system/flavor/flavor.hpp"
+#include "barretenberg/plonk/proof_system/types/prover_settings.hpp"
+
+#include <array>
 #include <span>
-#include <unordered_map>
 #include <vector>
-#include <algorithm>
-#include <cstddef>
 #include <memory>
-#include <utility>
-#include <string>
-#include "barretenberg/honk/pcs/claim.hpp"
 
 namespace honk {
 
-using Fr = barretenberg::fr;
-
 template <typename settings> class Prover {
 
+    using Fr = barretenberg::fr;
+    using Polynomial = barretenberg::Polynomial<Fr>;
+    using POLYNOMIAL = bonk::StandardArithmetization::POLYNOMIAL;
+
   public:
-    Prover(std::vector<barretenberg::polynomial>&& wire_polys,
+    Prover(std::vector<Polynomial>&& wire_polys,
            std::shared_ptr<bonk::proving_key> input_key = nullptr,
            const transcript::Manifest& manifest = transcript::Manifest());
 
@@ -44,7 +43,7 @@ template <typename settings> class Prover {
 
     void compute_wire_commitments();
 
-    barretenberg::polynomial compute_grand_product_polynomial(Fr beta, Fr gamma);
+    Polynomial compute_grand_product_polynomial(Fr beta, Fr gamma);
 
     void construct_prover_polynomials();
 
@@ -53,8 +52,12 @@ template <typename settings> class Prover {
 
     transcript::StandardTranscript transcript;
 
-    std::vector<barretenberg::polynomial> wire_polynomials;
-    barretenberg::polynomial z_permutation;
+    std::vector<Fr> public_inputs;
+
+    std::vector<Polynomial> wire_polynomials;
+    Polynomial z_permutation;
+
+    sumcheck::RelationParameters<Fr> relation_parameters;
 
     std::shared_ptr<bonk::proving_key> key;
 
@@ -79,6 +82,7 @@ template <typename settings> class Prover {
     // This makes 'settings' accesible from Prover
     using settings_ = settings;
 
+    sumcheck::SumcheckOutput<Fr> sumcheck_output;
     pcs::gemini::ProverOutput<pcs::kzg::Params> gemini_output;
     pcs::shplonk::ProverOutput<pcs::kzg::Params> shplonk_output;
 

--- a/cpp/src/barretenberg/honk/proof_system/verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.cpp
@@ -1,30 +1,24 @@
-#include <cmath>
-#include "barretenberg/common/throw_or_abort.hpp"
-#include <cstddef>
-#include <memory>
-#include "barretenberg/plonk/proof_system/constants.hpp"
+
 #include "./verifier.hpp"
-#include "barretenberg/plonk/proof_system/public_inputs/public_inputs.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/honk/pcs/commitment_key.hpp"
 #include "barretenberg/honk/pcs/gemini/gemini.hpp"
 #include "barretenberg/honk/pcs/kzg/kzg.hpp"
-#include "barretenberg/numeric/bitop/get_msb.hpp"
-#include "barretenberg/proof_system/flavor/flavor.hpp"
-#include "barretenberg/proof_system/polynomial_store/polynomial_store.hpp"
-#include "barretenberg/ecc/curves/bn254/fq12.hpp"
-#include "barretenberg/ecc/curves/bn254/pairing.hpp"
-#include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
-#include "barretenberg/polynomials/polynomial_arithmetic.hpp"
-#include "barretenberg/honk/composer/composer_helper/permutation_helper.hpp"
-#include <math.h>
-#include <string>
-#include "barretenberg/honk/utils/power_polynomial.hpp"
+#include "barretenberg/honk/pcs/shplonk/shplonk_single.hpp"
+#include "barretenberg/honk/sumcheck/sumcheck.hpp"
+#include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp"
+#include "barretenberg/honk/utils/public_inputs.hpp"
+#include "barretenberg/numeric/bitop/get_msb.hpp"
+#include "barretenberg/proof_system/flavor/flavor.hpp"
+#include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
 
-using namespace barretenberg;
-using namespace honk::sumcheck;
+#include <string>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 
 namespace honk {
 template <typename program_settings>
@@ -81,18 +75,25 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
 {
     using FF = typename program_settings::fr;
     using Commitment = barretenberg::g1::element;
-    using Transcript = typename program_settings::Transcript;
+    using CommitmentAffine = barretenberg::g1::affine_element;
+
+    using Sumcheck = sumcheck::Sumcheck<FF,
+                                        sumcheck::ArithmeticRelation,
+                                        sumcheck::GrandProductComputationRelation,
+                                        sumcheck::GrandProductInitializationRelation>;
     using Gemini = pcs::gemini::MultilinearReductionScheme<pcs::kzg::Params>;
     using Shplonk = pcs::shplonk::SingleBatchOpeningScheme<pcs::kzg::Params>;
     using KZG = pcs::kzg::UnivariateOpeningScheme<pcs::kzg::Params>;
+
     const size_t NUM_POLYNOMIALS = bonk::StandardArithmetization::NUM_POLYNOMIALS;
     const size_t NUM_UNSHIFTED = bonk::StandardArithmetization::NUM_UNSHIFTED_POLYNOMIALS;
     const size_t NUM_PRECOMPUTED = bonk::StandardArithmetization::NUM_PRECOMPUTED_POLYNOMIALS;
 
-    key->program_width = program_settings::program_width;
+    constexpr auto width = program_settings::program_width;
 
-    size_t log_n(numeric::get_msb(key->circuit_size));
-
+    const auto circuit_size = static_cast<uint32_t>(key->circuit_size);
+    const auto num_public_inputs = static_cast<uint32_t>(key->num_public_inputs);
+    const size_t log_n(numeric::get_msb(circuit_size));
     // Add the proof data to the transcript, according to the manifest. Also initialise the transcript's hash type
     // and challenge bytes.
     auto transcript = transcript::StandardTranscript(
@@ -100,16 +101,16 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
 
     // Add the circuit size and the number of public inputs) to the transcript.
     transcript.add_element("circuit_size",
-                           { static_cast<uint8_t>(key->circuit_size >> 24),
-                             static_cast<uint8_t>(key->circuit_size >> 16),
-                             static_cast<uint8_t>(key->circuit_size >> 8),
-                             static_cast<uint8_t>(key->circuit_size) });
+                           { static_cast<uint8_t>(circuit_size >> 24),
+                             static_cast<uint8_t>(circuit_size >> 16),
+                             static_cast<uint8_t>(circuit_size >> 8),
+                             static_cast<uint8_t>(circuit_size) });
 
     transcript.add_element("public_input_size",
-                           { static_cast<uint8_t>(key->num_public_inputs >> 24),
-                             static_cast<uint8_t>(key->num_public_inputs >> 16),
-                             static_cast<uint8_t>(key->num_public_inputs >> 8),
-                             static_cast<uint8_t>(key->num_public_inputs) });
+                           { static_cast<uint8_t>(num_public_inputs >> 24),
+                             static_cast<uint8_t>(num_public_inputs >> 16),
+                             static_cast<uint8_t>(num_public_inputs >> 8),
+                             static_cast<uint8_t>(num_public_inputs) });
 
     // Compute challenges from the proof data, based on the manifest, using the Fiat-Shamir heuristic
     transcript.apply_fiat_shamir("init");
@@ -125,60 +126,80 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
     transcript.apply_fiat_shamir("z");
     transcript.apply_fiat_shamir("separator");
 
-    // // TODO(Cody): Compute some basic public polys like id(X), pow(X), and any required Lagrange polys
+    std::vector<FF> public_inputs = many_from_buffer<FF>(transcript.get_element("public_inputs"));
+    ASSERT(public_inputs.size() == num_public_inputs);
+
+    // Get commitments to the wires
+    std::array<CommitmentAffine, width> wire_commitments;
+    for (size_t i = 0; i < width; ++i) {
+        wire_commitments[i] =
+            transcript.get_group_element(bonk::StandardArithmetization::ENUM_TO_COMM[NUM_PRECOMPUTED + i]);
+    }
+
+    // Get commitment to Z_PERM
+    auto z_permutation_commitment = transcript.get_group_element("Z_PERM");
+
+    // Get permutation challenges
+    const FF beta = FF::serialize_from_buffer(transcript.get_challenge("beta").begin());
+    const FF gamma = FF::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
+    const FF public_input_delta = compute_public_input_delta<FF>(public_inputs, beta, gamma, circuit_size);
+
+    sumcheck::RelationParameters<FF> relation_parameters{
+        .beta = beta,
+        .gamma = gamma,
+        .public_input_delta = public_input_delta,
+    };
+
+    // TODO(Cody): Compute some basic public polys like id(X), pow(X), and any required Lagrange polys
 
     // Execute Sumcheck Verifier
-    auto sumcheck = Sumcheck<FF,
-                             Transcript,
-                             ArithmeticRelation,
-                             GrandProductComputationRelation,
-                             GrandProductInitializationRelation>(transcript);
-    bool sumcheck_result = sumcheck.execute_verifier();
+    std::optional sumcheck_result = Sumcheck::execute_verifier(log_n, relation_parameters, transcript);
 
+    // Abort if sumcheck failed and returned nothing
+    if (!sumcheck_result.has_value()) {
+        return false;
+    }
+
+    // Get opening point and vector of multivariate evaluations produced by Sumcheck
+    // - Multivariate opening point u = (u_0, ..., u_{d-1})
+    auto [opening_point, multivariate_evaluations] = *sumcheck_result;
     // Execute Gemini/Shplonk verification:
 
     // Construct inputs for Gemini verifier:
     // - Multivariate opening point u = (u_0, ..., u_{d-1})
     // - batched unshifted and to-be-shifted polynomial commitments
-    std::vector<FF> opening_point; // u = (u_0,...,u_{d-1})
-    auto batched_commitment_unshifted = Commitment::zero();
-    auto batched_commitment_to_be_shifted = Commitment::zero();
-
-    // Construct MLE opening point
-    for (size_t round_idx = 0; round_idx < key->log_circuit_size; round_idx++) {
-        std::string label = "u_" + std::to_string(round_idx);
-        opening_point.emplace_back(transcript.get_challenge_field_element(label));
-    }
 
     // Compute powers of batching challenge rho
-    Fr rho = Fr::serialize_from_buffer(transcript.get_challenge("rho").begin());
-    std::vector<Fr> rhos = Gemini::powers_of_rho(rho, NUM_POLYNOMIALS);
-
-    // Get vector of multivariate evaluations produced by Sumcheck
-    auto multivariate_evaluations = transcript.get_field_element_vector("multivariate_evaluations");
+    FF rho = FF::serialize_from_buffer(transcript.get_challenge("rho").begin());
+    std::vector<FF> rhos = Gemini::powers_of_rho(rho, NUM_POLYNOMIALS);
 
     // Compute batched multivariate evaluation
-    Fr batched_evaluation = Fr::zero();
+    FF batched_evaluation = FF::zero();
     for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
         batched_evaluation += multivariate_evaluations[i] * rhos[i];
     }
 
     // Construct batched commitment for NON-shifted polynomials
-    for (size_t i = 0; i < NUM_UNSHIFTED; ++i) {
-        Commitment commitment;
-        if (i < NUM_PRECOMPUTED) { // if precomputed, commitment comes from verification key
-            commitment = key->commitments[bonk::StandardArithmetization::ENUM_TO_COMM[i]];
-        } else { // if witness, commitment comes from prover (via transcript)
-            commitment = transcript.get_group_element(bonk::StandardArithmetization::ENUM_TO_COMM[i]);
+    Commitment batched_commitment_unshifted = Commitment::zero();
+    {
+        // add precomputed commitments
+        for (size_t i = 0; i < NUM_PRECOMPUTED; ++i) {
+            // if precomputed, commitment comes from verification key
+            Commitment commitment = key->commitments[bonk::StandardArithmetization::ENUM_TO_COMM[i]];
+            batched_commitment_unshifted += commitment * rhos[i];
         }
-        batched_commitment_unshifted += commitment * rhos[i];
+        // add wire commitment
+        for (size_t i = 0; i < width; ++i) {
+            batched_commitment_unshifted += wire_commitments[i] * rhos[NUM_PRECOMPUTED + i];
+        }
+        // add z_perm
+        batched_commitment_unshifted += z_permutation_commitment * rhos[NUM_PRECOMPUTED + width];
     }
-
-    // Construct batched commitment for to-be-shifted polynomials
-    batched_commitment_to_be_shifted = transcript.get_group_element("Z_PERM") * rhos[NUM_UNSHIFTED];
+    // Construct batched commitment for to-be-shifted polynomials (for now only Z_PERM)
+    Commitment batched_commitment_to_be_shifted = z_permutation_commitment * rhos[NUM_UNSHIFTED];
 
     // Reconstruct the Gemini Proof from the transcript
-    auto gemini_proof = Gemini::reconstruct_proof_from_transcript(&transcript, key->log_circuit_size);
+    auto gemini_proof = Gemini::reconstruct_proof_from_transcript(&transcript, log_n);
 
     // Produce a Gemini claim consisting of:
     // - d+1 commitments [Fold_{r}^(0)], [Fold_{-r}^(0)], and [Fold^(l)], l = 1:d-1

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/univariate.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/univariate.hpp
@@ -211,6 +211,18 @@ template <class Fr, size_t _length> class Univariate {
     }
 };
 
+template <typename B, class Fr, size_t _length> inline void read(B& it, Univariate<Fr, _length>& univariate)
+{
+    using serialize::read;
+    read(it, univariate.evaluations);
+}
+
+template <typename B, class Fr, size_t _length> inline void write(B& it, Univariate<Fr, _length> const& univariate)
+{
+    using serialize::write;
+    write(it, univariate.evaluations);
+}
+
 template <class Fr, size_t view_length> class UnivariateView {
   public:
     std::span<const Fr, view_length> evaluations;

--- a/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
@@ -49,9 +49,8 @@ template <typename FF> class ArithmeticRelation {
         evals += tmp;
     };
 
-    void add_full_relation_value_contribution(FF& full_honk_relation_value,
-                                              const auto& purported_evaluations,
-                                              const RelationParameters<FF>&) const
+    static FF evaluate_full_relation_value_contribution(const auto& purported_evaluations,
+                                                        const RelationParameters<FF>&)
     {
         auto w_l = purported_evaluations[MULTIVARIATE::W_L];
         auto w_r = purported_evaluations[MULTIVARIATE::W_R];
@@ -62,10 +61,11 @@ template <typename FF> class ArithmeticRelation {
         auto q_o = purported_evaluations[MULTIVARIATE::Q_O];
         auto q_c = purported_evaluations[MULTIVARIATE::Q_C];
 
-        full_honk_relation_value += w_l * (q_m * w_r + q_l);
-        full_honk_relation_value += q_r * w_r;
-        full_honk_relation_value += q_o * w_o;
-        full_honk_relation_value += q_c;
+        FF eval = w_l * (q_m * w_r + q_l);
+        eval += q_r * w_r;
+        eval += q_o * w_o;
+        eval += q_c;
+        return eval;
     };
 };
 } // namespace honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp
@@ -59,9 +59,8 @@ template <typename FF> class GrandProductComputationRelation {
                  scaling_factor;
     };
 
-    void add_full_relation_value_contribution(FF& full_honk_relation_value,
-                                              auto& purported_evaluations,
-                                              const RelationParameters<FF>& relation_parameters) const
+    static FF evaluate_full_relation_value_contribution(const auto& purported_evaluations,
+                                                        const RelationParameters<FF>& relation_parameters)
     {
         const auto& beta = relation_parameters.beta;
         const auto& gamma = relation_parameters.gamma;
@@ -82,8 +81,7 @@ template <typename FF> class GrandProductComputationRelation {
         auto lagrange_last = purported_evaluations[MULTIVARIATE::LAGRANGE_LAST];
 
         // Contribution (1)
-        full_honk_relation_value +=
-            ((z_perm + lagrange_first) * (w_1 + beta * id_1 + gamma) * (w_2 + beta * id_2 + gamma) *
+        return ((z_perm + lagrange_first) * (w_1 + beta * id_1 + gamma) * (w_2 + beta * id_2 + gamma) *
                  (w_3 + beta * id_3 + gamma) -
              (z_perm_shift + lagrange_last * public_input_delta) * (w_1 + beta * sigma_1 + gamma) *
                  (w_2 + beta * sigma_2 + gamma) * (w_3 + beta * sigma_3 + gamma));

--- a/cpp/src/barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp
@@ -35,14 +35,13 @@ template <typename FF> class GrandProductInitializationRelation {
         evals += (lagrange_last * z_perm_shift) * scaling_factor;
     };
 
-    void add_full_relation_value_contribution(FF& full_honk_relation_value,
-                                              auto& purported_evaluations,
-                                              const RelationParameters<FF>&) const
+    static FF evaluate_full_relation_value_contribution(const auto& purported_evaluations,
+                                                        const RelationParameters<FF>&)
     {
         auto z_perm_shift = purported_evaluations[MULTIVARIATE::Z_PERM_SHIFT];
         auto lagrange_last = purported_evaluations[MULTIVARIATE::LAGRANGE_LAST];
 
-        full_honk_relation_value += lagrange_last * z_perm_shift;
-    };
+        return lagrange_last * z_perm_shift;
+    }
 };
 } // namespace honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation.hpp
@@ -2,10 +2,7 @@
 
 namespace honk::sumcheck {
 
-// TODO(#226)(Adrian): Remove zeta, alpha as they are not used by the relations.
 template <typename FF> struct RelationParameters {
-    FF zeta;
-    FF alpha;
     FF beta;
     FF gamma;
     FF public_input_delta;

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation.test.cpp
@@ -93,9 +93,7 @@ template <class FF> class SumcheckRelation : public testing::Test {
      */
     RelationParameters<FF> compute_mock_relation_parameters()
     {
-        return { .zeta = FF::random_element(),
-                 .alpha = FF::random_element(),
-                 .beta = FF::random_element(),
+        return { .beta = FF::random_element(),
                  .gamma = FF::random_element(),
                  .public_input_delta = FF::random_element() };
     }
@@ -151,8 +149,8 @@ template <class FF> class SumcheckRelation : public testing::Test {
             // Get an array of the same size as `extended_edges` with only the i-th element of each extended edge.
             std::array evals_i = transposed_univariate_array_at(extended_edges, i);
             // Evaluate the relation
-            relation.add_full_relation_value_contribution(
-                expected_evals_index.value_at(i), evals_i, relation_parameters);
+            expected_evals_index.value_at(i) =
+                relation.evaluate_full_relation_value_contribution(evals_i, relation_parameters);
         }
         EXPECT_EQ(expected_evals, expected_evals_index);
 

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
@@ -8,6 +8,7 @@
 #include "barretenberg/numeric/bitop/get_msb.hpp"
 
 #include <algorithm>
+#include <optional>
 #include <array>
 #include <cstddef>
 #include <span>
@@ -78,7 +79,6 @@ template <typename FF, template <class> class... Relations> class Sumcheck {
     static constexpr size_t NUM_POLYNOMIALS = bonk::StandardArithmetization::NUM_POLYNOMIALS;
 
     using RoundUnivariate = Univariate<FF, MAX_RELATION_LENGTH>;
-    using SumcheckRound = SumcheckRound<FF, NUM_POLYNOMIALS, Relations...>;
 
     /**
      * @brief Compute univariate restriction place in transcript, generate challenge, fold,... repeat until final round,
@@ -149,7 +149,7 @@ template <typename FF, template <class> class... Relations> class Sumcheck {
             const size_t round_size = 1 << (multivariate_d - round_idx);
             // Write the round univariate T_l(X) to the transcript
             // Multiply by [(1-X) + ζ^{ 2^{l} } X] to obtain the full round univariate S_l(X).
-            RoundUnivariate round_univariate = SumcheckRound::compute_univariate(
+            RoundUnivariate round_univariate = SumcheckRound<FF, NUM_POLYNOMIALS, Relations...>::compute_univariate(
                 round_polynomials, round_size, relation_parameters, pow_univariate, alpha);
             transcript.add_element("univariate_" + std::to_string(round_idx), round_univariate.to_buffer());
 

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
@@ -1,116 +1,84 @@
 #pragma once
-#include "barretenberg/common/serialize.hpp"
-#include <array>
-#include "barretenberg/honk/utils/public_inputs.hpp"
-#include "barretenberg/common/throw_or_abort.hpp"
 #include "sumcheck_round.hpp"
+#include "relations/relation.hpp"
+#include "polynomials/pow.hpp"
 #include "polynomials/univariate.hpp"
+#include "barretenberg/common/serialize.hpp"
 #include "barretenberg/proof_system/flavor/flavor.hpp"
+#include "barretenberg/numeric/bitop/get_msb.hpp"
+
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <span>
 #include <string>
 #include <vector>
-#include "barretenberg/honk/proof_system/prover.hpp"
+
 namespace honk::sumcheck {
-template <typename FF, class Transcript, template <class> class... Relations> class Sumcheck {
+
+/**
+ * @brief Contains the multi-linear `evaluations` of the polynomials at the `evaluation_point`.
+ * These are computed by the prover and need to be checked using a multi-linear PCS like Gemini.
+ */
+template <typename FF> struct SumcheckOutput {
+    // u = (u_0, ..., u_{d-1})
+    std::vector<FF> evaluation_point;
+    // Evaluations in `u` of the polynomials used in Sumcheck
+    std::array<FF, bonk::StandardArithmetization::NUM_POLYNOMIALS> evaluations;
+
+    bool operator==(const SumcheckOutput& other) const = default;
+};
+
+/**
+ * @brief Partially evaluate the multi-linear polynomial contained in `source`, at the point `round_challenge`,
+ * storing the result in `destination`.
+ *
+ * @param destination vector to store the resulting evaluations. It is resized to half the size of `source`.
+ *   P'(X_1, ..., X_{d-1}) = P(u_0, X_1, ..., X_{d-1}), with n/2 cofficients [v'_0, ..., v'_{2^{d-1}-1}], where
+ *   v'_i = v_{2i} * (1 - u_0) + v_{2i+1} * u_0.
+ * @param source coefficients of the polynomial we want to evaluate.
+ *   P(X_0, X_1, ..., X_{d-1}) with n=2^d coefficients [v_0, ..., v_{2^{d}-1}].
+ * @param round_challenge partial evaluation point `u_0`
+ *
+ * @details Illustration of layout in example of first round when d==3:
+ *
+ * groups    vertex terms              collected vertex terms               groups after partial evaluation
+ *     g0 -- v0 (1-X0)(1-X1)(1-X2) --- (v0(1-X0) + v1 X0) (1-X1)(1-X2) ---- (v0(1-u0) + v1 u0) (1-X1)(1-X2)
+ *        \- v1   X0  (1-X1)(1-X2) --/                                  --- (v2(1-u0) + v3 u0)   X1  (1-X2)
+ *     g1 -- v2 (1-X0)  X1  (1-X2) --- (v2(1-X0) + v3 X0)   X1  (1-X2)-/ -- (v4(1-u0) + v5 u0) (1-X1)  X2
+ *        \- v3   X0    X1  (1-X2) --/                                  / - (v6(1-u0) + v7 u0)   X1    X2
+ *     g2 -- v4 (1-X0)(1-X1)  X2   --- (v4(1-X0) + v5 X0) (1-X1)  X2  -/ /
+ *        \- v5   X0  (1-X1)  X2   --/                                  /
+ *     g3 -- v6 (1-X0)  X1    X2   --- (v6(1-X0) + v7 X0)   X1    X2  -/
+ *        \- v7   X0    X1    X2   --/
+ */
+template <typename FF>
+static void partially_evaluate(std::vector<FF>& destination, std::span<const FF> source, FF round_challenge)
+{
+    const size_t source_size = source.size();         // = 2^{d}
+    const size_t destination_size = source_size >> 1; // = 2^{d-1}
+    if (destination.size() < destination_size) {
+        // resizing may invalidate `source`
+        ASSERT(destination.data() != source.data());
+        destination.resize(destination_size);
+    }
+    for (size_t i = 0; i < destination_size; ++i) {
+        const FF coefficient_even = source[i << 1];      // v_{ 2i }
+        const FF coefficient_odd = source[(i << 1) + 1]; // v_{2i+1}
+        // v'_i = (1-u_0) * v_{ 2i } + u_0 * v_{2i+1} = v_{ 2i } + u_0 * (v_{2i+1} - v_{ 2i })
+        destination[i] = coefficient_even + round_challenge * (coefficient_odd - coefficient_even);
+    }
+    destination.resize(destination_size);
+}
+
+template <typename FF, template <class> class... Relations> class Sumcheck {
 
   public:
     static constexpr size_t MAX_RELATION_LENGTH = std::max({ Relations<FF>::RELATION_LENGTH... });
+    static constexpr size_t NUM_POLYNOMIALS = bonk::StandardArithmetization::NUM_POLYNOMIALS;
 
-    std::array<FF, bonk::StandardArithmetization::NUM_POLYNOMIALS> purported_evaluations;
-    Transcript& transcript;
-    const size_t multivariate_n;
-    const size_t multivariate_d;
-    SumcheckRound<FF, bonk::StandardArithmetization::NUM_POLYNOMIALS, Relations...> round;
-
-    /**
-    *
-    * @brief (folded_polynomials) Suppose the Honk polynomials (multilinear in d variables) are called P_1, ..., P_N.
-    * At initialization,
-    * we think of these as lying in a two-dimensional array, where each column records the value of one P_i on H^d.
-    * After the first round, the array will be updated ('folded'), so that the first n/2 rows will represent the
-    * evaluations P_i(u0, X1, ..., X_{d-1}) as a low-degree extension on H^{d-1}. In reality, we elude copying all
-    * of the polynomial-defining data by only populating folded_multivariates after the first round. I.e.:
-
-        We imagine all of the defining polynomial data in a matrix like this:
-                    | P_1 | P_2 | P_3 | P_4 | ... | P_N | N = number of multivariatesk
-                    |-----------------------------------|
-          group 0 --|  *  |  *  |  *  |  *  | ... |  *  | vertex 0
-                  \-|  *  |  *  |  *  |  *  | ... |  *  | vertex 1
-          group 1 --|  *  |  *  |  *  |  *  | ... |  *  | vertex 2
-                  \-|  *  |  *  |  *  |  *  | ... |  *  | vertex 3
-                    |  *  |  *  |  *  |  *  | ... |  *  |
-        group m-1 --|  *  |  *  |  *  |  *  | ... |  *  | vertex n-2
-                  \-|  *  |  *  |  *  |  *  | ... |  *  | vertex n-1
-            m = n/2
-                                        *
-            Each group consists of N edges |, and our construction of univariates and folding
-                                        *
-            operations naturally operate on these groups of edges
-
-    *
-    * NOTE: With ~40 columns, prob only want to allocate 256 EdgeGroup's at once to keep stack under 1MB?
-    * TODO(#224)(Cody): might want to just do C-style multidimensional array? for guaranteed adjacency?
-    */
-    std::array<std::vector<FF>, bonk::StandardArithmetization::NUM_POLYNOMIALS> folded_polynomials;
-
-    // prover instantiates sumcheck with circuit size and transcript
-    Sumcheck(size_t multivariate_n, Transcript& transcript)
-        : transcript(transcript)
-        , multivariate_n(multivariate_n)
-        , multivariate_d(numeric::get_msb(multivariate_n))
-        , round(multivariate_n, std::tuple(Relations<FF>()...))
-    {
-        for (auto& polynomial : folded_polynomials) {
-            polynomial.resize(multivariate_n >> 1);
-        }
-    };
-
-    // verifier instantiates with transcript alone
-    explicit Sumcheck(Transcript& transcript)
-        : transcript(transcript)
-        , multivariate_n([](std::vector<uint8_t> buffer) {
-            return static_cast<size_t>(buffer[3]) + (static_cast<size_t>(buffer[2]) << 8) +
-                   (static_cast<size_t>(buffer[1]) << 16) + (static_cast<size_t>(buffer[0]) << 24);
-        }(transcript.get_element("circuit_size")))
-        , multivariate_d(numeric::get_msb(multivariate_n))
-        , round(std::tuple(Relations<FF>()...))
-    {
-        for (auto& polynomial : folded_polynomials) {
-            polynomial.resize(multivariate_n >> 1);
-        }
-    };
-
-    /**
-     * @brief Get all the challenges and computed parameters used in sumcheck in a convenient format
-     *
-     * @return RelationParameters<FF>
-     */
-    RelationParameters<FF> retrieve_proof_parameters()
-    {
-        const FF alpha = FF::serialize_from_buffer(transcript.get_challenge("alpha").begin());
-        const FF zeta = FF::serialize_from_buffer(transcript.get_challenge("alpha", 1).begin());
-        const FF beta = FF::serialize_from_buffer(transcript.get_challenge("beta").begin());
-        const FF gamma = FF::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
-        const auto public_input_size_vector = transcript.get_element("public_input_size");
-        const size_t public_input_size = (static_cast<size_t>(public_input_size_vector[0]) << 24) |
-                                         (static_cast<size_t>(public_input_size_vector[1]) << 16) |
-                                         (static_cast<size_t>(public_input_size_vector[2]) << 8) |
-
-                                         static_cast<size_t>(public_input_size_vector[3]);
-        const auto circut_size_vector = transcript.get_element("circuit_size");
-        const size_t n = (static_cast<size_t>(circut_size_vector[0]) << 24) |
-                         (static_cast<size_t>(circut_size_vector[1]) << 16) |
-                         (static_cast<size_t>(circut_size_vector[2]) << 8) | static_cast<size_t>(circut_size_vector[3]);
-        std::vector<FF> public_inputs = many_from_buffer<FF>(transcript.get_element("public_inputs"));
-        ASSERT(public_inputs.size() == public_input_size);
-        FF public_input_delta = honk::compute_public_input_delta<FF>(public_inputs, beta, gamma, n);
-        const RelationParameters<FF> relation_parameters = RelationParameters<FF>{
-            .zeta = zeta, .alpha = alpha, .beta = beta, .gamma = gamma, .public_input_delta = public_input_delta
-        };
-        return relation_parameters;
-    }
+    using RoundUnivariate = Univariate<FF, MAX_RELATION_LENGTH>;
+    using SumcheckRound = SumcheckRound<FF, NUM_POLYNOMIALS, Relations...>;
 
     /**
      * @brief Compute univariate restriction place in transcript, generate challenge, fold,... repeat until final round,
@@ -118,43 +86,98 @@ template <typename FF, class Transcript, template <class> class... Relations> cl
      *
      * @details
      */
-    void execute_prover(auto full_polynomials) // pass by value, not by reference
+    static SumcheckOutput<FF> execute_prover(const size_t multivariate_d,
+                                             const RelationParameters<FF>& relation_parameters,
+                                             auto full_polynomials, // pass by value, not by reference
+                                             auto& transcript)
     {
-        // First round
-        // This populates folded_polynomials.
+        const FF alpha = FF::serialize_from_buffer(transcript.get_challenge("alpha").begin());
+        const FF zeta = FF::serialize_from_buffer(transcript.get_challenge("alpha", 1).begin());
 
-        const auto relation_parameters = retrieve_proof_parameters();
-        PowUnivariate<FF> pow_univariate(relation_parameters.zeta);
+        /**
+         * Suppose the Honk `full_polynomials` (multilinear in d variables) are called P_1, ..., P_{NUM_POLYNOMIALS}.
+         * At initialization, we think of these as lying in a two-dimensional array, where each column records the value
+         * of one P_i on H^d.
+         * After the first round, the array will be updated ('partially evaluated'), so that the first n/2 rows will
+         * represent the evaluations P_i(u0, X1, ..., X_{d-1}) as a low-degree extension on H^{d-1}.
+         *
+         *    We imagine all of the defining polynomial data in a matrix like this:
+         *                | P_1 | P_2 | P_3 | P_4 | ... | P_N | N = NUM_POLYNOMIALS
+         *                |-----------------------------------|
+         *      group 0 --|  *  |  *  |  *  |  *  | ... |  *  | vertex 0
+         *              \-|  *  |  *  |  *  |  *  | ... |  *  | vertex 1
+         *      group 1 --|  *  |  *  |  *  |  *  | ... |  *  | vertex 2
+         *              \-|  *  |  *  |  *  |  *  | ... |  *  | vertex 3
+         *                |  *  |  *  |  *  |  *  | ... |  *  |
+         *    group m-1 --|  *  |  *  |  *  |  *  | ... |  *  | vertex n-2
+         *              \-|  *  |  *  |  *  |  *  | ... |  *  | vertex n-1
+         *        m = n/2
+         *
+         * At the start of round l>0, the array contains the n/2^l evaluation of
+         * P_i(u0, ..., u_{l-1}, X_l, ..., X_{d-1}), and at the end of the round it is evaluated in X_l = u_l,
+         * where u_l is the challenge point sent by the verifier.
+         *
+         * Since the Honk prover requires the full description of the `full_polynomials` for the PCS opening, we store
+         * the partial evaluations in `partially_evaluated_polynomials`, an array of temporary buffers.
+         * To make the rounds uniform, we perform the Sumcheck rounds over `round_polynomials` which represents the
+         * matrix of partially evaluated polynomials for the given round.
+         *
+         *
+         * NOTE: With ~40 columns, prob only want to allocate 256 EdgeGroup's at once to keep stack under 1MB?
+         * TODO(#224)(Cody): might want to just do C-style multidimensional array? for guaranteed adjacency?
+         */
+        std::array<std::span<const FF>, NUM_POLYNOMIALS> round_polynomials;
+        for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
+            round_polynomials[i] = full_polynomials[i];
+        }
 
-        auto round_univariate = round.compute_univariate(full_polynomials, relation_parameters, pow_univariate);
-        transcript.add_element("univariate_0", round_univariate.to_buffer());
-        std::string challenge_label = "u_0";
-        transcript.apply_fiat_shamir(challenge_label);
-        FF round_challenge = FF::serialize_from_buffer(transcript.get_challenge(challenge_label).begin());
-        fold(full_polynomials, multivariate_n, round_challenge);
-        pow_univariate.partially_evaluate(round_challenge);
-        round.round_size = round.round_size >> 1; // TODO(#224)(Cody): Maybe fold should do this and release memory?
+        /**
+         * Array of temporary buffers containing the partial evaluations of the `full_polynomials`
+         * The function `partially_evaluate` takes care of resizing the vectors after each partial evaluation.
+         */
+        std::array<std::vector<FF>, NUM_POLYNOMIALS> partially_evaluated_polynomials;
 
-        // All but final round
-        // We operate on folded_polynomials in place.
-        for (size_t round_idx = 1; round_idx < multivariate_d; round_idx++) {
-            // Write the round univariate to the transcript
-            round_univariate = round.compute_univariate(folded_polynomials, relation_parameters, pow_univariate);
+        // Store the multi-variate evaluation point u = (u_0, ..., u_{d-1})
+        std::vector<FF> evaluation_points;
+        evaluation_points.reserve(multivariate_d);
+
+        // The pow polynomial and its partial evaluations can be efficiently computed by the PowUnivariate class.
+        PowUnivariate<FF> pow_univariate(zeta);
+
+        // Perform the d Sumcheck rounds
+        for (size_t round_idx = 0; round_idx < multivariate_d; round_idx++) {
+            const size_t round_size = 1 << (multivariate_d - round_idx);
+            // Write the round univariate T_l(X) to the transcript
+            // Multiply by [(1-X) + ζ^{ 2^{l} } X] to obtain the full round univariate S_l(X).
+            RoundUnivariate round_univariate = SumcheckRound::compute_univariate(
+                round_polynomials, round_size, relation_parameters, pow_univariate, alpha);
             transcript.add_element("univariate_" + std::to_string(round_idx), round_univariate.to_buffer());
-            challenge_label = "u_" + std::to_string(round_idx);
+
+            // Get the challenge
+            auto challenge_label = "u_" + std::to_string(round_idx);
             transcript.apply_fiat_shamir(challenge_label);
             FF round_challenge = FF::serialize_from_buffer(transcript.get_challenge(challenge_label).begin());
-            fold(folded_polynomials, round.round_size, round_challenge);
+            evaluation_points.emplace_back(round_challenge);
+
+            // Perform partial evaluation of the round polynomials, in the evaluation point u_l
+            for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
+                // The polynomials in `partially_evaluated_polynomials` are resized appropriately.
+                partially_evaluate(partially_evaluated_polynomials[i], round_polynomials[i], round_challenge);
+                // Sets the polynomials for the next round.
+                round_polynomials[i] = partially_evaluated_polynomials[i];
+            }
             pow_univariate.partially_evaluate(round_challenge);
-            round.round_size = round.round_size >> 1;
         }
 
         // Final round: Extract multivariate evaluations from folded_polynomials and add to transcript
-        std::array<FF, bonk::StandardArithmetization::NUM_POLYNOMIALS> multivariate_evaluations;
-        for (size_t i = 0; i < bonk::StandardArithmetization::NUM_POLYNOMIALS; ++i) {
-            multivariate_evaluations[i] = folded_polynomials[i][0];
+        std::array<FF, NUM_POLYNOMIALS> multivariate_evaluations;
+        for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
+            ASSERT(partially_evaluated_polynomials[i].size() == 1);
+            multivariate_evaluations[i] = partially_evaluated_polynomials[i][0];
         }
         transcript.add_element("multivariate_evaluations", to_buffer(multivariate_evaluations));
+
+        return SumcheckOutput<FF>{ .evaluation_point = evaluation_points, .evaluations = multivariate_evaluations };
     };
 
     /**
@@ -162,73 +185,100 @@ template <typename FF, class Transcript, template <class> class... Relations> cl
      * round, then use purported evaluations to generate purported full Honk relation value and check against final
      * target sum.
      */
-    bool execute_verifier()
+    static std::optional<SumcheckOutput<FF>> execute_verifier(const size_t multivariate_d,
+                                                              const RelationParameters<FF>& relation_parameters,
+                                                              auto& transcript)
     {
-        bool verified(true);
+        const FF alpha = FF::serialize_from_buffer(transcript.get_challenge("alpha").begin());
+        const FF zeta = FF::serialize_from_buffer(transcript.get_challenge("alpha", 1).begin());
 
-        const auto relation_parameters = retrieve_proof_parameters();
-        PowUnivariate<FF> pow_univariate(relation_parameters.zeta);
-        // All but final round.
-        // target_total_sum is initialized to zero then mutated in place.
+        PowUnivariate<FF> pow_univariate(zeta);
 
-        if (multivariate_d == 0) {
-            throw_or_abort("Number of variables in multivariate is 0.");
-        }
+        // Used to evaluate T_l in each round.
+        auto barycentric = BarycentricData<FF, MAX_RELATION_LENGTH, MAX_RELATION_LENGTH>();
 
-        for (size_t round_idx = 0; round_idx < multivariate_d; round_idx++) {
+        // Keep track of the evaluation points and so we can return them upon successful verification.
+        std::vector<FF> evaluation_points;
+        evaluation_points.reserve(multivariate_d);
+
+        // initialize sigma_0 = 0
+        FF target_sum{ 0 };
+        for (size_t round_idx = 0; round_idx < multivariate_d; ++round_idx) {
             // Obtain the round univariate from the transcript
-            auto round_univariate = Univariate<FF, MAX_RELATION_LENGTH>::serialize_from_buffer(
+            auto T_l = RoundUnivariate::serialize_from_buffer(
                 &transcript.get_element("univariate_" + std::to_string(round_idx))[0]);
-            bool checked = round.check_sum(round_univariate, pow_univariate);
-            verified = verified && checked;
-            FF round_challenge =
-                FF::serialize_from_buffer(transcript.get_challenge("u_" + std::to_string(round_idx)).begin());
 
-            round.compute_next_target_sum(round_univariate, round_challenge, pow_univariate);
-            pow_univariate.partially_evaluate(round_challenge);
+            // The "real" round polynomial S_l(X) is ( (1−X) + X⋅ζ^{ 2^{l} } ) ⋅ T_l(X)
+            // S_l(0) + S_l(1) = T^{l}(0) + ζ^{ 2^{l} } ⋅ T^{l}(1), since
+            //   S^{l}(0) = ( (1−0) + 0⋅ζ^{ 2^{l} } ) ⋅ T^{l}(0) = T^{l}(0)
+            //   S^{l}(1) = ( (1−1) + 1⋅ζ^{ 2^{l} } ) ⋅ T^{l}(1) = ζ^{ 2^{l} } ⋅ T^{l}(1)
+            FF claimed_sum = T_l.value_at(0) + (pow_univariate.zeta_pow * T_l.value_at(1));
 
-            if (!verified) {
-                return false;
+            // If the evaluation is wrong, abort and return nothing to indicate failure.
+            if (claimed_sum != target_sum) {
+                return std::nullopt;
             }
+
+            // Get the next challenge point and store it.
+            FF u_l = FF::serialize_from_buffer(transcript.get_challenge("u_" + std::to_string(round_idx)).begin());
+            evaluation_points.emplace_back(u_l);
+
+            // Compute next target_sum
+            // sigma_{l+1} = S^l(u_l)
+            //             = T^l(u_l) * [ (1−u_l) + u_l⋅ζ^{ 2^l } ]
+            target_sum = barycentric.evaluate(T_l, u_l) * pow_univariate.univariate_eval(u_l);
+
+            // Partially evaluate the pow_zeta polynomial
+            pow_univariate.partially_evaluate(u_l);
         }
 
         // Final round
-        auto purported_evaluations = transcript.get_field_element_vector("multivariate_evaluations");
-        FF full_honk_relation_purported_value = round.compute_full_honk_relation_purported_value(
-            purported_evaluations, relation_parameters, pow_univariate);
-        verified = verified && (full_honk_relation_purported_value == round.target_total_sum);
-        return verified;
-    };
+        auto purported_evaluations_vec = transcript.get_field_element_vector("multivariate_evaluations");
+        std::array<FF, NUM_POLYNOMIALS> purported_evaluations{};
+        std::copy_n(purported_evaluations_vec.begin(), NUM_POLYNOMIALS, purported_evaluations.begin());
 
-    // TODO(#224)(Cody): Rename. fold is not descriptive, and it's already in use in the Gemini context.
-    //             Probably just call it partial_evaluation?
-    /**
-     * @brief Evaluate at the round challenge and prepare class for next round.
-     * Illustration of layout in example of first round when d==3 (showing just one Honk polynomial,
-     * i.e., what happens in just one column of our two-dimensional array):
-     *
-     * groups    vertex terms              collected vertex terms               groups after folding
-     *     g0 -- v0 (1-X0)(1-X1)(1-X2) --- (v0(1-X0) + v1 X0) (1-X1)(1-X2) ---- (v0(1-u0) + v1 u0) (1-X1)(1-X2)
-     *        \- v1   X0  (1-X1)(1-X2) --/                                  --- (v2(1-u0) + v3 u0)   X1  (1-X2)
-     *     g1 -- v2 (1-X0)  X1  (1-X2) --- (v2(1-X0) + v3 X0)   X1  (1-X2)-/ -- (v4(1-u0) + v5 u0) (1-X1)  X2
-     *        \- v3   X0    X1  (1-X2) --/                                  / - (v6(1-u0) + v7 u0)   X1    X2
-     *     g2 -- v4 (1-X0)(1-X1)  X2   --- (v4(1-X0) + v5 X0) (1-X1)  X2  -/ /
-     *        \- v5   X0  (1-X1)  X2   --/                                  /
-     *     g3 -- v6 (1-X0)  X1    X2   --- (v6(1-X0) + v7 X0)   X1    X2  -/
-     *        \- v7   X0    X1    X2   --/
-     *
-     * @param challenge
-     */
-    void fold(auto& polynomials, size_t round_size, FF round_challenge)
-    {
-        // after the first round, operate in place on folded_polynomials
-        for (size_t j = 0; j < polynomials.size(); ++j) {
-            // for (size_t j = 0; j < bonk::StandardArithmetization::NUM_POLYNOMIALS; ++j) {
-            for (size_t i = 0; i < round_size; i += 2) {
-                folded_polynomials[j][i >> 1] =
-                    polynomials[j][i] + round_challenge * (polynomials[j][i + 1] - polynomials[j][i]);
-            }
+        // The full Honk identity evaluated in the opening point u.
+        FF full_eval = compute_full_evaluation(
+            purported_evaluations, pow_univariate.partial_evaluation_constant, relation_parameters, alpha);
+
+        // Check against sigma_d
+        if (full_eval != target_sum) {
+            return std::nullopt;
         }
-    };
+
+        return SumcheckOutput<FF>{ .evaluation_point = evaluation_points, .evaluations = purported_evaluations };
+    }
+
+    /**
+     * @brief Given the multi-linear evaluations of the Sumcheck polynomials,
+     * computes the evaluation of the full Honk identity.
+     *
+     * @param multivariate_evaluations container with polynomial
+     * @param pow_zeta_eval Evaluation of pow, computed by the verifier which multiplies the full identity.
+     * @param relation_parameters required by certain relations.
+     * @param alpha relation separation challenge.
+     * @return
+     */
+    static FF compute_full_evaluation(std::span<const FF, NUM_POLYNOMIALS> multivariate_evaluations,
+                                      const FF pow_zeta_eval,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF alpha)
+    {
+        constexpr size_t NUM_RELATIONS = sizeof...(Relations);
+        // Compute the evaluations of each relation by unpacking the type `Relations`
+        std::array<FF, NUM_RELATIONS> relation_evals = { Relations<FF>::evaluate_full_relation_value_contribution(
+            multivariate_evaluations, relation_parameters)... };
+
+        // Do the alpha-linear combination
+        FF alpha_pow{ alpha };
+        FF full_eval{ relation_evals[0] };
+        for (size_t i = 1; i < NUM_RELATIONS; ++i) {
+            full_eval += relation_evals[i] * alpha_pow;
+            alpha_pow *= alpha;
+        }
+        // Multiply by the evaluation of pow
+        full_eval *= pow_zeta_eval;
+        return full_eval;
+    }
 };
 } // namespace honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
@@ -83,11 +83,11 @@ static Univariate<FF, max_relation_length> compute_round_univariate(
 {
     size_t round_size = 1;
     // Improvement(Cody): This is ugly? Maye supply some/all of this data through "flavor" class?
-    using SumcheckRound = SumcheckRound<FF,
-                                        NUM_POLYNOMIALS,
-                                        ArithmeticRelation,
-                                        GrandProductComputationRelation,
-                                        GrandProductInitializationRelation>;
+    using Round = SumcheckRound<FF,
+                                NUM_POLYNOMIALS,
+                                ArithmeticRelation,
+                                GrandProductComputationRelation,
+                                GrandProductInitializationRelation>;
     auto w_l = input_polynomials[0];
     auto w_r = input_polynomials[1];
     auto w_o = input_polynomials[2];
@@ -127,7 +127,7 @@ static Univariate<FF, max_relation_length> compute_round_univariate(
                                                        lagrange_last);
     PowUnivariate<FF> pow_zeta(1);
     Univariate<FF, max_relation_length> round_univariate =
-        SumcheckRound::compute_univariate(full_polynomials, round_size, relation_parameters, pow_zeta, alpha);
+        Round::compute_univariate(full_polynomials, round_size, relation_parameters, pow_zeta, alpha);
     return round_univariate;
 }
 

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
@@ -1,15 +1,15 @@
-#include "barretenberg/proof_system/flavor/flavor.hpp"
 #include "sumcheck_round.hpp"
+#include "sumcheck.hpp"
+#include "polynomials/univariate.hpp"
 #include "relations/arithmetic_relation.hpp"
 #include "relations/grand_product_computation_relation.hpp"
 #include "relations/grand_product_initialization_relation.hpp"
-#include "polynomials/univariate.hpp"
+#include "barretenberg/proof_system/flavor/flavor.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 
 #include <tuple>
 
-#include "barretenberg/common/mem.hpp"
 #include <gtest/gtest.h>
 /**
  * We want to test if the univariate (S_l in the thesis) computed by the prover in a particular round is correct. We
@@ -78,17 +78,16 @@ std::array<std::span<FF>, NUM_POLYNOMIALS> construct_full_polynomials(std::array
 // The below two methods are used in the test ComputeUnivariateProver
 static Univariate<FF, max_relation_length> compute_round_univariate(
     std::array<std::array<FF, input_polynomial_length>, NUM_POLYNOMIALS>& input_polynomials,
-    const RelationParameters<FF>& relation_parameters)
+    const RelationParameters<FF>& relation_parameters,
+    const FF alpha)
 {
     size_t round_size = 1;
-    auto relations = std::tuple(
-        ArithmeticRelation<FF>(), GrandProductComputationRelation<FF>(), GrandProductInitializationRelation<FF>());
     // Improvement(Cody): This is ugly? Maye supply some/all of this data through "flavor" class?
-    auto round = SumcheckRound<FF,
-                               NUM_POLYNOMIALS,
-                               ArithmeticRelation,
-                               GrandProductComputationRelation,
-                               GrandProductInitializationRelation>(round_size, relations);
+    using SumcheckRound = SumcheckRound<FF,
+                                        NUM_POLYNOMIALS,
+                                        ArithmeticRelation,
+                                        GrandProductComputationRelation,
+                                        GrandProductInitializationRelation>;
     auto w_l = input_polynomials[0];
     auto w_r = input_polynomials[1];
     auto w_o = input_polynomials[2];
@@ -126,15 +125,16 @@ static Univariate<FF, max_relation_length> compute_round_univariate(
                                                        id_3,
                                                        lagrange_first,
                                                        lagrange_last);
-    PowUnivariate<FF> pow_zeta(relation_parameters.zeta);
+    PowUnivariate<FF> pow_zeta(1);
     Univariate<FF, max_relation_length> round_univariate =
-        round.compute_univariate(full_polynomials, relation_parameters, pow_zeta);
+        SumcheckRound::compute_univariate(full_polynomials, round_size, relation_parameters, pow_zeta, alpha);
     return round_univariate;
 }
 
 static Univariate<FF, max_relation_length> compute_expected_round_univariate(
     std::array<Univariate<FF, input_polynomial_length>, NUM_POLYNOMIALS>& input_univariates,
-    const RelationParameters<FF>& relation_parameters)
+    const RelationParameters<FF>& relation_parameters,
+    const FF alpha)
 {
     BarycentricData<FF, input_polynomial_length, max_relation_length> barycentric_2_to_max =
         BarycentricData<FF, input_polynomial_length, max_relation_length>();
@@ -177,17 +177,17 @@ static Univariate<FF, max_relation_length> compute_expected_round_univariate(
          (w_o_univariate + sigma_3_univariate * relation_parameters.beta + relation_parameters.gamma));
     auto expected_grand_product_initialization_relation = (z_perm_shift_univariate * lagrange_last_univariate);
     Univariate<FF, max_relation_length> expected_round_univariate =
-        expected_arithmetic_relation + expected_grand_product_computation_relation * relation_parameters.alpha +
-        expected_grand_product_initialization_relation * relation_parameters.alpha * relation_parameters.alpha;
+        expected_arithmetic_relation + expected_grand_product_computation_relation * alpha +
+        expected_grand_product_initialization_relation * alpha.sqr();
     return expected_round_univariate;
 }
 
 // The below two methods are used in the test ComputeUnivariateVerifier
 static FF compute_full_purported_value(std::array<FF, NUM_POLYNOMIALS>& input_values,
-                                       const RelationParameters<FF>& relation_parameters)
+                                       const RelationParameters<FF>& relation_parameters,
+                                       const FF alpha)
 {
-    std::vector<FF> purported_evaluations;
-    purported_evaluations.resize(NUM_POLYNOMIALS);
+    std::array<FF, NUM_POLYNOMIALS> purported_evaluations;
     purported_evaluations[POLYNOMIAL::W_L] = input_values[0];
     purported_evaluations[POLYNOMIAL::W_R] = input_values[1];
     purported_evaluations[POLYNOMIAL::W_O] = input_values[2];
@@ -206,21 +206,16 @@ static FF compute_full_purported_value(std::array<FF, NUM_POLYNOMIALS>& input_va
     purported_evaluations[POLYNOMIAL::ID_3] = input_values[15];
     purported_evaluations[POLYNOMIAL::LAGRANGE_FIRST] = input_values[16];
     purported_evaluations[POLYNOMIAL::LAGRANGE_LAST] = input_values[17];
-    auto relations = std::tuple(
-        ArithmeticRelation<FF>(), GrandProductComputationRelation<FF>(), GrandProductInitializationRelation<FF>());
-    auto round = SumcheckRound<FF,
-                               NUM_POLYNOMIALS,
-                               ArithmeticRelation,
-                               GrandProductComputationRelation,
-                               GrandProductInitializationRelation>(relations);
-    PowUnivariate<FF> pow_univariate(relation_parameters.zeta);
-    FF full_purported_value =
-        round.compute_full_honk_relation_purported_value(purported_evaluations, relation_parameters, pow_univariate);
+    using Sumcheck =
+        Sumcheck<FF, ArithmeticRelation, GrandProductComputationRelation, GrandProductInitializationRelation>;
+    PowUnivariate<FF> pow_univariate(1);
+    FF full_purported_value = Sumcheck::compute_full_evaluation(purported_evaluations, 1, relation_parameters, alpha);
     return full_purported_value;
 }
 
 static FF compute_full_purported_value_expected(std::array<FF, NUM_POLYNOMIALS>& input_values,
-                                                const RelationParameters<FF>& relation_parameters)
+                                                const RelationParameters<FF>& relation_parameters,
+                                                const FF alpha)
 {
     FF w_l = input_values[0];
     FF w_r = input_values[1];
@@ -251,9 +246,9 @@ static FF compute_full_purported_value_expected(std::array<FF, NUM_POLYNOMIALS>&
         (w_r + sigma_2 * relation_parameters.beta + relation_parameters.gamma) *
         (w_o + sigma_3 * relation_parameters.beta + relation_parameters.gamma);
     auto expected_grand_product_initialization_relation = z_perm_shift * lagrange_last;
-    auto expected_full_purported_value =
-        expected_arithmetic_relation + expected_grand_product_computation_relation * relation_parameters.alpha +
-        expected_grand_product_initialization_relation * relation_parameters.alpha * relation_parameters.alpha;
+    auto expected_full_purported_value = expected_arithmetic_relation +
+                                         expected_grand_product_computation_relation * alpha +
+                                         expected_grand_product_initialization_relation * alpha.sqr();
     return expected_full_purported_value;
 }
 
@@ -265,19 +260,18 @@ TEST(SumcheckRound, ComputeUnivariateProver)
             for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
                 input_polynomials[i] = { FF::random_element(), FF::random_element() };
             }
-            const RelationParameters<FF> relation_parameters =
-                RelationParameters<FF>{ .zeta = FF::random_element(),
-                                        .alpha = FF::random_element(),
-                                        .beta = FF::random_element(),
-                                        .gamma = FF::random_element(),
-                                        .public_input_delta = FF::random_element() };
-            auto round_univariate = compute_round_univariate(input_polynomials, relation_parameters);
+            const FF alpha = FF::random_element();
+            const RelationParameters<FF> relation_parameters = RelationParameters<FF>{
+                .beta = FF::random_element(), .gamma = FF::random_element(), .public_input_delta = FF::random_element()
+            };
+            auto round_univariate = compute_round_univariate(input_polynomials, relation_parameters, alpha);
             // Compute round_univariate manually
             std::array<Univariate<FF, input_polynomial_length>, NUM_POLYNOMIALS> input_univariates;
             for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
                 input_univariates[i] = Univariate<FF, input_polynomial_length>(input_polynomials[i]);
             }
-            auto expected_round_univariate = compute_expected_round_univariate(input_univariates, relation_parameters);
+            auto expected_round_univariate =
+                compute_expected_round_univariate(input_univariates, relation_parameters, alpha);
             EXPECT_EQ(round_univariate, expected_round_univariate);
         } else {
             std::array<std::array<FF, input_polynomial_length>, NUM_POLYNOMIALS> input_polynomials;
@@ -285,15 +279,16 @@ TEST(SumcheckRound, ComputeUnivariateProver)
                 input_polynomials[i] = { 1, 2 };
             }
             const RelationParameters<FF> relation_parameters =
-                RelationParameters<FF>{ .zeta = 1, .alpha = 1, .beta = 1, .gamma = 1, .public_input_delta = 1 };
-            auto round_univariate = compute_round_univariate(input_polynomials, relation_parameters);
+                RelationParameters<FF>{ .beta = 1, .gamma = 1, .public_input_delta = 1 };
+            auto round_univariate = compute_round_univariate(input_polynomials, relation_parameters, 1);
             // Compute round_univariate manually
             std::array<Univariate<FF, input_polynomial_length>, NUM_POLYNOMIALS> input_univariates;
             for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
                 input_univariates[i] = Univariate<FF, input_polynomial_length>(input_polynomials[i]);
             }
             // expected_round_univariate = { 6, 26, 66, 132, 230, 366 }
-            auto expected_round_univariate = compute_expected_round_univariate(input_univariates, relation_parameters);
+            auto expected_round_univariate =
+                compute_expected_round_univariate(input_univariates, relation_parameters, 1);
             EXPECT_EQ(round_univariate, expected_round_univariate);
         };
     };
@@ -309,16 +304,14 @@ TEST(SumcheckRound, ComputeUnivariateVerifier)
             for (size_t i = 0; i < NUM_POLYNOMIALS; ++i) {
                 input_values[i] = FF::random_element();
             }
-            const RelationParameters<FF> relation_parameters =
-                RelationParameters<FF>{ .zeta = FF::random_element(),
-                                        .alpha = FF::random_element(),
-                                        .beta = FF::random_element(),
-                                        .gamma = FF::random_element(),
-                                        .public_input_delta = FF::random_element() };
-            auto full_purported_value = compute_full_purported_value(input_values, relation_parameters);
+            const FF alpha = FF::random_element();
+            const RelationParameters<FF> relation_parameters = RelationParameters<FF>{
+                .beta = FF::random_element(), .gamma = FF::random_element(), .public_input_delta = FF::random_element()
+            };
+            auto full_purported_value = compute_full_purported_value(input_values, relation_parameters, alpha);
             // Compute round_univariate manually
             auto expected_full_purported_value =
-                compute_full_purported_value_expected(input_values, relation_parameters);
+                compute_full_purported_value_expected(input_values, relation_parameters, alpha);
             EXPECT_EQ(full_purported_value, expected_full_purported_value);
         } else {
             std::array<FF, NUM_POLYNOMIALS> input_values;
@@ -326,11 +319,11 @@ TEST(SumcheckRound, ComputeUnivariateVerifier)
                 input_values[i] = FF(2);
             }
             const RelationParameters<FF> relation_parameters =
-                RelationParameters<FF>{ .zeta = 2, .alpha = 1, .beta = 1, .gamma = 1, .public_input_delta = 1 };
-            auto full_purported_value = compute_full_purported_value(input_values, relation_parameters);
+                RelationParameters<FF>{ .beta = 1, .gamma = 1, .public_input_delta = 1 };
+            auto full_purported_value = compute_full_purported_value(input_values, relation_parameters, 1);
             // Compute round_univariate manually
             auto expected_full_purported_value =
-                compute_full_purported_value_expected(input_values, relation_parameters);
+                compute_full_purported_value_expected(input_values, relation_parameters, 1);
             EXPECT_EQ(full_purported_value, expected_full_purported_value);
         };
     };


### PR DESCRIPTION


# Description

## Sumcheck

- Both parties now return a `SumcheckOutput` so that the evaluations and opening point do not need to be re-read from the transcript
- Remove `alpha` and  `zeta` from `RelationParameters` 
- Remove constructors in favor of passing arguments directly to the prover/verifier. 
- Verifier is implemented completely in Sumcheck and no longer depends on SumcheckRound.
- Sumcheck and SumcheckRound are static. Parameters are passed explicitly to functions to show what is modified and ensure constness.
- renamed `fold` to `partially_evaluate` and make all Sumcheck rounds uniform for the prover. (no more special case for the first round)
- temporary buffers for partially evaluated polynomials are now created in `execute_prover`
- Added method for evaluating the full Honk identity

## Honk Prover/Verifier 

- Clean up types to make things a bit more generic
- Move challenge extraction in ways which will make the transcript work easier

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
