### PR TITLE
fix: Store lagrange forms of selector polys w/ Ultra

### DIFF
--- a/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
@@ -46,6 +46,15 @@ namespace plonk {
 
 std::vector<ComposerBase::SelectorProperties> ultra_selector_properties()
 {
+    // When reading and writing the proving key from a buffer we must precompute the Lagrange form of certain selector
+    // polynomials. In order to avoid a new selector type and definitions in the polynomial manifest, we can instead
+    // store the Lagrange forms of all the selector polynomials.
+    //
+    // This workaround increases the memory footprint of the prover, and is a possible place of improvement in the
+    // future. Below is the previous state showing where the Lagrange form is necessary for a selector:
+    //     { "q_m", true },         { "q_c", true },    { "q_1", true },        { "q_2", true },
+    //     { "q_3", true },         { "q_4", false },   { "q_arith", false },   { "q_sort", false },
+    //     { "q_elliptic", false }, { "q_aux", false }, { "table_type", true },
     std::vector<ComposerBase::SelectorProperties> result{
         { "q_m", true },        { "q_c", true },   { "q_1", true },        { "q_2", true },
         { "q_3", true },        { "q_4", true },   { "q_arith", true },    { "q_sort", true },

--- a/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
@@ -47,9 +47,9 @@ namespace plonk {
 std::vector<ComposerBase::SelectorProperties> ultra_selector_properties()
 {
     std::vector<ComposerBase::SelectorProperties> result{
-        { "q_m", true },         { "q_c", true },    { "q_1", true },        { "q_2", true },
-        { "q_3", true },         { "q_4", false },   { "q_arith", false },   { "q_sort", false },
-        { "q_elliptic", false }, { "q_aux", false }, { "table_type", true },
+        { "q_m", true },        { "q_c", true },   { "q_1", true },        { "q_2", true },
+        { "q_3", true },        { "q_4", true },   { "q_arith", true },    { "q_sort", true },
+        { "q_elliptic", true }, { "q_aux", true }, { "table_type", true },
     };
     return result;
 }

--- a/cpp/src/barretenberg/proof_system/types/polynomial_manifest.hpp
+++ b/cpp/src/barretenberg/proof_system/types/polynomial_manifest.hpp
@@ -234,6 +234,10 @@ class PrecomputedPolyList {
             case PolynomialSource::SELECTOR: // monomial and fft
                 precomputed_poly_ids.emplace_back(label);
                 precomputed_poly_ids.emplace_back(label + "_fft");
+                // Store all lagrange forms of selector polynomials for ultra
+                if (composer_type == plonk::ComposerType::PLOOKUP) {
+                    precomputed_poly_ids.emplace_back(label + "_lagrange");
+                }
                 break;
             case PolynomialSource::PERMUTATION: // monomial, fft, and lagrange
                 precomputed_poly_ids.emplace_back(label);


### PR DESCRIPTION
# Description

This PR switches to storing the lagrange form of all selector polynomials for the UltraComposer.

A bug came about while integrating this PR Noir's Rust backend: https://github.com/AztecProtocol/barretenberg/pull/249.
The lagrange forms of certain selector polynomials were missing from the proving key when it was read from a buffer. Thus, when it came time to construct a proof and the UltraProver attempted to fetch polynomials such as `q_2_lagrange` there would be an exception because the lagrange form was not in the polynomial store. The root of this cause was that the precomputed polynomials list was [set explicitly when writing](https://github.com/AztecProtocol/barretenberg/blob/24ab0dca5c5df4173963863220a6777d35efbbbf/cpp/src/barretenberg/proof_system/proving_key/serialize.hpp#L47) the proving key. For selector polynomials only poly IDs for [monomials and ffts](https://github.com/AztecProtocol/barretenberg/blob/24ab0dca5c5df4173963863220a6777d35efbbbf/cpp/src/barretenberg/proof_system/types/polynomial_manifest.hpp#L234) are included. This wasn't an issue for the DSL package with Turbo as the lagrange form of the selectors is never used. However, once we switched to using Ultra we needed the lagrange form of some selector polys such as `Q_2`, `Q_M`, `table_value_*`. 

Rather than adding a new selector type and confusing the definitions of selector types, this PR opts for storing the lagrange form of all selectors polynomials for Ultra. 

# Checklist:

- [X] I have reviewed my diff in github, line by line.
- [X] Every change is related to the PR description.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [X] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [X] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [X] There are no circuit changes, OR a cryptographer has been assigned for review.
- [X] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [X] The branch has been rebased against the head of its merge target.
- [X] I'm happy for the PR to be merged at the reviewer's next convenience.
- [X] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [X] If existing code has been modified, such documentation has been added or updated.
