### PR TITLE
`array_push` for Generic Type

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
@@ -102,6 +102,8 @@ template <typename Composer> class address_t {
 
     bool_t<Composer> operator==(const address_t& other) const { return this->to_field() == other.to_field(); }
 
+    bool_t<Composer> operator!=(const address_t& other) const { return this->to_field() != other.to_field(); }
+
     field_t<Composer> to_field() const { return address_; }
 
     fr get_value() const { return address_.get_value(); };

--- a/cpp/src/barretenberg/stdlib/primitives/field/array.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/field/array.hpp
@@ -85,6 +85,18 @@ inline size_t array_push(std::array<std::shared_ptr<T>, SIZE>& arr, std::shared_
     throw_or_abort("array_push cannot push to a full array");
 };
 
+template <typename Composer, typename T, size_t SIZE> inline void array_push(std::array<T, SIZE>& arr, T const& value)
+{
+    bool_t<Composer> already_pushed = false;
+    for (size_t i = 0; i < arr.size(); ++i) {
+        bool_t<Composer> is_zero = arr[i].is_empty();
+        arr[i].conditional_select(!already_pushed && is_zero, value);
+
+        already_pushed |= is_zero;
+    }
+    already_pushed.assert_equal(true, "array_push cannot push to a full array");
+};
+
 /**
  * Note: this assumes `0` always means 'not used', so be careful. If you actually want `0` to be counted, you'll need
  * something else.

--- a/cpp/src/barretenberg/stdlib/primitives/field/array.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/field/array.hpp
@@ -61,6 +61,10 @@ void array_push(std::array<field_t<Composer>, SIZE>& arr, field_t<Composer> cons
     already_pushed.assert_equal(true, "array_push cannot push to a full array");
 };
 
+/**
+ * Note: this assumes `0` always means 'not used', so be careful. If you actually want `0` to be counted, you'll need
+ * something else.
+ */
 template <typename Composer, size_t SIZE>
 inline size_t array_push(std::array<std::optional<field_t<Composer>>, SIZE>& arr, field_t<Composer> const& value)
 {
@@ -73,6 +77,10 @@ inline size_t array_push(std::array<std::optional<field_t<Composer>>, SIZE>& arr
     throw_or_abort("array_push cannot push to a full array");
 };
 
+/**
+ * Note: this assumes `0` always means 'not used', so be careful. If you actually want `0` to be counted, you'll need
+ * something else.
+ */
 template <typename T, size_t SIZE>
 inline size_t array_push(std::array<std::shared_ptr<T>, SIZE>& arr, std::shared_ptr<T> const& value)
 {
@@ -85,6 +93,10 @@ inline size_t array_push(std::array<std::shared_ptr<T>, SIZE>& arr, std::shared_
     throw_or_abort("array_push cannot push to a full array");
 };
 
+/**
+ * Note: this assumes `0` always means 'not used', so be careful. If you actually want `0` to be counted, you'll need
+ * something else.
+ */
 template <typename Composer, typename T, size_t SIZE> inline void array_push(std::array<T, SIZE>& arr, T const& value)
 {
     bool_t<Composer> already_pushed = false;

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -187,7 +187,7 @@ template <typename Curve> struct verification_key {
         }
     }
 
-  private:
+  public:
     field_t<Composer> compress()
     {
         field_t<Composer> compressed_domain = domain.compress();

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -215,7 +215,7 @@ template <typename Curve> struct verification_key {
         return compressed_key;
     }
 
-    barretenberg::fr compress_native(const std::shared_ptr<bonk::verification_key>& key)
+    static barretenberg::fr compress_native(const std::shared_ptr<bonk::verification_key>& key)
     {
         barretenberg::fr compressed_domain = evaluation_domain<Composer>::compress_native(key->domain);
 


### PR DESCRIPTION
# Description

Add a simple array push for generic type and adds a test. Also makes a couple of minor changes needed for aztec3.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
