### PR TITLE
Add cout for verification_key struct

### DIFF
--- a/cpp/src/barretenberg/proof_system/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/proof_system/verification_key/verification_key.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <map>
+#include "barretenberg/common/streams.hpp"
 #include "barretenberg/srs/reference_string/reference_string.hpp"
 #include "barretenberg/srs/reference_string/env_reference_string.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
@@ -112,5 +113,16 @@ template <typename B> inline void write(B& buf, verification_key const& key)
     write(buf, key.contains_recursive_proof);
     write(buf, key.recursive_proof_public_input_indices);
 }
+
+inline std::ostream& operator<<(std::ostream& os, verification_key const& key)
+{
+    return os
+        << "key.composer_type: " << key.composer_type << "\n"
+        << "key.circuit_size: " << static_cast<uint32_t>(key.circuit_size) << "\n"
+        << "key.num_public_inputs: " << static_cast<uint32_t>(key.num_public_inputs) << "\n"
+        << "key.commitments: " << key.commitments << "\n"
+        << "key.contains_recursive_proof: " << key.contains_recursive_proof << "\n"
+        << "key.recursive_proof_public_input_indices: " << key.recursive_proof_public_input_indices << "\n";
+};
 
 } // namespace bonk

--- a/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -1,6 +1,7 @@
 #include "blake3s.hpp"
 #include "blake3s_plookup.hpp"
 #include "barretenberg/crypto/blake3s/blake3s.hpp"
+#include "barretenberg/common/streams.hpp"
 #include <gtest/gtest.h>
 #include "barretenberg/plonk/composer/turbo_composer.hpp"
 #include "barretenberg/plonk/composer/ultra_composer.hpp"
@@ -13,18 +14,6 @@ typedef stdlib::byte_array<Composer> byte_array;
 typedef stdlib::byte_array<plonk::UltraComposer> byte_array_plookup;
 typedef stdlib::public_witness_t<Composer> public_witness_t;
 typedef stdlib::public_witness_t<plonk::UltraComposer> public_witness_t_plookup;
-
-namespace std {
-inline std::ostream& operator<<(std::ostream& os, std::vector<uint8_t> const& t)
-{
-    os << "[ ";
-    for (auto e : t) {
-        os << std::setfill('0') << std::hex << std::setw(2) << (int)e << " ";
-    }
-    os << "]";
-    return os;
-}
-} // namespace std
 
 TEST(stdlib_blake3s, test_single_block)
 {

--- a/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -18,18 +18,6 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-namespace std {
-inline std::ostream& operator<<(std::ostream& os, std::vector<uint8_t> const& t)
-{
-    os << "[ ";
-    for (auto e : t) {
-        os << std::setfill('0') << std::hex << std::setw(2) << (int)e << " ";
-    }
-    os << "]";
-    return os;
-}
-} // namespace std
-
 TEST(stdlib_keccak, keccak_format_input_table)
 {
     Composer composer = Composer();


### PR DESCRIPTION
Add method for writing a verification_key in human-friendly format to an ostream. Needed for proper serialization/deserialization tests between aztec3-circuits and -packages.