### PR TITLE
Mc/hash vk

### DIFF
--- a/cpp/src/barretenberg/polynomials/evaluation_domain.hpp
+++ b/cpp/src/barretenberg/polynomials/evaluation_domain.hpp
@@ -38,7 +38,7 @@ template <typename Fr> class EvaluationDomain {
 
     const std::vector<Fr*>& get_round_roots() const { return round_roots; };
     const std::vector<Fr*>& get_inverse_round_roots() const { return inverse_round_roots; }
-
+    
     size_t size;        // n, always a power of 2
     size_t num_threads; // num_threads * thread_size = size
     size_t thread_size;

--- a/cpp/src/barretenberg/polynomials/evaluation_domain.hpp
+++ b/cpp/src/barretenberg/polynomials/evaluation_domain.hpp
@@ -38,7 +38,7 @@ template <typename Fr> class EvaluationDomain {
 
     const std::vector<Fr*>& get_round_roots() const { return round_roots; };
     const std::vector<Fr*>& get_inverse_round_roots() const { return inverse_round_roots; }
-    
+
     size_t size;        // n, always a power of 2
     size_t num_threads; // num_threads * thread_size = size
     size_t thread_size;

--- a/cpp/src/barretenberg/proof_system/verification_key/verification_key.cpp
+++ b/cpp/src/barretenberg/proof_system/verification_key/verification_key.cpp
@@ -8,14 +8,20 @@
 namespace bonk {
 
 /**
- * @brief Hashes the evaluation domain to match the 'circuit' approach taken in stdlib/recursion/verification_key/verification_key.hpp.
- * @note: in that reference file, the circuit-equivalent of this function is a _method_ of the `evaluation_domain' struct. But we cannot do that with the native `barretenberg::evaluation_domain` type unfortunately, because it's defined in polynomials/evaluation_domain.hpp, and `polynomial` is a bberg library which does not depend on `crypto` in its CMakeLists.txt file. (We'd need `crypto` to be able to call native pedersen functions).
+ * @brief Hashes the evaluation domain to match the 'circuit' approach taken in
+ * stdlib/recursion/verification_key/verification_key.hpp.
+ * @note: in that reference file, the circuit-equivalent of this function is a _method_ of the `evaluation_domain'
+ * struct. But we cannot do that with the native `barretenberg::evaluation_domain` type unfortunately, because it's
+ * defined in polynomials/evaluation_domain.hpp, and `polynomial` is a bberg library which does not depend on `crypto`
+ * in its CMakeLists.txt file. (We'd need `crypto` to be able to call native pedersen functions).
  *
  * @param domain to compress
  * @param composer_type to use when choosing pedersen compression function
  * @return barretenberg::fr compression of the evaluation domain as a field
  */
-barretenberg::fr compress_native_evaluation_domain(barretenberg::evaluation_domain const& domain, plonk::ComposerType composer_type) {
+barretenberg::fr compress_native_evaluation_domain(barretenberg::evaluation_domain const& domain,
+                                                   plonk::ComposerType composer_type)
+{
     barretenberg::fr out;
     if (composer_type == plonk::ComposerType::PLOOKUP) {
         out = crypto::pedersen_commitment::lookup::compress_native({
@@ -63,7 +69,7 @@ barretenberg::fr verification_key_data::compress_native(const size_t hash_index)
     preimage_data.emplace_back(composer_type);
     preimage_data.emplace_back(compressed_domain);
     preimage_data.emplace_back(num_public_inputs);
-    for (const auto& [tag, selector] : this->commitments) {
+    for (const auto& [tag, selector] : commitments) {
         const auto x_limbs = split_bigfield_limbs(selector.x);
         const auto y_limbs = split_bigfield_limbs(selector.y);
 

--- a/cpp/src/barretenberg/proof_system/verification_key/verification_key.cpp
+++ b/cpp/src/barretenberg/proof_system/verification_key/verification_key.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/crypto/sha256/sha256.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
+#include "barretenberg/crypto/pedersen_commitment/pedersen_lookup.hpp"
 #include "barretenberg/polynomials/evaluation_domain.hpp"
 #include "verification_key.hpp"
 #include "../../plonk/proof_system/constants.hpp"

--- a/cpp/src/barretenberg/proof_system/verification_key/verification_key.cpp
+++ b/cpp/src/barretenberg/proof_system/verification_key/verification_key.cpp
@@ -6,15 +6,29 @@
 
 namespace bonk {
 
-barretenberg::fr compress_native_evaluation_domain(barretenberg::evaluation_domain const& domain) {
+/**
+ * @brief Hashes the evaluation domain to match the 'circuit' approach taken in stdlib/recursion/verification_key/verification_key.hpp.
+ * @note: in that reference file, the circuit-equivalent of this function is a _method_ of the `evaluation_domain' struct. But we cannot do that with the native `barretenberg::evaluation_domain` type unfortunately, because it's defined in polynomials/evaluation_domain.hpp, and `polynomial` is a bberg library which does not depend on `crypto` in its CMakeLists.txt file. (We'd need `crypto` to be able to call native pedersen functions).
+ *
+ * @param domain to compress
+ * @param composer_type to use when choosing pedersen compression function
+ * @return barretenberg::fr compression of the evaluation domain as a field
+ */
+barretenberg::fr compress_native_evaluation_domain(barretenberg::evaluation_domain const& domain, plonk::ComposerType composer_type) {
     barretenberg::fr out;
-
-    out = crypto::pedersen_commitment::compress_native({
-        domain.root,
-        domain.domain,
-        domain.generator,
-    });
-    
+    if (composer_type == plonk::ComposerType::PLOOKUP) {
+        out = crypto::pedersen_commitment::lookup::compress_native({
+            domain.root,
+            domain.domain,
+            domain.generator,
+        });
+    } else {
+        out = crypto::pedersen_commitment::compress_native({
+            domain.root,
+            domain.domain,
+            domain.generator,
+        });
+    }
     return out;
 }
 
@@ -31,7 +45,7 @@ barretenberg::fr compress_native_evaluation_domain(barretenberg::evaluation_doma
 barretenberg::fr verification_key_data::compress_native(const size_t hash_index)
 {
     barretenberg::evaluation_domain domain = evaluation_domain(circuit_size);
-    barretenberg::fr compressed_domain = compress_native_evaluation_domain(domain);
+    barretenberg::fr compressed_domain = compress_native_evaluation_domain(domain, plonk::ComposerType(composer_type));
 
     constexpr size_t num_limb_bits = plonk::NUM_LIMB_BITS_IN_FIELD_SIMULATION;
 
@@ -48,10 +62,6 @@ barretenberg::fr verification_key_data::compress_native(const size_t hash_index)
     preimage_data.emplace_back(composer_type);
     preimage_data.emplace_back(compressed_domain);
     preimage_data.emplace_back(num_public_inputs);
-    // for (auto& commitment_entry : commitments) {
-    //     preimage_data.emplace_back(commitment_entry.second.x);
-    //     preimage_data.emplace_back(commitment_entry.second.y);
-    // }
     for (const auto& [tag, selector] : this->commitments) {
         const auto x_limbs = split_bigfield_limbs(selector.x);
         const auto y_limbs = split_bigfield_limbs(selector.y);
@@ -67,9 +77,13 @@ barretenberg::fr verification_key_data::compress_native(const size_t hash_index)
         preimage_data.push_back(y_limbs[3]);
     }
 
-    // NOTE: this does not do the PLOOKUP version of the hash. 
-    // TODO: implement this!
-    return crypto::pedersen_commitment::compress_native(preimage_data, hash_index);
+    barretenberg::fr compressed_key;
+    if (plonk::ComposerType(composer_type) == plonk::ComposerType::PLOOKUP) {
+        compressed_key = crypto::pedersen_commitment::lookup::compress_native(preimage_data, hash_index);
+    } else {
+        compressed_key = crypto::pedersen_commitment::compress_native(preimage_data, hash_index);
+    }
+    return compressed_key;
 }
 
 verification_key::verification_key(const size_t num_gates,

--- a/cpp/src/barretenberg/proof_system/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/proof_system/verification_key/verification_key.hpp
@@ -116,13 +116,12 @@ template <typename B> inline void write(B& buf, verification_key const& key)
 
 inline std::ostream& operator<<(std::ostream& os, verification_key const& key)
 {
-    return os
-        << "key.composer_type: " << key.composer_type << "\n"
-        << "key.circuit_size: " << static_cast<uint32_t>(key.circuit_size) << "\n"
-        << "key.num_public_inputs: " << static_cast<uint32_t>(key.num_public_inputs) << "\n"
-        << "key.commitments: " << key.commitments << "\n"
-        << "key.contains_recursive_proof: " << key.contains_recursive_proof << "\n"
-        << "key.recursive_proof_public_input_indices: " << key.recursive_proof_public_input_indices << "\n";
+    return os << "key.composer_type: " << key.composer_type << "\n"
+              << "key.circuit_size: " << static_cast<uint32_t>(key.circuit_size) << "\n"
+              << "key.num_public_inputs: " << static_cast<uint32_t>(key.num_public_inputs) << "\n"
+              << "key.commitments: " << key.commitments << "\n"
+              << "key.contains_recursive_proof: " << key.contains_recursive_proof << "\n"
+              << "key.recursive_proof_public_input_indices: " << key.recursive_proof_public_input_indices << "\n";
 };
 
 } // namespace bonk

--- a/cpp/src/barretenberg/proof_system/verification_key/verification_key.test.cpp
+++ b/cpp/src/barretenberg/proof_system/verification_key/verification_key.test.cpp
@@ -15,7 +15,8 @@ using namespace bonk;
  *
  * @return verification_key_data randomly generated
  */
-verification_key_data rand_vk_data() {
+verification_key_data rand_vk_data()
+{
     verification_key_data key_data;
     key_data.composer_type = static_cast<uint32_t>(plonk::ComposerType::STANDARD);
     key_data.circuit_size = 1024; // not random - must be power of 2
@@ -103,7 +104,7 @@ TEST(verification_key, compression_inequality_composer_type)
     expect_compressions_ne(key0_data, key1_data);
 }
 
-TEST(verification_key, compression_inequality_different_circuit_size) \
+TEST(verification_key, compression_inequality_different_circuit_size)
 {
     verification_key_data key0_data = rand_vk_data();
     verification_key_data key1_data = key0_data;
@@ -111,7 +112,7 @@ TEST(verification_key, compression_inequality_different_circuit_size) \
     expect_compressions_ne(key0_data, key1_data);
 }
 
-TEST(verification_key, compression_inequality_different_num_public_inputs) \
+TEST(verification_key, compression_inequality_different_num_public_inputs)
 {
     verification_key_data key0_data = rand_vk_data();
     verification_key_data key1_data = key0_data;
@@ -119,7 +120,7 @@ TEST(verification_key, compression_inequality_different_num_public_inputs) \
     expect_compressions_ne(key0_data, key1_data);
 }
 
-TEST(verification_key, compression_inequality_different_commitments) \
+TEST(verification_key, compression_inequality_different_commitments)
 {
     verification_key_data key0_data = rand_vk_data();
     verification_key_data key1_data = key0_data;
@@ -127,7 +128,7 @@ TEST(verification_key, compression_inequality_different_commitments) \
     expect_compressions_ne(key0_data, key1_data);
 }
 
-TEST(verification_key, compression_inequality_different_num_commitments) \
+TEST(verification_key, compression_inequality_different_num_commitments)
 {
     verification_key_data key0_data = rand_vk_data();
     verification_key_data key1_data = key0_data;
@@ -135,7 +136,7 @@ TEST(verification_key, compression_inequality_different_num_commitments) \
     expect_compressions_ne(key0_data, key1_data);
 }
 
-TEST(verification_key, compression_equality_different_contains_recursive_proof) \
+TEST(verification_key, compression_equality_different_contains_recursive_proof)
 {
     verification_key_data key0_data = rand_vk_data();
     verification_key_data key1_data = key0_data;
@@ -144,7 +145,7 @@ TEST(verification_key, compression_equality_different_contains_recursive_proof) 
     expect_compressions_eq(key0_data, key1_data);
 }
 
-TEST(verification_key, compression_equality_different_recursive_proof_public_input_indices) \
+TEST(verification_key, compression_equality_different_recursive_proof_public_input_indices)
 {
     verification_key_data key0_data = rand_vk_data();
     verification_key_data key1_data = key0_data;

--- a/cpp/src/barretenberg/proof_system/verification_key/verification_key.test.cpp
+++ b/cpp/src/barretenberg/proof_system/verification_key/verification_key.test.cpp
@@ -1,43 +1,153 @@
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/common/streams.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
 #include "verification_key.hpp"
+
+namespace {
+auto& engine = numeric::random::get_debug_engine();
+}
 
 using namespace barretenberg;
 using namespace bonk;
 
+/**
+ * @brief generated a random vk data for use in tests
+ *
+ * @return verification_key_data randomly generated
+ */
+verification_key_data rand_vk_data() {
+    verification_key_data key_data;
+    key_data.composer_type = static_cast<uint32_t>(plonk::ComposerType::STANDARD);
+    key_data.circuit_size = 1024; // not random - must be power of 2
+    key_data.num_public_inputs = engine.get_random_uint32();
+    key_data.commitments["test1"] = g1::element::random_element();
+    key_data.commitments["test2"] = g1::element::random_element();
+    key_data.commitments["foo1"] = g1::element::random_element();
+    key_data.commitments["foo2"] = g1::element::random_element();
+    return key_data;
+}
+
+/**
+ * @brief expect that two vk data compressions are equal for a few different hash indices
+ *
+ * @param key0_data
+ * @param key1_data
+ */
+void expect_compressions_eq(verification_key_data key0_data, verification_key_data key1_data)
+{
+    // 0 hash index
+    EXPECT_EQ(key0_data.compress_native(0), key1_data.compress_native(0));
+    // nonzero hash index
+    EXPECT_EQ(key0_data.compress_native(15), key1_data.compress_native(15));
+}
+
+/**
+ * @brief expect that two vk data compressions are not-equal for a few different hash indices
+ *
+ * @param key0_data
+ * @param key1_data
+ */
+void expect_compressions_ne(verification_key_data key0_data, verification_key_data key1_data)
+{
+    EXPECT_NE(key0_data.compress_native(0), key1_data.compress_native(0));
+    EXPECT_NE(key0_data.compress_native(15), key1_data.compress_native(15));
+    // ne hash indeces still lead to ne compressions
+    EXPECT_NE(key0_data.compress_native(0), key1_data.compress_native(15));
+    EXPECT_NE(key0_data.compress_native(14), key1_data.compress_native(15));
+}
+
 TEST(verification_key, buffer_serialization)
 {
-    verification_key_data key;
-    key.composer_type = static_cast<uint32_t>(plonk::ComposerType::STANDARD);
-    key.circuit_size = 1234;
-    key.num_public_inputs = 10;
-    key.commitments["test1"] = g1::element::random_element();
-    key.commitments["test2"] = g1::element::random_element();
-    key.commitments["foo1"] = g1::element::random_element();
-    key.commitments["foo2"] = g1::element::random_element();
+    verification_key_data key_data = rand_vk_data();
 
-    auto buf = to_buffer(key);
+    auto buf = to_buffer(key_data);
     auto result = from_buffer<verification_key_data>(buf);
 
-    EXPECT_EQ(key, result);
+    EXPECT_EQ(key_data, result);
 }
 
 TEST(verification_key, stream_serialization)
 {
-    verification_key_data key;
-    key.composer_type = static_cast<uint32_t>(plonk::ComposerType::STANDARD);
-    key.circuit_size = 1234;
-    key.num_public_inputs = 10;
-    key.commitments["test1"] = g1::element::random_element();
-    key.commitments["test2"] = g1::element::random_element();
-    key.commitments["foo1"] = g1::element::random_element();
-    key.commitments["foo2"] = g1::element::random_element();
+    verification_key_data key_data = rand_vk_data();
 
     std::stringstream s;
-    write(s, key);
+    write(s, key_data);
 
     verification_key_data result;
     read(static_cast<std::istream&>(s), result);
 
-    EXPECT_EQ(key, result);
+    EXPECT_EQ(key_data, result);
+}
+
+TEST(verification_key, basic_compression_equality)
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data; // copy
+    expect_compressions_eq(key0_data, key1_data);
+}
+
+TEST(verification_key, compression_inequality_index_mismatch)
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data; // copy
+    // inquality on hash index mismatch
+    EXPECT_NE(key0_data.compress_native(0), key1_data.compress_native(15));
+    EXPECT_NE(key0_data.compress_native(14), key1_data.compress_native(15));
+}
+
+TEST(verification_key, compression_inequality_composer_type)
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data; // copy
+    key0_data.composer_type = static_cast<uint32_t>(plonk::ComposerType::PLOOKUP);
+    expect_compressions_ne(key0_data, key1_data);
+}
+
+TEST(verification_key, compression_inequality_different_circuit_size) \
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data;
+    key0_data.circuit_size = 4096;
+    expect_compressions_ne(key0_data, key1_data);
+}
+
+TEST(verification_key, compression_inequality_different_num_public_inputs) \
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data;
+    key0_data.num_public_inputs = 42;
+    expect_compressions_ne(key0_data, key1_data);
+}
+
+TEST(verification_key, compression_inequality_different_commitments) \
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data;
+    key0_data.commitments["test1"] = g1::element::random_element();
+    expect_compressions_ne(key0_data, key1_data);
+}
+
+TEST(verification_key, compression_inequality_different_num_commitments) \
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data;
+    key0_data.commitments["new"] = g1::element::random_element();
+    expect_compressions_ne(key0_data, key1_data);
+}
+
+TEST(verification_key, compression_equality_different_contains_recursive_proof) \
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data;
+    key0_data.contains_recursive_proof = false;
+    key1_data.contains_recursive_proof = true;
+    expect_compressions_eq(key0_data, key1_data);
+}
+
+TEST(verification_key, compression_equality_different_recursive_proof_public_input_indices) \
+{
+    verification_key_data key0_data = rand_vk_data();
+    verification_key_data key1_data = key0_data;
+    key1_data.recursive_proof_public_input_indices.push_back(42);
+    expect_compressions_eq(key0_data, key1_data);
 }

--- a/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
@@ -54,7 +54,7 @@ template <typename B> void read(B& it, address& addr)
     using serialize::read;
     fr address_field;
     read(it, address_field);
-    addr = address_field;
+    addr = address(address_field);
 }
 
 template <typename B> void write(B& buf, address const& addr)

--- a/cpp/src/barretenberg/stdlib/recursion/CMakeLists.txt
+++ b/cpp/src/barretenberg/stdlib/recursion/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(stdlib_recursion ecc plonk stdlib_primitives stdlib_pedersen_commitment stdlib_blake3s)
+barretenberg_module(stdlib_recursion ecc proof_system stdlib_primitives stdlib_pedersen_commitment stdlib_blake3s)

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -188,7 +188,7 @@ template <typename Curve> struct verification_key {
     }
 
   public:
-    field_t<Composer> compress()
+    field_t<Composer> compress(size_t const hash_index = 0)
     {
         field_t<Composer> compressed_domain = domain.compress();
 
@@ -208,9 +208,9 @@ template <typename Curve> struct verification_key {
 
         field_t<Composer> compressed_key;
         if constexpr (Composer::type == ComposerType::PLOOKUP) {
-            compressed_key = pedersen_plookup_commitment<Composer>::compress(key_witnesses);
+            compressed_key = pedersen_plookup_commitment<Composer>::compress(key_witnesses, hash_index);
         } else {
-            compressed_key = pedersen_commitment<Composer>::compress(key_witnesses);
+            compressed_key = pedersen_commitment<Composer>::compress(key_witnesses, hash_index);
         }
         return compressed_key;
     }

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -5,7 +5,6 @@
 
 #include "barretenberg/proof_system/types/polynomial_manifest.hpp"
 
-#include "barretenberg/plonk/proof_system/utils/kate_verification.hpp"
 #include "barretenberg/plonk/proof_system/public_inputs/public_inputs.hpp"
 
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
@@ -216,7 +215,8 @@ template <typename Curve> struct verification_key {
         return compressed_key;
     }
 
-    static barretenberg::fr compress_native(const std::shared_ptr<bonk::verification_key>& key, const size_t hash_index = 0)
+    static barretenberg::fr compress_native(const std::shared_ptr<bonk::verification_key>& key,
+                                            const size_t hash_index = 0)
     {
         barretenberg::fr compressed_domain = evaluation_domain<Composer>::compress_native(key->domain);
 
@@ -248,6 +248,7 @@ template <typename Curve> struct verification_key {
             preimage_data.push_back(y_limbs[2]);
             preimage_data.push_back(y_limbs[3]);
         }
+
         barretenberg::fr compressed_key;
         if constexpr (Composer::type == ComposerType::PLOOKUP) {
             compressed_key = crypto::pedersen_commitment::lookup::compress_native(preimage_data, hash_index);

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -192,25 +192,26 @@ template <typename Curve> struct verification_key {
     {
         field_t<Composer> compressed_domain = domain.compress();
 
-        std::vector<field_t<Composer>> key_witnesses;
-        key_witnesses.push_back(compressed_domain);
-        key_witnesses.push_back(num_public_inputs);
+        std::vector<field_t<Composer>> preimage_data;
+        preimage_data.push_back(Composer::type);
+        preimage_data.push_back(compressed_domain);
+        preimage_data.push_back(num_public_inputs);
         for (const auto& [tag, selector] : commitments) {
-            key_witnesses.push_back(selector.x.binary_basis_limbs[0].element);
-            key_witnesses.push_back(selector.x.binary_basis_limbs[1].element);
-            key_witnesses.push_back(selector.x.binary_basis_limbs[2].element);
-            key_witnesses.push_back(selector.x.binary_basis_limbs[3].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[0].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[1].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[2].element);
-            key_witnesses.push_back(selector.y.binary_basis_limbs[3].element);
+            preimage_data.push_back(selector.x.binary_basis_limbs[0].element);
+            preimage_data.push_back(selector.x.binary_basis_limbs[1].element);
+            preimage_data.push_back(selector.x.binary_basis_limbs[2].element);
+            preimage_data.push_back(selector.x.binary_basis_limbs[3].element);
+            preimage_data.push_back(selector.y.binary_basis_limbs[0].element);
+            preimage_data.push_back(selector.y.binary_basis_limbs[1].element);
+            preimage_data.push_back(selector.y.binary_basis_limbs[2].element);
+            preimage_data.push_back(selector.y.binary_basis_limbs[3].element);
         }
 
         field_t<Composer> compressed_key;
         if constexpr (Composer::type == ComposerType::PLOOKUP) {
-            compressed_key = pedersen_plookup_commitment<Composer>::compress(key_witnesses, hash_index);
+            compressed_key = pedersen_plookup_commitment<Composer>::compress(preimage_data, hash_index);
         } else {
-            compressed_key = pedersen_commitment<Composer>::compress(key_witnesses, hash_index);
+            compressed_key = pedersen_commitment<Composer>::compress(preimage_data, hash_index);
         }
         return compressed_key;
     }

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -230,7 +230,6 @@ template <typename Curve> struct verification_key {
         };
 
         std::vector<barretenberg::fr> preimage_data;
-        // TODO: put composer type in here.
         preimage_data.push_back(Composer::type);
         preimage_data.push_back(compressed_domain);
         preimage_data.push_back(key->num_public_inputs);
@@ -252,7 +251,7 @@ template <typename Curve> struct verification_key {
         if constexpr (Composer::type == ComposerType::PLOOKUP) {
             compressed_key = crypto::pedersen_commitment::lookup::compress_native(preimage_data, hash_index);
         } else {
-            compressed_key = crypto::pedersen_commitment::compress_native(preimage_data, hash_index); // TODO: we need a hash index here!
+            compressed_key = crypto::pedersen_commitment::compress_native(preimage_data, hash_index);
         }
         return compressed_key;
     }

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
@@ -1,0 +1,42 @@
+#include "verification_key.hpp"
+#include <gtest/gtest.h>
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/ecc/curves/bn254/g1.hpp"
+#include "barretenberg/proof_system/verification_key/verification_key.hpp"
+#include "barretenberg/plonk/proof_system/constants.hpp"
+#include "barretenberg/stdlib/types/types.hpp"
+
+using namespace plonk;
+
+namespace {
+auto& engine = numeric::random::get_debug_engine();
+}
+
+verification_key_data rand_vk_data(plonk::ComposerType composer_type)
+{
+    verification_key_data key_data;
+    key_data.composer_type = static_cast<uint32_t>(composer_type);
+    key_data.circuit_size = 1024; // not random - must be power of 2
+    key_data.num_public_inputs = engine.get_random_uint16();
+    key_data.commitments["test1"] = g1::element::random_element();
+    key_data.commitments["test2"] = g1::element::random_element();
+    key_data.commitments["foo1"] = g1::element::random_element();
+    key_data.commitments["foo2"] = g1::element::random_element();
+    return key_data;
+}
+
+TEST(stdlib_verification_key, native_compress_comparison)
+{
+    // Compute compression of native verification key (i.e. vk_data)
+    auto crs = std::make_unique<bonk::FileReferenceStringFactory>("../srs_db/ignition");
+    verification_key_data vk_data = rand_vk_data(stdlib::types::Composer::type);
+    const size_t hash_idx = 10;
+    auto native_vk_compression = vk_data.compress_native(hash_idx);
+
+    // Compute compression of recursive verification key
+    auto verification_key = std::make_shared<bonk::verification_key>(std::move(vk_data), crs->get_verifier_crs());
+    auto recursive_vk_compression =
+        stdlib::recursion::verification_key<stdlib::types::bn254>::compress_native(verification_key, hash_idx);
+    EXPECT_EQ(native_vk_compression, recursive_vk_compression);
+}

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
@@ -26,7 +26,7 @@ verification_key_data rand_vk_data(plonk::ComposerType composer_type)
     return key_data;
 }
 
-TEST(stdlib_verification_key, native_compress_comparison)
+TEST(stdlib_verification_key, compress_native_comparison)
 {
     // Compute compression of native verification key (i.e. vk_data)
     auto crs = std::make_unique<bonk::FileReferenceStringFactory>("../srs_db/ignition");


### PR DESCRIPTION
# Description

- Adding a method to hash the `verification_key_data` struct in a way which aligns with how the `verification_key` is hashed.
- (David will be adding tests :) )

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
