### PR TITLE
working serialized proving key size and circuit change test for ultra

### DIFF
--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/c_bind.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/c_bind.cpp
@@ -42,9 +42,10 @@ WASM_EXPORT void join_split__release_key()
 
 WASM_EXPORT uint32_t join_split__get_new_proving_key_data(uint8_t** output)
 {
-    // Computing the size of the serialized key is non trivial. We know it's ~331mb.
-    // Allocate a buffer large enough to hold it, and abort if we overflow.
-    // This is to keep memory usage down.
+// Computing the size of the serialized key is non trivial. We know it's ~331mb.
+// Allocate a buffer large enough to hold it, and abort if we overflow.
+// This is to keep memory usage down.
+#ifdef USE_TURBO
     size_t total_buf_len = 350 * 1024 * 1024;
     auto raw_buf = (uint8_t*)malloc(total_buf_len);
     auto raw_buf_end = raw_buf;
@@ -56,6 +57,15 @@ WASM_EXPORT uint32_t join_split__get_new_proving_key_data(uint8_t** output)
         std::abort();
     }
     return len;
+#else
+    auto proving_key = get_proving_key();
+    auto buffer = to_buffer(*proving_key);
+    auto raw_buf = (uint8_t*)malloc(buffer.size());
+    memcpy(raw_buf, (void*)buffer.data(), buffer.size());
+    *output = raw_buf;
+
+    return static_cast<uint32_t>(buffer.size());
+#endif
 }
 
 WASM_EXPORT void join_split__init_verification_key(void* pippenger, uint8_t const* g2x)

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
@@ -800,11 +800,17 @@ TEST_F(join_split_tests, test_0_input_notes_and_detect_circuit_change)
 
     EXPECT_TRUE(result.valid);
 
-    // The below part detects any changes in the join-split circuit
+// The below part detects any changes in the join-split circuit
+#ifdef USE_TURBO
     constexpr uint32_t CIRCUIT_GATE_COUNT = 64000;
     constexpr uint32_t GATES_NEXT_POWER_OF_TWO = 65536;
     const uint256_t VK_HASH("bb2062d006d31d3234766277711eb28577d5f6082d0f484b87e8235628f8e864");
+#else
+    constexpr uint32_t CIRCUIT_GATE_COUNT = 522850;
+    constexpr uint32_t GATES_NEXT_POWER_OF_TWO = 524288;
+    const uint256_t VK_HASH("012959f86e485f3a8f0b06c900082fca1c34b535cdf4f1088f03154ea655b401");
 
+#endif
     auto number_of_gates_js = result.number_of_gates;
     auto vk_hash_js = get_verification_key()->sha256_hash();
 
@@ -2613,11 +2619,15 @@ TEST_F(join_split_tests, test_send_two_virtual_notes_full_proof)
 // Miscellaneous
 // *************************************************************************************************************
 
-TEST_F(join_split_tests, serialzed_proving_key_size)
+TEST_F(join_split_tests, serialized_proving_key_size)
 {
     uint8_t* ptr;
     auto len = join_split__get_new_proving_key_data(&ptr);
+#ifdef USE_TURBO
     EXPECT_LE(len, 2 * 170 * 1024 * 1024);
+#else
+    EXPECT_LE(len, 2315258552);
+#endif
 }
 
 } // namespace join_split_example::proofs::join_split


### PR DESCRIPTION
# Description

This updates a couple of the join split tests to differentiate between when Barretenberg is built using TurboPlonk or UltraPlonk. 

I changed the `0_input_notes_and_detect_circuit_change` and the `serialized_proving_key_size` tests. They use a `#ifdef ` so the tests should work as expected for TP as well.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
