### PR TITLE
Add debugging CMake preset & update code-workspace

### DIFF
--- a/barretenberg.code-workspace
+++ b/barretenberg.code-workspace
@@ -149,6 +149,7 @@
         "cmake.configureArgs": [
             "--preset clang15",
             "-G Ninja",
+            "-g"
         ],
         "cmake.useCMakePresets": "auto",
     },

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -41,6 +41,17 @@
       }
     },
     {
+      "name": "clang15-dbg",
+      "displayName": "Debugging build with Clang-15",
+      "description": "Build with globally installed Clang-15 in debug mode",
+      "inherits": "default",
+      "environment": {
+        "CC": "clang-15",
+        "CXX": "clang++-15",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
       "name": "gcc",
       "displayName": "Build with GCC",
       "description": "Build with globally installed GCC",
@@ -131,6 +142,11 @@
       "configurePreset": "clang15"
     },
     {
+      "name": "clang15-dbg",
+      "inherits": "default",
+      "configurePreset": "clang15-dbg"
+    },
+    {
       "name": "gcc",
       "inherits": "default",
       "configurePreset": "gcc"
@@ -180,6 +196,11 @@
       "name": "clang15",
       "inherits": "default",
       "configurePreset": "clang15"
+    },
+    {
+      "name": "clang15-dbg",
+      "inherits": "default",
+      "configurePreset": "clang15-dbg"
     },
     {
       "name": "gcc",

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -46,8 +46,6 @@
       "description": "Build with globally installed Clang-15 in debug mode",
       "inherits": "clang15",
       "environment": {
-        "CC": "clang-15",
-        "CXX": "clang++-15",
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -44,7 +44,7 @@
       "name": "clang15-dbg",
       "displayName": "Debugging build with Clang-15",
       "description": "Build with globally installed Clang-15 in debug mode",
-      "inherits": "default",
+      "inherits": "clang15",
       "environment": {
         "CC": "clang-15",
         "CXX": "clang++-15",


### PR DESCRIPTION
# Description
The clang15 CMake preset and and barretenberg.code-workspace didn't support debugging. I added a preset and changed `cmake.configureArgs` in the code-workspace file to enable using the built-in debugger.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
