### PR TITLE
Increase number of sub-generators per hash index to 128

### DIFF
--- a/cpp/src/barretenberg/crypto/generators/generator_data.cpp
+++ b/cpp/src/barretenberg/crypto/generators/generator_data.cpp
@@ -13,7 +13,7 @@ constexpr size_t num_hash_indices = 32;
 #else
 constexpr size_t num_default_generators = 2048;
 constexpr size_t num_hash_indices = 32;
-constexpr size_t num_generators_per_hash_index = 64;
+constexpr size_t num_generators_per_hash_index = 128;
 #endif
 
 constexpr size_t hash_indices_generator_offset = 2048;


### PR DESCRIPTION
# Description

The pre-image size in VK compression is 123, so we need ≥128 sub-generators. TODO: This increases number of sub-generators for each hash index, can we somehow customise the number of generators we need? 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
