### PR TITLE
Build a3crypto.wasm

### DIFF
--- a/cpp/dockerfiles/Dockerfile.wasm-linux-clang
+++ b/cpp/dockerfiles/Dockerfile.wasm-linux-clang
@@ -5,11 +5,11 @@ WORKDIR /usr/src/barretenberg/cpp/src
 RUN curl -s -L https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz | tar zxfv -
 WORKDIR /usr/src/barretenberg/cpp
 COPY . .
-# Build both honk_tests barretenberg.wasm a3crypto.wasm
+# Build both honk_tests barretenberg.wasm primitives.wasm
 # This ensures that we aren't using features that would be incompatible with WASM for Honk
-RUN cmake --preset wasm && cmake --build --preset wasm --target honk_tests --target barretenberg.wasm --target a3crypto.wasm
+RUN cmake --preset wasm && cmake --build --preset wasm --target honk_tests --target barretenberg.wasm --target primitives.wasm
 
 FROM alpine:3.17
 COPY --from=builder /usr/src/barretenberg/cpp/build-wasm/bin/barretenberg.wasm /usr/src/barretenberg/cpp/build/bin/barretenberg.wasm
-COPY --from=builder /usr/src/barretenberg/cpp/build-wasm/bin/a3crypto.wasm /usr/src/barretenberg/cpp/build/bin/a3crypto.wasm
+COPY --from=builder /usr/src/barretenberg/cpp/build-wasm/bin/primitives.wasm /usr/src/barretenberg/cpp/build/bin/primitives.wasm
 COPY --from=builder /usr/src/barretenberg/cpp/build-wasm/bin/*_tests /usr/src/barretenberg/cpp/build/bin/

--- a/cpp/dockerfiles/Dockerfile.wasm-linux-clang
+++ b/cpp/dockerfiles/Dockerfile.wasm-linux-clang
@@ -5,10 +5,11 @@ WORKDIR /usr/src/barretenberg/cpp/src
 RUN curl -s -L https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz | tar zxfv -
 WORKDIR /usr/src/barretenberg/cpp
 COPY . .
-# Build both honk_tests barretenberg.wasm
+# Build both honk_tests barretenberg.wasm a3crypto.wasm
 # This ensures that we aren't using features that would be incompatible with WASM for Honk
-RUN cmake --preset wasm && cmake --build --preset wasm --target honk_tests --target barretenberg.wasm
+RUN cmake --preset wasm && cmake --build --preset wasm --target honk_tests --target barretenberg.wasm --target a3crypto.wasm
 
 FROM alpine:3.17
 COPY --from=builder /usr/src/barretenberg/cpp/build-wasm/bin/barretenberg.wasm /usr/src/barretenberg/cpp/build/bin/barretenberg.wasm
+COPY --from=builder /usr/src/barretenberg/cpp/build-wasm/bin/a3crypto.wasm /usr/src/barretenberg/cpp/build/bin/a3crypto.wasm
 COPY --from=builder /usr/src/barretenberg/cpp/build-wasm/bin/*_tests /usr/src/barretenberg/cpp/build/bin/

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -111,8 +111,10 @@ if(WASM)
         -nostartfiles -O2 -Wl,--no-entry -Wl,--export-dynamic -Wl,--import-memory -Wl,--allow-undefined -Wl,--stack-first -Wl,-z,stack-size=1048576
     )
 
+    # Repeat the above but for the smaller primitives.wasm
+    # Used in packages where we don't need the full contents of barretenberg
     add_executable(
-        a3crypto.wasm
+        primitives.wasm
         $<TARGET_OBJECTS:numeric_objects>
         $<TARGET_OBJECTS:crypto_sha256_objects>
         $<TARGET_OBJECTS:crypto_aes128_objects>
@@ -126,7 +128,7 @@ if(WASM)
     )
 
     target_link_options(
-        a3crypto.wasm
+        primitives.wasm
         PRIVATE
         -nostartfiles -O2 -Wl,--no-entry -Wl,--export-dynamic -Wl,--import-memory -Wl,--allow-undefined -Wl,--stack-first -Wl,-z,stack-size=1048576
     )
@@ -145,9 +147,9 @@ if(WASM)
     )
 
     add_custom_command(
-        TARGET a3crypto.wasm
+        TARGET primitives.wasm
         POST_BUILD
-        COMMAND wasm-opt "$<TARGET_FILE:a3crypto.wasm>" -O2 --asyncify -o "$<TARGET_FILE:a3crypto.wasm>"
+        COMMAND wasm-opt "$<TARGET_FILE:primitives.wasm>" -O2 -o "$<TARGET_FILE:primitives.wasm>"
         VERBATIM
     )
 

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -115,11 +115,13 @@ if(WASM)
     # Used in packages where we don't need the full contents of barretenberg
     add_executable(
         primitives.wasm
+        $<TARGET_OBJECTS:srs_objects>
         $<TARGET_OBJECTS:numeric_objects>
         $<TARGET_OBJECTS:crypto_sha256_objects>
         $<TARGET_OBJECTS:crypto_aes128_objects>
         $<TARGET_OBJECTS:crypto_blake2s_objects>
         $<TARGET_OBJECTS:crypto_blake3s_objects>
+        $<TARGET_OBJECTS:crypto_generators_objects>
         $<TARGET_OBJECTS:crypto_keccak_objects>
         $<TARGET_OBJECTS:crypto_schnorr_objects>
         $<TARGET_OBJECTS:crypto_pedersen_hash_objects>

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -111,6 +111,26 @@ if(WASM)
         -nostartfiles -O2 -Wl,--no-entry -Wl,--export-dynamic -Wl,--import-memory -Wl,--allow-undefined -Wl,--stack-first -Wl,-z,stack-size=1048576
     )
 
+    add_executable(
+        a3crypto.wasm
+        $<TARGET_OBJECTS:numeric_objects>
+        $<TARGET_OBJECTS:crypto_sha256_objects>
+        $<TARGET_OBJECTS:crypto_aes128_objects>
+        $<TARGET_OBJECTS:crypto_blake2s_objects>
+        $<TARGET_OBJECTS:crypto_blake3s_objects>
+        $<TARGET_OBJECTS:crypto_keccak_objects>
+        $<TARGET_OBJECTS:crypto_schnorr_objects>
+        $<TARGET_OBJECTS:crypto_pedersen_hash_objects>
+        $<TARGET_OBJECTS:crypto_pedersen_commitment_objects>
+        $<TARGET_OBJECTS:ecc_objects>
+    )
+
+    target_link_options(
+        a3crypto.wasm
+        PRIVATE
+        -nostartfiles -O2 -Wl,--no-entry -Wl,--export-dynamic -Wl,--import-memory -Wl,--allow-undefined -Wl,--stack-first -Wl,-z,stack-size=1048576
+    )
+
     find_program(WASM_OPT wasm-opt)
 
     if(NOT WASM_OPT)
@@ -121,6 +141,13 @@ if(WASM)
         TARGET barretenberg.wasm
         POST_BUILD
         COMMAND wasm-opt "$<TARGET_FILE:barretenberg.wasm>" -O2 --asyncify -o "$<TARGET_FILE:barretenberg.wasm>"
+        VERBATIM
+    )
+
+    add_custom_command(
+        TARGET a3crypto.wasm
+        POST_BUILD
+        COMMAND wasm-opt "$<TARGET_FILE:a3crypto.wasm>" -O2 --asyncify -o "$<TARGET_FILE:a3crypto.wasm>"
         VERBATIM
     )
 


### PR DESCRIPTION
Builds a smaller wasm than barretenberg with crypto primitives to be used from aztec3-packages. Goal is to have access to pedersen (and others) from small packages like p2p, that don't require the full-blown barretenberg or circuits wasm.

See [this thread](https://aztecprotocol.slack.com/archives/C03P17YHVK8/p1680533771535709) for more info.