### PR TITLE
More Tests on A3 `stdlib` methods

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
@@ -391,7 +391,26 @@ TEST(stdlib_bool, must_imply)
     EXPECT_EQ(result, true);
 }
 
-// TODO: must_imply failure case
+TEST(stdlib_bool, must_imply_fails)
+{
+    honk::StandardHonkComposer composer = honk::StandardHonkComposer();
+    for (size_t j = 0; j < 3; ++j) { // ignore the case when both lhs and rhs are constants
+        bool lhs_constant = (bool)(j % 2);
+        bool rhs_constant = (bool)(j > 1 ? true : false);
+
+        // If a number is divisible by 2 and 3, it is divisible by 6
+        // => 8 is not divisible by 3, so it must not be divisible by 6
+        const size_t i = 8;
+        bool a_val = (bool)(i % 2 == 0);
+        bool b_val = (bool)(i % 6 == 0);
+        bool_t a = lhs_constant ? bool_t(a_val) : (witness_t(&composer, a_val));
+        bool_t b = rhs_constant ? bool_t(b_val) : (witness_t(&composer, b_val));
+        a.must_imply(b, "div by 2 does not imply div by 8");
+
+        EXPECT_EQ(composer.failed(), true);
+        EXPECT_EQ(composer.err(), "div by 2 does not imply div by 8");
+    }
+}
 
 TEST(stdlib_bool, must_imply_multiple)
 {

--- a/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
@@ -53,6 +53,23 @@ template <typename Composer> class stdlib_array : public testing::Test {
         EXPECT_EQ(proof_result, true);
     }
 
+    static void test_array_length_null()
+    {
+        Composer composer = Composer();
+
+        std::array<field_ct, 0> values_ct;
+        auto filled_len = array_length<Composer>(values_ct);
+        EXPECT_EQ(filled_len.get_value(), 0);
+        EXPECT_TRUE(filled_len.is_constant());
+
+        auto prover = composer.create_prover();
+        auto verifier = composer.create_verifier();
+        auto proof = prover.construct_proof();
+        info("composer gates = ", composer.get_num_gates());
+        bool proof_result = verifier.verify_proof(proof);
+        EXPECT_EQ(proof_result, true);
+    }
+
     static void test_array_length_fails()
     {
         Composer composer = Composer();
@@ -285,7 +302,7 @@ template <typename Composer> class stdlib_array : public testing::Test {
         }
 
         bool proof_result = false;
-        if (composer.err().empty()) {
+        if (!composer.failed()) {
             auto prover = composer.create_prover();
             auto verifier = composer.create_verifier();
             auto proof = prover.construct_proof();
@@ -615,6 +632,10 @@ TYPED_TEST_SUITE(stdlib_array, ComposerTypes);
 TYPED_TEST(stdlib_array, test_array_length)
 {
     TestFixture::test_array_length();
+}
+TYPED_TEST(stdlib_array, test_array_length_null)
+{
+    TestFixture::test_array_length_null();
 }
 TYPED_TEST(stdlib_array, test_array_length_fails)
 {

--- a/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
@@ -29,8 +29,6 @@ template <typename Composer> class stdlib_array : public testing::Test {
     typedef stdlib::public_witness_t<Composer> public_witness_ct;
 
   public:
-    // TODO: empty array and singleton array edge cases for all array functions.
-
     static void test_array_length()
     {
         Composer composer = Composer();
@@ -375,6 +373,36 @@ template <typename Composer> class stdlib_array : public testing::Test {
         EXPECT_TRUE(proof_result);
     }
 
+    static void test_pata_null_source()
+    {
+        // null means array size is 0
+        Composer composer = Composer();
+
+        std::array<fr, 0> source;
+        std::array<fr, 4> target = { 1, 2, 0, 0 };
+        std::array<fr, 4> expected_target = { 1, 2, 0, 0 };
+        bool proof_result;
+        std::string error;
+        std::tie(proof_result, error) = test_push_array_to_array_helper(composer, source, target, expected_target);
+
+        EXPECT_TRUE(proof_result);
+    }
+
+    static void test_pata_null_target_fails()
+    {
+        Composer composer = Composer();
+
+        std::array<fr, 4> source = { 1, 2, 0, 0 };
+        std::array<fr, 0> target;
+        std::array<fr, 0> expected_target;
+        bool proof_result;
+        std::string error;
+        std::tie(proof_result, error) = test_push_array_to_array_helper(composer, source, target, expected_target);
+
+        EXPECT_FALSE(proof_result);
+        EXPECT_EQ(error, "push_array_to_array target array capacity exceeded");
+    }
+
     static void test_pata_singletons_full_to_not_full()
     {
         Composer composer = Composer();
@@ -387,6 +415,35 @@ template <typename Composer> class stdlib_array : public testing::Test {
         std::tie(proof_result, error) = test_push_array_to_array_helper(composer, source, target, expected_target);
 
         EXPECT_TRUE(proof_result);
+    }
+
+    static void test_pata_singletons_not_full_to_full()
+    {
+        Composer composer = Composer();
+
+        std::array<fr, 1> source = { 0 };
+        std::array<fr, 1> target = { 1 };
+        std::array<fr, 1> expected_target = { 1 };
+        bool proof_result;
+        std::string error;
+        std::tie(proof_result, error) = test_push_array_to_array_helper(composer, source, target, expected_target);
+
+        EXPECT_TRUE(proof_result);
+    }
+
+    static void test_pata_singletons_full_to_full()
+    {
+        Composer composer = Composer();
+
+        std::array<fr, 1> source = { 2 };
+        std::array<fr, 1> target = { 1 };
+        std::array<fr, 1> expected_target = { 1 };
+        bool proof_result;
+        std::string error;
+        std::tie(proof_result, error) = test_push_array_to_array_helper(composer, source, target, expected_target);
+
+        EXPECT_FALSE(proof_result);
+        EXPECT_EQ(error, "push_array_to_array target array capacity exceeded");
     }
 
     static void test_pata_same_size_full_to_full_fails()
@@ -608,9 +665,25 @@ TYPED_TEST(stdlib_array, test_pata_smaller_source_full_to_not_full)
 {
     TestFixture::test_pata_smaller_source_full_to_not_full();
 }
+TYPED_TEST(stdlib_array, test_pata_null_source)
+{
+    TestFixture::test_pata_null_source();
+}
+TYPED_TEST(stdlib_array, test_pata_null_target_fails)
+{
+    TestFixture::test_pata_null_target_fails();
+}
 TYPED_TEST(stdlib_array, test_pata_singletons_full_to_not_full)
 {
     TestFixture::test_pata_singletons_full_to_not_full();
+}
+TYPED_TEST(stdlib_array, test_pata_singletons_not_full_to_full)
+{
+    TestFixture::test_pata_singletons_not_full_to_full();
+}
+TYPED_TEST(stdlib_array, test_pata_singletons_full_to_full)
+{
+    TestFixture::test_pata_singletons_full_to_full();
 }
 TYPED_TEST(stdlib_array, test_pata_same_size_full_to_full_fails)
 {


### PR DESCRIPTION
# Description

Adds a few more tests to test:
1. Failure case of `must_imply` for the `bool_t` class
2. Edge cases of null and singleton array in array methods

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
