### PR TITLE
Fix `from_witness` method in ECDSA

### DIFF
--- a/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -21,9 +21,13 @@ bool_t<Composer> verify_signature(const stdlib::byte_array<Composer>& message,
 template <typename Composer>
 static signature<Composer> from_witness(Composer* ctx, const crypto::ecdsa::signature& input)
 {
-    byte_array x(ctx, input.r);
-    byte_array y(ctx, input.s);
-    signature<Composer> out(x, y);
+    std::vector<uint8_t> r_vec(std::begin(input.r), std::end(input.r));
+    std::vector<uint8_t> s_vec(std::begin(input.s), std::end(input.s));
+    stdlib::byte_array<Composer> r(ctx, r_vec);
+    stdlib::byte_array<Composer> s(ctx, s_vec);
+    signature<Composer> out;
+    out.r = r;
+    out.s = s;
     return out;
 }
 


### PR DESCRIPTION
# Description

This method wasn't being correctly implemented so fixing it for ECDSA to work in a3-circuits.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
