### PR TITLE
Split shplonk in prep for work queue

### DIFF
--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -239,13 +239,28 @@ template <typename settings> void Prover<settings>::execute_pcs_evaluation_round
 /**
  * - Do Fiat-Shamir to get "nu" challenge.
  * - Compute commitment [Q]_1
+ * */
+template <typename settings> void Prover<settings>::execute_shplonk_batched_quotient_round()
+{
+    nu_challenge = transcript.get_challenge("Shplonk:nu");
+
+    batched_quotient_Q =
+        Shplonk::compute_batched_quotient(gemini_output.opening_pairs, gemini_output.witnesses, nu_challenge);
+
+    // commit to Q(X) and add [Q] to the transcript
+    auto Q_commitment = commitment_key->commit(batched_quotient_Q);
+    transcript.send_to_verifier("Shplonk:Q", Q_commitment);
+}
+
+/**
  * - Do Fiat-Shamir to get "z" challenge.
  * - Compute polynomial Q(X) - Q_z(X)
  * */
-template <typename settings> void Prover<settings>::execute_shplonk_round()
+template <typename settings> void Prover<settings>::execute_shplonk_partial_evaluation_round()
 {
-    shplonk_output =
-        Shplonk::reduce_prove(commitment_key, gemini_output.opening_pairs, gemini_output.witnesses, transcript);
+    const Fr z_challenge = transcript.get_challenge("Shplonk:z");
+    shplonk_output = Shplonk::compute_partially_evaluated_batched_quotient(
+        gemini_output.opening_pairs, gemini_output.witnesses, std::move(batched_quotient_Q), nu_challenge, z_challenge);
 }
 
 /**
@@ -302,7 +317,9 @@ template <typename settings> plonk::proof& Prover<settings>::construct_proof()
 
     // Fiat-Shamir: nu
     // Compute Shplonk batched quotient commitment
-    execute_shplonk_round();
+    execute_shplonk_batched_quotient_round();
+    execute_shplonk_partial_evaluation_round();
+    // execute_shplonk_round();
     // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
 
     // Fiat-Shamir: z

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -319,7 +319,6 @@ template <typename settings> plonk::proof& Prover<settings>::construct_proof()
     // Compute Shplonk batched quotient commitment
     execute_shplonk_batched_quotient_round();
     execute_shplonk_partial_evaluation_round();
-    // execute_shplonk_round();
     // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
 
     // Fiat-Shamir: z

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -44,7 +44,6 @@ template <typename settings> class Prover {
     void execute_pcs_evaluation_round();
     void execute_shplonk_batched_quotient_round();
     void execute_shplonk_partial_evaluation_round();
-    // void execute_shplonk_round();
     void execute_kzg_round();
 
     void compute_wire_commitments();

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -42,7 +42,9 @@ template <typename settings> class Prover {
     void execute_relation_check_rounds();
     void execute_univariatization_round();
     void execute_pcs_evaluation_round();
-    void execute_shplonk_round();
+    void execute_shplonk_batched_quotient_round();
+    void execute_shplonk_partial_evaluation_round();
+    // void execute_shplonk_round();
     void execute_kzg_round();
 
     void compute_wire_commitments();
@@ -70,6 +72,9 @@ template <typename settings> class Prover {
 
     // Container for d + 1 Fold polynomials produced by Gemini
     std::vector<Polynomial> fold_polynomials;
+
+    Polynomial batched_quotient_Q;
+    Fr nu_challenge;
 
     // Honk only needs a small portion of the functionality but may be fine to use existing work_queue
     // NOTE: this is not currently in use, but it may well be used in the future.


### PR DESCRIPTION
# Description

TLDR: Split Shplonk (just like we did for Gemini) to facilitate computation of commitments in work_queue.

The Shplonk prover has two main operations: 1) compute batched quotient polynomial Q, and 2) compute polynomial Q - Q_z. The challenge z at which Q is partially evaluated depends on the commitment [Q]. In order to compute this commitment in the work_queue, operations (2) must be separated from task (1). As part of this separation, all transcript operations have been moved to the `Prover` itself.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
