### PR TITLE
fix(dsl): Use info instead of std::cout to log

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -1,4 +1,5 @@
 #include "acir_format.hpp"
+#include "barretenberg/common/log.hpp"
 
 using namespace proof_system::plonk::stdlib::types;
 
@@ -15,7 +16,7 @@ void read_witness(Composer& composer, std::vector<barretenberg::fr> witness)
 void create_circuit(Composer& composer, const acir_format& constraint_system)
 {
     if (constraint_system.public_inputs.size() > constraint_system.varnum) {
-        std::cout << "too many public inputs!" << std::endl;
+        info("create_circuit: too many public inputs!");
     }
 
     for (size_t i = 1; i < constraint_system.varnum; ++i) {
@@ -91,7 +92,7 @@ Composer create_circuit(const acir_format& constraint_system,
                         std::unique_ptr<proof_system::ReferenceStringFactory>&& crs_factory)
 {
     if (constraint_system.public_inputs.size() > constraint_system.varnum) {
-        std::cout << "too many public inputs!" << std::endl;
+        info("create_circuit: too many public inputs!");
     }
 
     Composer composer(std::move(crs_factory));
@@ -172,7 +173,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system,
                                      std::unique_ptr<ReferenceStringFactory>&& crs_factory)
 {
     if (constraint_system.public_inputs.size() > constraint_system.varnum) {
-        std::cout << "too many public inputs!" << std::endl;
+        info("create_circuit_with_witness: too many public inputs!");
     }
 
     Composer composer(std::move(crs_factory));
@@ -253,7 +254,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system,
 Composer create_circuit_with_witness(const acir_format& constraint_system, std::vector<fr> witness)
 {
     if (constraint_system.public_inputs.size() > constraint_system.varnum) {
-        std::cout << "too many public inputs!" << std::endl;
+        info("create_circuit_with_witness: too many public inputs!");
     }
 
     auto composer = Composer();
@@ -334,7 +335,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system, std::
 void create_circuit_with_witness(Composer& composer, const acir_format& constraint_system, std::vector<fr> witness)
 {
     if (constraint_system.public_inputs.size() > constraint_system.varnum) {
-        std::cout << "too many public inputs!" << std::endl;
+        info("create_circuit_with_witness: too many public inputs!");
     }
 
     for (size_t i = 1; i < constraint_system.varnum; ++i) {


### PR DESCRIPTION
# Description

This uses `info()` instead of `std::cout` to log in the acir_format DSL code. There are a few other uses of `std::cout` in the non-test files that probably also need to be changed, but this solves a crash I had in wasm.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
