### PR TITLE
Lde/reinstate work queue

### DIFF
--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
@@ -168,12 +168,6 @@ StandardProver StandardHonkComposerHelper<CircuitConstructor>::create_prover(
     auto manifest = Flavor::create_manifest(circuit_constructor.public_inputs.size(), num_sumcheck_rounds);
     StandardProver output_state(std::move(wire_polynomials), circuit_proving_key);
 
-    // TODO(Cody): This should be more generic
-    std::unique_ptr<pcs::kzg::CommitmentKey> kate_commitment_key =
-        std::make_unique<pcs::kzg::CommitmentKey>(circuit_proving_key->circuit_size, "../srs_db/ignition");
-
-    output_state.commitment_key = std::move(kate_commitment_key);
-
     return output_state;
 }
 template class StandardHonkComposerHelper<StandardCircuitConstructor>;

--- a/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
+++ b/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
@@ -60,23 +60,20 @@ template <typename Params> class UnivariateOpeningScheme {
     using Accumulator = BilinearAccumulator<Params>;
 
     /**
-     * @brief Compute KZG opening proof (commitment) and add it to transcript
+     * @brief Compute KZG opening proof polynomial
      *
-     * @param ck CommitmentKey
      * @param opening_pair OpeningPair = {r, v = polynomial(r)}
      * @param polynomial the witness polynomial being opened
+     * @return KZG quotient polynomial of the form (p(X) - v) / (X - r)
      */
-    static void reduce_prove(std::shared_ptr<CK> ck,
-                             const OpeningPair<Params>& opening_pair,
-                             const Polynomial& polynomial,
-                             ProverTranscript<Fr>& transcript)
+    static Polynomial compute_opening_proof_polynomial(const OpeningPair<Params>& opening_pair,
+                                                       const Polynomial& polynomial)
     {
         Polynomial quotient(polynomial);
         quotient[0] -= opening_pair.evaluation;
         quotient.factor_roots(opening_pair.challenge);
-        CommitmentAffine quotient_commitment = ck->commit(quotient);
 
-        transcript.send_to_verifier("KZG:W", quotient_commitment);
+        return quotient;
     };
 
     /**

--- a/cpp/src/barretenberg/honk/pcs/kzg/kzg.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/kzg/kzg.test.cpp
@@ -40,7 +40,8 @@ TYPED_TEST(BilinearAccumulationTest, single)
 
     auto prover_transcript = ProverTranscript<Fr>::init_empty();
 
-    KZG::reduce_prove(this->ck(), opening_pair, witness, prover_transcript);
+    auto quotient_W = KZG::compute_opening_proof_polynomial(opening_pair, witness);
+    prover_transcript.send_to_verifier("KZG:W", this->commit(quotient_W));
 
     auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
     auto kzg_claim = KZG::reduce_verify(opening_claim, verifier_transcript);
@@ -148,7 +149,8 @@ TYPED_TEST(BilinearAccumulationTest, GeminiShplonkKzgWithShift)
 
     // KZG prover:
     // - Adds commitment [W] to transcript
-    KZG::reduce_prove(this->ck(), shplonk_opening_pair, shplonk_witness, prover_transcript);
+    auto quotient_W = KZG::compute_opening_proof_polynomial(shplonk_opening_pair, shplonk_witness);
+    prover_transcript.send_to_verifier("KZG:W", this->commit(quotient_W));
 
     // Run the full verifier PCS protocol with genuine opening claims (genuine commitment, genuine evaluation)
 

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -5,6 +5,7 @@
 #include "barretenberg/honk/sumcheck/sumcheck.hpp"
 #include <array>
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp" // will go away
+#include "barretenberg/honk/transcript/transcript.hpp"
 #include "barretenberg/honk/utils/power_polynomial.hpp"
 #include "barretenberg/honk/pcs/commitment_key.hpp"
 #include <memory>
@@ -39,13 +40,13 @@ using POLYNOMIAL = proof_system::honk::StandardArithmetization::POLYNOMIAL;
  * */
 template <typename settings>
 Prover<settings>::Prover(std::vector<barretenberg::polynomial>&& wire_polys,
-                         std::shared_ptr<plonk::proving_key> input_key)
+                         const std::shared_ptr<plonk::proving_key> input_key)
     : wire_polynomials(wire_polys)
     , key(input_key)
     , commitment_key(std::make_unique<pcs::kzg::CommitmentKey>(
           input_key->circuit_size,
           "../srs_db/ignition")) // TODO(Cody): Need better constructors for prover.
-// , queue(proving_key.get(), &transcript)
+    , queue(key, transcript, commitment_key)
 {
     // Note(luke): This could be done programmatically with some hacks but this isnt too bad and its nice to see the
     // polys laid out explicitly.
@@ -75,16 +76,16 @@ Prover<settings>::Prover(std::vector<barretenberg::polynomial>&& wire_polys,
 }
 
 /**
- * - Commit to wires 1,2,3
+ * - Add commitment to wires 1,2,3 to work queue
  * - Add PI to transcript (I guess PI will stay in w_2 for now?)
  *
  * */
 template <typename settings> void Prover<settings>::compute_wire_commitments()
 {
     for (size_t i = 0; i < settings::Arithmetization::num_wires; ++i) {
-        auto commitment = commitment_key->commit(wire_polynomials[i]);
-
-        transcript.send_to_verifier("W_" + std::to_string(i + 1), commitment);
+        queue.add_to_queue({ .work_type = WorkType::SCALAR_MULTIPLICATION,
+                             .mul_scalars = wire_polynomials[i],
+                             .label = "W_" + std::to_string(i + 1) });
     }
 }
 
@@ -94,8 +95,6 @@ template <typename settings> void Prover<settings>::compute_wire_commitments()
  * */
 template <typename settings> void Prover<settings>::execute_preamble_round()
 {
-    // queue.flush_queue(); // NOTE: Don't remove; we may reinstate the queue
-
     const auto circuit_size = static_cast<uint32_t>(key->circuit_size);
     const auto num_public_inputs = static_cast<uint32_t>(key->num_public_inputs);
 
@@ -113,7 +112,6 @@ template <typename settings> void Prover<settings>::execute_preamble_round()
  * */
 template <typename settings> void Prover<settings>::execute_wire_commitments_round()
 {
-    // queue.flush_queue(); // NOTE: Don't remove; we may reinstate the queue
     compute_wire_commitments();
 }
 
@@ -131,8 +129,6 @@ template <typename settings> void Prover<settings>::execute_tables_round()
  * */
 template <typename settings> void Prover<settings>::execute_grand_product_computation_round()
 {
-    // queue.flush_queue(); // NOTE: Don't remove; we may reinstate the queue
-
     // Compute and store parameters required by relations in Sumcheck
     auto [beta, gamma] = transcript.get_challenges("beta", "gamma");
 
@@ -147,9 +143,8 @@ template <typename settings> void Prover<settings>::execute_grand_product_comput
     z_permutation =
         prover_library::compute_permutation_grand_product<settings::program_width>(key, wire_polynomials, beta, gamma);
 
-    auto commitment = commitment_key->commit(z_permutation);
-
-    transcript.send_to_verifier("Z_PERM", commitment);
+    queue.add_to_queue(
+        { .work_type = WorkType::SCALAR_MULTIPLICATION, .mul_scalars = z_permutation, .label = "Z_PERM" });
 
     prover_polynomials[POLYNOMIAL::Z_PERM] = z_permutation;
     prover_polynomials[POLYNOMIAL::Z_PERM_SHIFT] = z_permutation.shifted();
@@ -162,8 +157,6 @@ template <typename settings> void Prover<settings>::execute_grand_product_comput
  * */
 template <typename settings> void Prover<settings>::execute_relation_check_rounds()
 {
-    // queue.flush_queue(); // NOTE: Don't remove; we may reinstate the queue
-
     using Sumcheck = sumcheck::Sumcheck<Fr,
                                         ProverTranscript<Fr>,
                                         sumcheck::ArithmeticRelation,
@@ -197,22 +190,15 @@ template <typename settings> void Prover<settings>::execute_univariatization_rou
     Polynomial batched_poly_to_be_shifted(key->circuit_size); // batched to-be-shifted polynomials
     batched_poly_to_be_shifted.add_scaled(prover_polynomials[POLYNOMIAL::Z_PERM], rhos[NUM_UNSHIFTED_POLYS]);
 
-    // // Reserve space for d+1 Fold polynomials. At the end of this round, the last d-1 polynomials will
-    // // correspond to Fold^(i). At the end of the full Gemini prover protocol, the first two will
-    // // be the partially evaluated Fold polynomials Fold_{r}^(0) and Fold_{-r}^(0).
-    // fold_polynomials.reserve(key->log_circuit_size + 1);
-    // fold_polynomials.emplace_back(batched_poly_unshifted);
-    // fold_polynomials.emplace_back(batched_poly_to_be_shifted);
-
     // Compute d-1 polynomials Fold^(i), i = 1, ..., d-1.
     fold_polynomials = Gemini::compute_fold_polynomials(
         sumcheck_output.challenge_point, std::move(batched_poly_unshifted), std::move(batched_poly_to_be_shifted));
 
     // Compute and add to trasnscript the commitments [Fold^(i)], i = 1, ..., d-1
     for (size_t l = 0; l < key->log_circuit_size - 1; ++l) {
-        std::string label = "Gemini:FOLD_" + std::to_string(l + 1);
-        auto commitment = commitment_key->commit(fold_polynomials[l + 2]);
-        transcript.send_to_verifier(label, commitment);
+        queue.add_to_queue({ .work_type = WorkType::SCALAR_MULTIPLICATION,
+                             .mul_scalars = fold_polynomials[l + 2],
+                             .label = "Gemini:FOLD_" + std::to_string(l + 1) });
     }
 }
 
@@ -282,34 +268,30 @@ template <typename settings> plonk::proof& Prover<settings>::construct_proof()
 {
     // Add circuit size and public input size to transcript.
     execute_preamble_round();
-    // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
 
     // Compute wire commitments; Add PI to transcript
     execute_wire_commitments_round();
-    // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
+    queue.process_queue();
 
     // Currently a no-op; may execute some "random widgets", commit to W_4, do RAM/ROM stuff
     // if this prover structure is kept when we bring tables to Honk.
     // Suggestion: Maybe we shouldn't mix and match proof creation for different systems and
     // instead instatiate construct_proof differently for each?
     execute_tables_round();
-    // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
 
     // Fiat-Shamir: beta & gamma
     // Compute grand product(s) and commitments.
     execute_grand_product_computation_round();
-    // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
+    queue.process_queue();
 
     // Fiat-Shamir: alpha
     // Run sumcheck subprotocol.
     execute_relation_check_rounds();
-    // // queue currently only handles commitments, not partial multivariate evaluations.
-    // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
 
     // Fiat-Shamir: rho
     // Compute Fold polynomials and their commitments.
     execute_univariatization_round();
-    // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
+    queue.process_queue();
 
     // Fiat-Shamir: r
     // Compute Fold evaluations
@@ -324,9 +306,6 @@ template <typename settings> plonk::proof& Prover<settings>::construct_proof()
     // Fiat-Shamir: z
     // Compute KZG quotient commitment
     execute_kzg_round();
-    // queue.process_queue(); // NOTE: Don't remove; we may reinstate the queue
-
-    // queue.flush_queue(); // NOTE: Don't remove; we may reinstate the queue
 
     return export_proof();
 }

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -65,13 +65,16 @@ template <typename settings> class Prover {
 
     std::shared_ptr<plonk::proving_key> key;
 
-    std::shared_ptr<pcs::kzg::CommitmentKey> commitment_key;
-
     // Container for spans of all polynomials required by the prover (i.e. all multivariates evaluated by Sumcheck).
     std::array<std::span<Fr>, honk::StandardArithmetization::POLYNOMIAL::COUNT> prover_polynomials;
 
     // Container for d + 1 Fold polynomials produced by Gemini
     std::vector<Polynomial> fold_polynomials;
+
+    Polynomial batched_quotient_Q; // batched quotient poly computed by Shplonk
+    Fr nu_challenge;               // needed in both Shplonk rounds
+
+    Polynomial quotient_W;
 
     work_queue<pcs::kzg::Params> queue;
 

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include "barretenberg/honk/pcs/claim.hpp"
 #include "barretenberg/honk/proof_system/prover_library.hpp"
+#include "barretenberg/honk/proof_system/work_queue.hpp"
 
 namespace proof_system::honk {
 
@@ -72,21 +73,7 @@ template <typename settings> class Prover {
     // Container for d + 1 Fold polynomials produced by Gemini
     std::vector<Polynomial> fold_polynomials;
 
-    Polynomial batched_quotient_Q;
-    Fr nu_challenge;
-
-    // Honk only needs a small portion of the functionality but may be fine to use existing work_queue
-    // NOTE: this is not currently in use, but it may well be used in the future.
-    // TODO(Adrian): Uncomment when we need this again.
-    // proof_system::work_queue queue;
-    // void flush_queued_work_items() { queue.flush_queue(); }
-    // proof_system::work_queue::work_item_info get_queued_work_item_info() const {
-    //     return queue.get_queued_work_item_info();
-    // }
-    // size_t get_scalar_multiplication_size(const size_t work_item_number) const
-    // {
-    //     return queue.get_scalar_multiplication_size(work_item_number);
-    // }
+    work_queue<pcs::kzg::Params> queue;
 
     // This makes 'settings' accesible from Prover
     using settings_ = settings;

--- a/cpp/src/barretenberg/honk/proof_system/verifier.test.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.test.cpp
@@ -198,8 +198,6 @@ template <class FF> class VerifierTests : public testing::Test {
         std::unique_ptr<pcs::kzg::CommitmentKey> kate_commitment_key =
             std::make_unique<pcs::kzg::CommitmentKey>(proving_key->circuit_size, "../srs_db/ignition");
 
-        prover.commitment_key = std::move(kate_commitment_key);
-
         return prover;
     }
 };

--- a/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "barretenberg/honk/transcript/transcript.hpp"
+#include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
+#include <cstddef>
+#include <memory>
+
+namespace proof_system::honk {
+
+// Currently only one type of work queue operation but there will likely be others related to Sumcheck
+enum WorkType { SCALAR_MULTIPLICATION };
+
+template <typename Params> class work_queue {
+
+    using CommitmentKey = typename Params::CK;
+    using FF = typename Params::Fr;
+    using Commitment = typename Params::C;
+
+  public:
+    struct work_item_info {
+        uint32_t num_scalar_multiplications;
+    };
+
+    struct work_item {
+        WorkType work_type = SCALAR_MULTIPLICATION;
+        std::span<FF> mul_scalars;
+        std::string label;
+    };
+
+    explicit work_queue(std::shared_ptr<proof_system::plonk::proving_key>& proving_key,
+                        proof_system::honk::ProverTranscript<FF>& prover_transcript,
+                        std::shared_ptr<CommitmentKey>& commitment_key)
+        : key(proving_key)
+        , transcript(prover_transcript)
+        , commitment_key(commitment_key){};
+
+    work_queue(const work_queue& other) = default;
+    work_queue(work_queue&& other) noexcept = default;
+    work_queue& operator=(const work_queue& other) = delete;
+    work_queue& operator=(work_queue&& other) = delete;
+    ~work_queue() = default;
+
+    [[nodiscard]] work_item_info get_queued_work_item_info() const
+    {
+        uint32_t scalar_mul_count = 0;
+        for (const auto& item : work_item_queue) {
+            if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
+                ++scalar_mul_count;
+            }
+        }
+        return work_item_info{ scalar_mul_count };
+    };
+
+    [[nodiscard]] FF* get_scalar_multiplication_data(size_t work_item_number) const
+    {
+        size_t count = 0;
+        for (const auto& item : work_item_queue) {
+            if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
+                if (count == work_item_number) {
+                    return const_cast<FF*>(item.mul_scalars.data());
+                }
+                ++count;
+            }
+        }
+        return nullptr;
+    };
+
+    [[nodiscard]] size_t get_scalar_multiplication_size(size_t work_item_number) const
+    {
+        size_t count = 0;
+        for (const auto& item : work_item_queue) {
+            if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
+                if (count == work_item_number) {
+                    return item.mul_scalars.size();
+                }
+                ++count;
+            }
+        }
+        return 0;
+    };
+
+    void put_scalar_multiplication_data(const Commitment& result, size_t work_item_number)
+    {
+        size_t count = 0;
+        for (const auto& item : work_item_queue) {
+            if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
+                if (count == work_item_number) {
+                    transcript.send_to_verifier(item.label, result);
+                    return;
+                }
+                ++count;
+            }
+        }
+    };
+
+    void flush_queue() { work_item_queue = std::vector<work_item>(); };
+
+    void add_to_queue(const work_item& item)
+    {
+        // Note: currently no difference between wasm and native but may be in the future
+#if defined(__wasm__)
+        work_item_queue.push_back(item);
+#else
+        work_item_queue.push_back(item);
+#endif
+    };
+
+    void process_queue()
+    {
+        for (const auto& item : work_item_queue) {
+            switch (item.work_type) {
+
+            case WorkType::SCALAR_MULTIPLICATION: {
+
+                // Run pippenger multi-scalar multiplication.
+                auto commitment = commitment_key->commit(item.mul_scalars);
+
+                transcript.send_to_verifier(item.label, commitment);
+
+                break;
+            }
+            default: {
+            }
+            }
+        }
+        work_item_queue = std::vector<work_item>();
+    };
+
+    [[nodiscard]] std::vector<work_item> get_queue() const { return work_item_queue; };
+
+  private:
+    std::shared_ptr<proof_system::plonk::proving_key> key;
+    // TODO(luke): Consider handling all transcript interactions in the prover rather than embedding them in the queue.
+    proof_system::honk::ProverTranscript<FF>& transcript;
+    std::shared_ptr<CommitmentKey>& commitment_key;
+    std::vector<work_item> work_item_queue;
+};
+} // namespace proof_system::honk

--- a/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
@@ -10,6 +10,9 @@ namespace proof_system::honk {
 // Currently only one type of work queue operation but there will likely be others related to Sumcheck
 enum WorkType { SCALAR_MULTIPLICATION };
 
+// TODO(luke): This Params template parameter is the same type expected by e.g. components of the PCS. Eventually it
+// should be replaced by some sort of Flavor concept that contains info about the Field etc. This should be resolved
+// at the same time as the similar patterns in Gemini etc.
 template <typename Params> class work_queue {
 
     using CommitmentKey = typename Params::CK;
@@ -27,7 +30,7 @@ template <typename Params> class work_queue {
     };
 
   private:
-    std::shared_ptr<proof_system::plonk::proving_key> key;
+    std::shared_ptr<proof_system::plonk::proving_key> proving_key;
     // TODO(luke): Consider handling all transcript interactions in the prover rather than embedding them in the queue.
     proof_system::honk::ProverTranscript<FF>& transcript;
     CommitmentKey commitment_key;
@@ -36,9 +39,10 @@ template <typename Params> class work_queue {
   public:
     explicit work_queue(std::shared_ptr<proof_system::plonk::proving_key>& proving_key,
                         proof_system::honk::ProverTranscript<FF>& prover_transcript)
-        : key(proving_key)
+        : proving_key(proving_key)
         , transcript(prover_transcript)
-        , commitment_key(key->circuit_size, "../srs_db/ignition"){}; // TODO(luke): make this properly parameterized
+        , commitment_key(proving_key->circuit_size,
+                         "../srs_db/ignition"){}; // TODO(luke): make this properly parameterized
 
     work_queue(const work_queue& other) = default;
     work_queue(work_queue&& other) noexcept = default;

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
@@ -41,7 +41,7 @@ TEST(commitment_scheme, kate_open)
     auto circuit_proving_key = std::make_shared<proving_key>(n, 0, crs, ComposerType::STANDARD);
     work_queue queue(circuit_proving_key.get(), &inp_tx);
 
-    newKate.commit(&coeffs[0], "F_COMM", 0, queue);
+    newKate.commit(&coeffs[0], "F_COMM", n, queue);
     queue.process_queue();
 
     fr y = fr::random_element();
@@ -49,7 +49,7 @@ TEST(commitment_scheme, kate_open)
     fr f = polynomial_arithmetic::evaluate(&coeffs[0], z, n);
 
     newKate.compute_opening_polynomial(&coeffs[0], &W[0], z, n);
-    newKate.commit(&W[0], "W_COMM", fr(0), queue);
+    newKate.commit(&W[0], "W_COMM", n, queue);
     queue.process_queue();
 
     // check if W(y)(y - z) = F(y) - F(z)
@@ -103,7 +103,7 @@ TEST(commitment_scheme, kate_batch_open)
         for (size_t j = 0; j < m; ++j) {
             newKate.commit(&coeffs[k * m * n + j * n],
                            "F_{" + std::to_string(k + 1) + ", " + std::to_string(j + 1) + "}",
-                           0,
+                           n,
                            queue);
         }
     }
@@ -116,7 +116,7 @@ TEST(commitment_scheme, kate_batch_open)
     for (size_t k = 0; k < t; ++k) {
         challenges[k] = fr::random_element();
         tags[k] = "W_" + std::to_string(k + 1);
-        item_constants[k] = fr(0);
+        item_constants[k] = n;
     }
 
     // compute opening polynomials W_1, W_2, ..., W_t

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
@@ -224,9 +224,11 @@ void KateCommitmentScheme<settings>::batch_open(const transcript::StandardTransc
 
     // Commit to the opening and shifted opening polynomials
     KateCommitmentScheme::commit(
-        input_key->polynomial_store.get("opening_poly").get_coefficients(), "PI_Z", fr(0), queue);
-    KateCommitmentScheme::commit(
-        input_key->polynomial_store.get("shifted_opening_poly").get_coefficients(), "PI_Z_OMEGA", fr(0), queue);
+        input_key->polynomial_store.get("opening_poly").get_coefficients(), "PI_Z", input_key->circuit_size, queue);
+    KateCommitmentScheme::commit(input_key->polynomial_store.get("shifted_opening_poly").get_coefficients(),
+                                 "PI_Z_OMEGA",
+                                 input_key->circuit_size,
+                                 queue);
 }
 
 template <typename settings>

--- a/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
@@ -79,7 +79,7 @@ template <typename settings> void ProverBase<settings>::compute_wire_commitments
         barretenberg::fr* coefficients = key->polynomial_store.get(wire_tag).get_coefficients();
 
         // This automatically saves the computed point to the transcript
-        fr domain_size_flag = i > 2 ? work_queue::MSMType::MONOMIAL_N : work_queue::MSMType::MONOMIAL_N_PLUS_ONE;
+        fr domain_size_flag = i > 2 ? key->circuit_size : (key->circuit_size + 1);
         commitment_scheme->commit(coefficients, commit_tag, domain_size_flag, queue);
     }
 
@@ -137,7 +137,7 @@ template <typename settings> void ProverBase<settings>::compute_quotient_commitm
         std::string quotient_tag = "T_" + std::to_string(i + 1);
         // Set flag that determines domain size (currently n or n+1) in pippenger (see process_queue()).
         // Note: After blinding, all t_i have size n+1 representation (degree n) except t_4 in Turbo/Ultra.
-        fr domain_size_flag = i > 2 ? work_queue::MSMType::MONOMIAL_N : work_queue::MSMType::MONOMIAL_N_PLUS_ONE;
+        fr domain_size_flag = i > 2 ? key->circuit_size : (key->circuit_size + 1);
         commitment_scheme->commit(coefficients, quotient_tag, domain_size_flag, queue);
     }
 }
@@ -311,7 +311,7 @@ template <typename settings> void ProverBase<settings>::execute_second_round()
             .work_type = work_queue::WorkType::SCALAR_MULTIPLICATION,
             .mul_scalars = key->polynomial_store.get(wire_tag).get_coefficients(),
             .tag = "W_4",
-            .constant = work_queue::MSMType::MONOMIAL_N_PLUS_ONE,
+            .constant = key->circuit_size + 1,
             .index = 0,
         });
     }

--- a/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
@@ -326,7 +326,7 @@ void ProverPermutationWidget<program_width, idpolys, num_roots_cut_out_of_vanish
         work_queue::WorkType::SCALAR_MULTIPLICATION,
         z_perm.get_coefficients(),
         "Z_PERM",
-        barretenberg::fr(0),
+        key->circuit_size,
         0,
     });
 

--- a/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
@@ -358,7 +358,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_rou
             .work_type = work_queue::WorkType::SCALAR_MULTIPLICATION,
             .mul_scalars = s.get_coefficients(),
             .tag = "S",
-            .constant = barretenberg::fr(0),
+            .constant = key->circuit_size,
             .index = 0,
         });
 
@@ -382,7 +382,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_rou
             .work_type = work_queue::WorkType::SCALAR_MULTIPLICATION,
             .mul_scalars = z.get_coefficients(),
             .tag = "Z_LOOKUP",
-            .constant = barretenberg::fr(0),
+            .constant = key->circuit_size,
             .index = 0,
         });
 

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
@@ -3,9 +3,9 @@
 #include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
 
-namespace proof_system {
+namespace proof_system::plonk {
 
-work_queue::work_queue(plonk::proving_key* prover_key, transcript::StandardTranscript* prover_transcript)
+work_queue::work_queue(proving_key* prover_key, transcript::StandardTranscript* prover_transcript)
     : key(prover_key)
     , transcript(prover_transcript)
     , work_item_queue()
@@ -278,4 +278,4 @@ std::vector<work_queue::work_item> work_queue::get_queue() const
     return work_item_queue;
 }
 
-} // namespace proof_system
+} // namespace proof_system::plonk

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.cpp
@@ -50,7 +50,7 @@ size_t work_queue::get_scalar_multiplication_size(const size_t work_item_number)
     for (const auto& item : work_item_queue) {
         if (item.work_type == WorkType::SCALAR_MULTIPLICATION) {
             if (count == work_item_number) {
-                return (item.constant == MSMType::MONOMIAL_N_PLUS_ONE) ? key->circuit_size + 1 : key->circuit_size;
+                return static_cast<size_t>(static_cast<uint256_t>(item.constant));
             }
             ++count;
         }
@@ -198,39 +198,12 @@ void work_queue::process_queue()
         switch (item.work_type) {
         // most expensive op
         case WorkType::SCALAR_MULTIPLICATION: {
-            // We use the variable work_item::constant to set the size of the multi-scalar multiplication.
-            // Note that a size (n+1) MSM is always needed to commit to the quotient polynomial parts t_1, t_2
-            // and t_3 for Standard/Turbo/Ultra due to the addition of blinding factors
-            size_t msm_size = 0;
-            barretenberg::g1::affine_element* srs_points;
-            switch (static_cast<size_t>(uint256_t(item.constant))) {
-            case MSMType::MONOMIAL_N: {
-                if (key->reference_string->get_monomial_size() < key->small_domain.size) {
-                    info("MSM: Monomial reference string size: ",
-                         key->reference_string->get_monomial_size(),
-                         ", required size: ",
-                         key->small_domain.size);
-                }
-                msm_size = key->small_domain.size;
-                srs_points = key->reference_string->get_monomial_points();
-                break;
-            }
-            case MSMType::MONOMIAL_N_PLUS_ONE: {
-                if (key->reference_string->get_monomial_size() < key->small_domain.size + 1) {
-                    info("MSM: Monomial reference string size: ",
-                         key->reference_string->get_monomial_size(),
-                         ", required size: ",
-                         key->small_domain.size + 1);
-                }
-                msm_size = key->small_domain.size + 1;
-                srs_points = key->reference_string->get_monomial_points();
-                break;
-            }
-            default: {
-                info("Incorrect item constant value: ", static_cast<size_t>(uint256_t(item.constant)));
-                srs_points = key->reference_string->get_monomial_points();
-            }
-            }
+            // Note: work_item.constant is an Fr type (see SMALL_FFT), but here it is interpreted simply as a size_t
+            auto msm_size = static_cast<size_t>(static_cast<uint256_t>(item.constant));
+
+            ASSERT(msm_size <= key->reference_string->get_monomial_size());
+
+            barretenberg::g1::affine_element* srs_points = key->reference_string->get_monomial_points();
 
             // Run pippenger multi-scalar multiplication.
             auto runtime_state = barretenberg::scalar_multiplication::pippenger_runtime_state(msm_size);

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.hpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.hpp
@@ -3,7 +3,7 @@
 #include "../../transcript/transcript_wrappers.hpp"
 #include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
 
-namespace proof_system {
+namespace proof_system::plonk {
 // TODO(Cody): Template by flavor?
 class work_queue {
 
@@ -29,7 +29,7 @@ class work_queue {
         barretenberg::fr shift_factor;
     };
 
-    work_queue(plonk::proving_key* prover_key = nullptr, transcript::StandardTranscript* prover_transcript = nullptr);
+    work_queue(proving_key* prover_key = nullptr, transcript::StandardTranscript* prover_transcript = nullptr);
 
     work_queue(const work_queue& other) = default;
     work_queue(work_queue&& other) = default;
@@ -61,8 +61,8 @@ class work_queue {
     std::vector<work_item> get_queue() const;
 
   private:
-    plonk::proving_key* key;
+    proving_key* key;
     transcript::StandardTranscript* transcript;
     std::vector<work_item> work_item_queue;
 };
-} // namespace proof_system
+} // namespace proof_system::plonk

--- a/cpp/src/barretenberg/proof_system/work_queue/work_queue.hpp
+++ b/cpp/src/barretenberg/proof_system/work_queue/work_queue.hpp
@@ -9,7 +9,6 @@ class work_queue {
 
   public:
     enum WorkType { FFT, SMALL_FFT, IFFT, SCALAR_MULTIPLICATION };
-    enum MSMType { MONOMIAL_N, MONOMIAL_N_PLUS_ONE };
 
     struct work_item_info {
         uint32_t num_scalar_multiplications;


### PR DESCRIPTION
# Description

Add a simplified `work_queue` for Honk. Use it to compute commitments throughout StandardHonk prover.

The new work queue for Honk is largely a copy-paste then simplify. The only real changes are
- work queue now owns a commitment key instead of calling pedersen directly. (This is instead of the Prover owning the proving key which now no longer makes sense since it is not responsible for commitments).
- simplified interface for adding things to the work queue, i.e. `add_commitment` instead of `add_to_queue(Lots of ugly details)`
- Remove some objects from `WorkItem` like the vague and no longer needed `index` and `constant` which were needed only for FFT operations

This PR also includes a simple change to the original `work_queue` that allows the MSM size to be set directly and flexibly rather than based on an enum. I made this change when I was still planning on using the original work queue for Honk (to accommodate Fold poly commitments). It's no longer necessary but seems like a nice simplifying change so I've left it in.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
