### PR TITLE
Improve stdlib_primitives testing

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
@@ -1,66 +1,87 @@
 #include "byte_array.hpp"
 #include <gtest/gtest.h>
+#include "../../types/types.hpp"
+#include "barretenberg/plonk/composer/standard_composer.hpp"
 #include "barretenberg/honk/composer/standard_honk_composer.hpp"
-#include "barretenberg/plonk/composer/turbo_composer.hpp"
-#include "barretenberg/plonk/composer/ultra_composer.hpp"
+#include "barretenberg/stdlib/primitives/bool/bool.hpp"
+#include "barretenberg/stdlib/primitives/field/field.hpp"
+#include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
-// ULTRATODO: make these typed tests
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+
 namespace test_stdlib_byte_array {
 using namespace barretenberg;
-using namespace proof_system::plonk;
-typedef honk::StandardHonkComposer Composer;
-typedef stdlib::bool_t<Composer> bool_t;
-typedef stdlib::field_t<Composer> field_t;
-typedef stdlib::witness_t<Composer> witness_t;
-typedef stdlib::byte_array<Composer> byte_array;
+using namespace plonk;
 
-TEST(stdlib_byte_array, test_reverse)
+#define STDLIB_TYPE_ALIASES                                                                                            \
+    using Composer = TypeParam;                                                                                        \
+    using witness_ct = stdlib::witness_t<Composer>;                                                                    \
+    using byte_array_ct = stdlib::byte_array<Composer>;                                                                \
+    using field_ct = stdlib::field_t<Composer>;                                                                        \
+    using bool_ct = stdlib::bool_t<Composer>;
+
+template <class Composer> class ByteArrayTest : public ::testing::Test {};
+
+template <class Composer> using byte_array_ct = stdlib::byte_array<Composer>;
+
+using ComposerTypes =
+    ::testing::Types<honk::StandardHonkComposer, plonk::StandardComposer, plonk::TurboComposer, plonk::UltraComposer>;
+TYPED_TEST_SUITE(ByteArrayTest, ComposerTypes);
+
+TYPED_TEST(ByteArrayTest, test_reverse)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     std::vector<uint8_t> expected = { 0x04, 0x03, 0x02, 0x01 };
-    byte_array arr(&composer, std::vector<uint8_t>{ 0x01, 0x02, 0x03, 0x04 });
+    byte_array_ct arr(&composer, std::vector<uint8_t>{ 0x01, 0x02, 0x03, 0x04 });
 
     EXPECT_EQ(arr.size(), 4UL);
     EXPECT_EQ(arr.reverse().get_value(), expected);
 }
 
-TEST(stdlib_byte_array, test_string_constructor)
+TYPED_TEST(ByteArrayTest, test_string_constructor)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     std::string a = "ascii";
-    byte_array arr(&composer, a);
+    byte_array_ct arr(&composer, a);
     EXPECT_EQ(arr.get_string(), a);
 }
 
-TEST(stdlib_byte_array, test_ostream_operator)
+TYPED_TEST(ByteArrayTest, test_ostream_operator)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     std::string a = "\1\2\3a";
-    byte_array arr(&composer, a);
+    byte_array_ct arr(&composer, a);
     std::ostringstream os;
     os << arr;
     EXPECT_EQ(os.str(), "[ 01 02 03 61 ]");
 }
 
-TEST(stdlib_byte_array, test_byte_array_input_output_consistency)
+TYPED_TEST(ByteArrayTest, test_byte_array_input_output_consistency)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
     fr a_expected = fr::random_element();
     fr b_expected = fr::random_element();
 
-    field_t a = witness_t(&composer, a_expected);
-    field_t b = witness_t(&composer, b_expected);
+    field_ct a = witness_ct(&composer, a_expected);
+    field_ct b = witness_ct(&composer, b_expected);
 
-    byte_array arr(&composer);
+    byte_array_ct arr(&composer);
 
-    arr.write(static_cast<byte_array>(a));
-    arr.write(static_cast<byte_array>(b));
+    arr.write(static_cast<byte_array_ct>(a));
+    arr.write(static_cast<byte_array_ct>(b));
 
     EXPECT_EQ(arr.size(), 64UL);
 
-    field_t a_result(arr.slice(0, 32));
-    field_t b_result(arr.slice(32));
+    field_ct a_result(arr.slice(0, 32));
+    field_ct b_result(arr.slice(32));
 
     EXPECT_EQ(a_result.get_value(), a_expected);
     EXPECT_EQ(b_result.get_value(), b_expected);
@@ -72,10 +93,12 @@ TEST(stdlib_byte_array, test_byte_array_input_output_consistency)
     EXPECT_EQ(verified, true);
 }
 
-TEST(stdlib_byte_array, get_bit)
+TYPED_TEST(ByteArrayTest, get_bit)
 {
-    Composer composer = Composer();
-    byte_array arr(&composer, std::vector<uint8_t>{ 0x01, 0x02, 0x03, 0x04 });
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
+    byte_array_ct arr(&composer, std::vector<uint8_t>{ 0x01, 0x02, 0x03, 0x04 });
 
     EXPECT_EQ(arr.get_bit(0).get_value(), false);
     EXPECT_EQ(arr.get_bit(1).get_value(), false);
@@ -104,15 +127,17 @@ TEST(stdlib_byte_array, get_bit)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_byte_array, set_bit)
+TYPED_TEST(ByteArrayTest, set_bit)
 {
-    Composer composer = Composer();
-    byte_array arr(&composer, std::vector<uint8_t>{ 0x01, 0x02, 0x03, 0x04 });
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
-    arr.set_bit(16, bool_t(witness_t(&composer, true)));
-    arr.set_bit(18, bool_t(witness_t(&composer, true)));
-    arr.set_bit(24, bool_t(witness_t(&composer, false)));
-    arr.set_bit(0, bool_t(witness_t(&composer, true)));
+    byte_array_ct arr(&composer, std::vector<uint8_t>{ 0x01, 0x02, 0x03, 0x04 });
+
+    arr.set_bit(16, bool_ct(witness_ct(&composer, true)));
+    arr.set_bit(18, bool_ct(witness_ct(&composer, true)));
+    arr.set_bit(24, bool_ct(witness_ct(&composer, false)));
+    arr.set_bit(0, bool_ct(witness_ct(&composer, true)));
 
     const auto out = arr.get_value();
     EXPECT_EQ(out[0], uint8_t(0));

--- a/cpp/src/barretenberg/stdlib/primitives/group/group.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/group/group.test.cpp
@@ -1,31 +1,39 @@
 #include "../../types/types.hpp"
+#include <gtest/gtest.h>
 #include "barretenberg/honk/composer/standard_honk_composer.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
-#include "barretenberg/common/test.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
+#define STDLIB_TYPE_ALIASES                                                                                            \
+    using Composer = TypeParam;                                                                                        \
+    using witness_ct = stdlib::witness_t<Composer>;                                                                    \
+    using field_ct = stdlib::field_t<Composer>;                                                                        \
+    using group_ct = stdlib::group<Composer>;
 
-using namespace barretenberg;
-// using namespace proof_system::plonk::stdlib::types;
 namespace stdlib_group_tests {
+using namespace barretenberg;
+using namespace plonk;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-using Composer = proof_system::honk::StandardHonkComposer;
-using witness_ct = proof_system::plonk::stdlib::witness_t<Composer>;
-using field_ct = proof_system::plonk::stdlib::field_t<Composer>;
-using group_ct = proof_system::plonk::stdlib::group<Composer>;
+template <class Composer> class GroupTest : public ::testing::Test {};
 
-TEST(stdlib_group, test_fixed_base_scalar_mul)
+using ComposerTypes =
+    ::testing::Types<honk::StandardHonkComposer, plonk::StandardComposer, plonk::TurboComposer, plonk::UltraComposer>;
+TYPED_TEST_SUITE(GroupTest, ComposerTypes);
+
+TYPED_TEST(GroupTest, TestFixedBaseScalarMul)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     auto scalar = uint256_t(123, 0, 0, 0);
     auto priv_key = grumpkin::fr(scalar);
     auto pub_key = crypto::generators::get_generator_data(crypto::generators::DEFAULT_GEN_1).generator * priv_key;
 
-    Composer composer;
     auto priv_key_witness = field_ct(witness_ct(&composer, fr(scalar)));
 
-    auto result = group_ct::fixed_base_scalar_mul<128>(priv_key_witness, 0);
+    auto result = group_ct::template fixed_base_scalar_mul<128>(priv_key_witness, 0);
 
     EXPECT_EQ(result.x.get_value(), pub_key.x);
     EXPECT_EQ(result.y.get_value(), pub_key.y);
@@ -45,13 +53,15 @@ TEST(stdlib_group, test_fixed_base_scalar_mul)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_group, test_fixed_base_scalar_mul_zero_fails)
+TYPED_TEST(GroupTest, TestFixedBaseScalarMulZeroFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     auto scalar = uint256_t(0, 0, 0, 0);
 
-    Composer composer;
     auto priv_key_witness = field_ct(witness_ct(&composer, fr(scalar)));
-    group_ct::fixed_base_scalar_mul<128>(priv_key_witness, 0);
+    group_ct::template fixed_base_scalar_mul<128>(priv_key_witness, 0);
 
     auto prover = composer.create_prover();
 
@@ -65,8 +75,11 @@ TEST(stdlib_group, test_fixed_base_scalar_mul_zero_fails)
     EXPECT_EQ(composer.err(), "input scalar to fixed_base_scalar_mul_internal cannot be 0");
 }
 
-TEST(stdlib_group, test_fixed_base_scalar_mul_with_two_limbs)
+TYPED_TEST(GroupTest, TestFixedBaseScalarMulWithTwoLimbs)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     const uint256_t scalar = engine.get_random_uint256();
 
     auto priv_key_low = (scalar.slice(0, 128));
@@ -74,7 +87,6 @@ TEST(stdlib_group, test_fixed_base_scalar_mul_with_two_limbs)
     auto priv_key = grumpkin::fr(scalar);
     auto pub_key = grumpkin::g1::one * priv_key;
     pub_key = pub_key.normalize();
-    Composer composer;
     auto priv_key_low_witness = field_ct(witness_ct(&composer, fr(priv_key_low)));
     auto priv_key_high_witness = field_ct(witness_ct(&composer, fr(priv_key_high)));
 

--- a/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.test.cpp
@@ -1,62 +1,65 @@
 
 #include <cstddef>
 #include <gtest/gtest.h>
+#include "barretenberg/stdlib/primitives/bool/bool.hpp"
+#include "barretenberg/stdlib/primitives/witness/witness.hpp"
 #include "safe_uint.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "../byte_array/byte_array.hpp"
 #include "barretenberg/honk/composer/standard_honk_composer.hpp"
 #include "barretenberg/stdlib/types/types.hpp"
 
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+
+#define STDLIB_TYPE_ALIASES                                                                                            \
+    using Composer = TypeParam;                                                                                        \
+    using witness_ct = stdlib::witness_t<Composer>;                                                                    \
+    using field_ct = stdlib::field_t<Composer>;                                                                        \
+    using bool_ct = stdlib::bool_t<Composer>;                                                                          \
+    using suint_ct = stdlib::safe_uint_t<Composer>;                                                                    \
+    using byte_array_ct = stdlib::byte_array<Composer>;                                                                \
+    using public_witness_ct = stdlib::public_witness_t<Composer>;
+
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-using namespace proof_system::plonk::stdlib::types;
-
 namespace test_stdlib_safe_uint {
+using namespace barretenberg;
+using namespace plonk;
 template <class T> void ignore_unused(T&) {} // use to ignore unused variables in lambdas
 
-using Composer = proof_system::honk::StandardHonkComposer;
-typedef proof_system::plonk::stdlib::bool_t<Composer> bool_t;
-typedef proof_system::plonk::stdlib::field_t<Composer> field_t;
-typedef proof_system::plonk::stdlib::safe_uint_t<Composer> suint_t;
-typedef proof_system::plonk::stdlib::witness_t<Composer> witness_t;
-typedef proof_system::plonk::stdlib::public_witness_t<Composer> public_witness_t;
-typedef proof_system::plonk::stdlib::byte_array<Composer> byte_array_t;
+template <class Composer> class SafeUintTest : public ::testing::Test {};
 
-struct verify_logic_result {
-    bool valid;
-    std::string err;
-};
-
-verify_logic_result verify_logic(Composer& composer)
-{
-    if (composer.failed()) {
-        info("Circuit logic failed: " + composer.err());
-    }
-    return { !composer.failed(), composer.err() };
-}
+using ComposerTypes =
+    ::testing::Types<honk::StandardHonkComposer, plonk::StandardComposer, plonk::TurboComposer, plonk::UltraComposer>;
+TYPED_TEST_SUITE(SafeUintTest, ComposerTypes);
 
 // CONSTRUCTOR
 
-TEST(stdlib_safeuint, test_constructor_with_value_out_of_range_fails)
+TYPED_TEST(SafeUintTest, TestConstructorWithValueOutOfRangeFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     // check incorrect range init causes failure
 
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 100));
-    suint_t b(a, 2, "b");
+    field_ct a(witness_ct(&composer, 100));
+    suint_ct b(a, 2, "b");
 
-    auto result = verify_logic(composer);
-    EXPECT_FALSE(result.valid);
-    EXPECT_EQ(result.err, "safe_uint_t range constraint failure: b");
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    plonk::proof proof = prover.construct_proof();
+    EXPECT_FALSE(verifier.verify_proof(proof));
 }
 
-TEST(stdlib_safeuint, test_constructor_with_value_in_range)
+TYPED_TEST(SafeUintTest, TestConstructorWithValueInRange)
 {
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 100));
-    suint_t b(a, 7);
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
+    field_ct a(witness_ct(&composer, 100));
+    suint_ct b(a, 7);
 
     auto prover = composer.create_prover();
     auto verifier = composer.create_verifier();
@@ -67,16 +70,18 @@ TEST(stdlib_safeuint, test_constructor_with_value_in_range)
 // * OPERATOR
 
 #if !defined(__wasm__)
-TEST(stdlib_safeuint, test_multiply_operation_out_of_range_fails)
+TYPED_TEST(SafeUintTest, TestMultiplyOperationOutOfRangeFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     // Since max is initally set to (1 << 2) - 1 = 3 (as bit range checks are easier than generic integer bounds),
     // should allow largest power of 3 smaller than r iterations, which is 159. Hence below we should exceed r, and
     // expect a throw
     try {
-        Composer composer = Composer();
-        field_t a(witness_t(&composer, 2));
-        suint_t c(a, 2);
-        suint_t d(a, 2);
+
+        field_ct a(witness_ct(&composer, 2));
+        suint_ct c(a, 2);
+        suint_ct d(a, 2);
         for (auto i = 0; i < 160; i++) {
             c = c * d;
         }
@@ -88,14 +93,16 @@ TEST(stdlib_safeuint, test_multiply_operation_out_of_range_fails)
     }
 }
 
-TEST(stdlib_safeuint, test_multiply_operation_on_constants_out_of_range_fails)
+TYPED_TEST(SafeUintTest, TestMultiplyOperationOnConstantsOutOfRangeFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     //  Now we check that when using constants the maximum grows more slowly - since they are bounded by themselves
     //  rather than the next 2^n-1
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 2));
-    suint_t c(a, 2);
-    suint_t d(fr(2));
+
+    field_ct a(witness_ct(&composer, 2));
+    suint_ct c(a, 2);
+    suint_ct d(fr(2));
 
     for (auto i = 0; i < 252; i++) {
         c = c * d;
@@ -103,10 +110,10 @@ TEST(stdlib_safeuint, test_multiply_operation_on_constants_out_of_range_fails)
     // Below we should exceed r, and expect a throw
 
     try {
-        Composer composer = Composer();
-        field_t a(witness_t(&composer, 2));
-        suint_t c(a, 2);
-        suint_t d(fr(2));
+
+        field_ct a(witness_ct(&composer, 2));
+        suint_ct c(a, 2);
+        suint_ct d(fr(2));
         for (auto i = 0; i < 253; i++) {
             c = c * d;
         }
@@ -119,14 +126,16 @@ TEST(stdlib_safeuint, test_multiply_operation_on_constants_out_of_range_fails)
 }
 // + OPERATOR
 
-TEST(stdlib_safeuint, test_add_operation_out_of_range_fails)
+TYPED_TEST(SafeUintTest, TestAddOperationOutOfRangeFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     // Here we test the addition operator also causes a throw when exceeding r
     try {
-        Composer composer = Composer();
-        field_t a(witness_t(&composer, 2));
-        suint_t c(a, 2);
-        suint_t d(a, 2);
+
+        field_ct a(witness_ct(&composer, 2));
+        suint_ct c(a, 2);
+        suint_ct d(a, 2);
         for (auto i = 0; i < 159; i++) {
             c = c * d;
         }
@@ -141,14 +150,15 @@ TEST(stdlib_safeuint, test_add_operation_out_of_range_fails)
 #endif
 // SUBTRACT METHOD
 
-TEST(stdlib_safeuint, test_subtract_method)
+TYPED_TEST(SafeUintTest, TestSubtractMethod)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 2));
-    field_t b(witness_t(&composer, 9));
-    suint_t c(a, 2);
-    suint_t d(b, 4);
+    field_ct a(witness_ct(&composer, 2));
+    field_ct b(witness_ct(&composer, 9));
+    suint_ct c(a, 2);
+    suint_ct d(b, 4);
     c = d.subtract(c, 3);
 
     auto prover = composer.create_prover();
@@ -157,32 +167,36 @@ TEST(stdlib_safeuint, test_subtract_method)
     EXPECT_TRUE(verifier.verify_proof(proof));
 }
 
-TEST(stdlib_safeuint, test_subtract_method_minued_gt_lhs_fails)
+TYPED_TEST(SafeUintTest, TestSubtractMethodMinuedGtLhsFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     // test failure when range for difference too small
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 2));
-    field_t b(witness_t(&composer, 9));
-    suint_t c(a, 2, "c");
-    suint_t d(b, 4, "d");
+
+    field_ct a(witness_ct(&composer, 2));
+    field_ct b(witness_ct(&composer, 9));
+    suint_ct c(a, 2, "c");
+    suint_ct d(b, 4, "d");
     c = d.subtract(c, 2, "d - c"); // we can't be sure that 4-bits minus 2-bits is 2-bits.
 
-    auto result = verify_logic(composer);
-    EXPECT_FALSE(result.valid);
-    EXPECT_EQ(result.err, "safe_uint_t range constraint failure: subtract: d - c");
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    plonk::proof proof = prover.construct_proof();
+    EXPECT_FALSE(verifier.verify_proof(proof));
 }
 
 #if !defined(__wasm__)
-TEST(stdlib_safeuint, test_subtract_method_underflow_fails)
+TYPED_TEST(SafeUintTest, TestSubtractMethodUnderflowFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 2));
-    field_t b(witness_t(&composer, field_t::modulus / 2));
-    suint_t c(a, 2);
-    suint_t d(b, suint_t::MAX_BIT_NUM);
+    field_ct a(witness_ct(&composer, 2));
+    field_ct b(witness_ct(&composer, field_ct::modulus / 2));
+    suint_ct c(a, 2);
+    suint_ct d(b, suint_ct::MAX_BIT_NUM);
     try {
-        c = c.subtract(d, suint_t::MAX_BIT_NUM);
+        c = c.subtract(d, suint_ct::MAX_BIT_NUM);
         FAIL() << "Expected out of range error";
     } catch (std::runtime_error const& err) {
         EXPECT_EQ(err.what(), std::string("maximum value exceeded in safe_uint subtract"));
@@ -193,13 +207,15 @@ TEST(stdlib_safeuint, test_subtract_method_underflow_fails)
 #endif
 // - OPERATOR
 
-TEST(stdlib_safeuint, test_minus_operator)
+TYPED_TEST(SafeUintTest, TestMinusOperator)
 {
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 2));
-    field_t b(witness_t(&composer, 9));
-    suint_t c(a, 2);
-    suint_t d(b, 4);
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
+    field_ct a(witness_ct(&composer, 2));
+    field_ct b(witness_ct(&composer, 9));
+    suint_ct c(a, 2);
+    suint_ct d(b, 4);
     c = d - c;
 
     auto prover = composer.create_prover();
@@ -209,14 +225,15 @@ TEST(stdlib_safeuint, test_minus_operator)
 }
 
 #if !defined(__wasm__)
-TEST(stdlib_safeuint, test_minus_operator_underflow_fails)
+TYPED_TEST(SafeUintTest, TestMinusOperatorUnderflowFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 2));
-    field_t b(witness_t(&composer, field_t::modulus / 2));
-    suint_t c(a, 2);
-    suint_t d(b, suint_t::MAX_BIT_NUM);
+    field_ct a(witness_ct(&composer, 2));
+    field_ct b(witness_ct(&composer, field_ct::modulus / 2));
+    suint_ct c(a, 2);
+    suint_ct d(b, suint_ct::MAX_BIT_NUM);
     try {
         c = c - d;
     } catch (std::runtime_error const& err) {
@@ -229,21 +246,21 @@ TEST(stdlib_safeuint, test_minus_operator_underflow_fails)
 
 // DIVIDE METHOD
 
-TEST(stdlib_safeuint, test_divide_method)
+TYPED_TEST(SafeUintTest, TestDivideMethod)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
-    Composer composer = Composer();
-
-    field_t a1(witness_t(&composer, 2));
-    field_t b1(witness_t(&composer, 9));
-    suint_t c1(a1, 2);
-    suint_t d1(b1, 4);
+    field_ct a1(witness_ct(&composer, 2));
+    field_ct b1(witness_ct(&composer, 9));
+    suint_ct c1(a1, 2);
+    suint_ct d1(b1, 4);
     c1 = d1.divide(c1, 3, 1);
 
-    field_t a2(witness_t(&composer, engine.get_random_uint8()));
-    field_t b2(witness_t(&composer, engine.get_random_uint32()));
-    suint_t c2(a2, 8);
-    suint_t d2(b2, 32);
+    field_ct a2(witness_ct(&composer, engine.get_random_uint8()));
+    field_ct b2(witness_ct(&composer, engine.get_random_uint32()));
+    suint_ct c2(a2, 8);
+    suint_ct d2(b2, 32);
     c2 = d2.divide(c2, 32, 8);
 
     auto prover = composer.create_prover();
@@ -252,71 +269,83 @@ TEST(stdlib_safeuint, test_divide_method)
     EXPECT_TRUE(verifier.verify_proof(proof));
 }
 
-TEST(stdlib_safeuint, test_divide_method_quotient_range_too_small_fails)
+TYPED_TEST(SafeUintTest, TestDivideMethodQuotientRangeTooSmallFails)
 {
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 2));
-    field_t b(witness_t(&composer, 32));
-    suint_t c(a, 2);
-    suint_t d(b, 6);
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
+    field_ct a(witness_ct(&composer, 2));
+    field_ct b(witness_ct(&composer, 32));
+    suint_ct c(a, 2);
+    suint_ct d(b, 6);
     d = d.divide(c, 4, 1, "d/c");
 
-    auto result = verify_logic(composer);
-    EXPECT_FALSE(result.valid);
-    EXPECT_EQ(result.err, "safe_uint_t range constraint failure: divide method quotient: d/c");
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    plonk::proof proof = prover.construct_proof();
+    EXPECT_FALSE(verifier.verify_proof(proof));
 }
 
 #if !defined(__wasm__)
-TEST(stdlib_safeuint, test_divide_remainder_too_large)
+TYPED_TEST(SafeUintTest, TestDivideRemainderTooLarge)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     // test failure when range for remainder too small
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 5));
-    suint_t c(a, 3);
-    suint_t d((fr::modulus - 1) / 3);
-    suint_t b;
+
+    field_ct a(witness_ct(&composer, 5));
+    suint_ct c(a, 3);
+    suint_ct d((fr::modulus - 1) / 3);
+    suint_ct b;
     EXPECT_ANY_THROW(b = c / d);
 }
 #endif
 
-TEST(stdlib_safeuint, test_divide_method_quotient_remainder_incorrect_fails)
+TYPED_TEST(SafeUintTest, TestDivideMethodQuotientRemainderIncorrectFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     // test failure when quotient and remainder values are wrong
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 5));
-    field_t b(witness_t(&composer, 19));
-    suint_t c(a, 3);
-    suint_t d(b, 5);
+
+    field_ct a(witness_ct(&composer, 5));
+    field_ct b(witness_ct(&composer, 19));
+    suint_ct c(a, 3);
+    suint_ct d(b, 5);
     d = d.divide(c, 3, 2, "d/c", [](uint256_t, uint256_t) { return std::make_pair(2, 3); });
 
-    auto result = verify_logic(composer);
-    EXPECT_FALSE(result.valid);
-    EXPECT_EQ(result.err, "divide method quotient and/or remainder incorrect");
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    plonk::proof proof = prover.construct_proof();
+    EXPECT_FALSE(verifier.verify_proof(proof));
 }
 
-TEST(stdlib_safeuint, test_divide_method_quotient_remainder_mod_r_fails)
+TYPED_TEST(SafeUintTest, TestDivideMethodQuotientRemainderModRFails)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     // test failure when quotient and remainder are only correct mod r
-    Composer composer = Composer();
-    field_t a(witness_t(&composer, 5));
-    field_t b(witness_t(&composer, 19));
-    suint_t c(a, 3);
-    suint_t d(b, 5);
+
+    field_ct a(witness_ct(&composer, 5));
+    field_ct b(witness_ct(&composer, 19));
+    suint_ct c(a, 3);
+    suint_ct d(b, 5);
     d = d.divide(c, 3, 1, "d/c", [](uint256_t a, uint256_t b) { return std::make_pair((fr)a / (fr)b, 0); });
     // 19 / 5 in the field is 0x1d08fbde871dc67f6e96903a4db401d17e858b5eaf6f438a5bedf9bf2999999e, so the quotient
     // should fail the range check of 3-bits.
 
-    auto result = verify_logic(composer);
-    EXPECT_FALSE(result.valid);
-    EXPECT_EQ(result.err, "safe_uint_t range constraint failure: divide method quotient: d/c");
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+    plonk::proof proof = prover.construct_proof();
+    EXPECT_FALSE(verifier.verify_proof(proof));
 }
 
-TEST(stdlib_safeuint, test_div_operator)
+TYPED_TEST(SafeUintTest, TestDivOperator)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
-    suint_t a(witness_t(&composer, 1000), 10, "a");
-    suint_t b(2, 2, "b");
+    suint_ct a(witness_ct(&composer, 1000), 10, "a");
+    suint_ct b(2, 2, "b");
 
     a = a / b;
 
@@ -328,22 +357,23 @@ TEST(stdlib_safeuint, test_div_operator)
 
 // / OPERATOR
 
-TEST(stdlib_safeuint, test_divide_operator)
+TYPED_TEST(SafeUintTest, TestDivideOperator)
 {
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
     // test success cases
     {
-        Composer composer = Composer();
-
-        field_t a1(witness_t(&composer, 2));
-        field_t b1(witness_t(&composer, 9));
-        suint_t c1(a1, 2);
-        suint_t d1(b1, 4);
+        auto composer = Composer();
+        field_ct a1(witness_ct(&composer, 2));
+        field_ct b1(witness_ct(&composer, 9));
+        suint_ct c1(a1, 2);
+        suint_ct d1(b1, 4);
         d1 / c1;
 
-        field_t a2(witness_t(&composer, engine.get_random_uint8()));
-        field_t b2(witness_t(&composer, engine.get_random_uint32()));
-        suint_t c2(a2, 8);
-        suint_t d2(b2, 32);
+        field_ct a2(witness_ct(&composer, engine.get_random_uint8()));
+        field_ct b2(witness_ct(&composer, engine.get_random_uint32()));
+        suint_ct c2(a2, 8);
+        suint_ct d2(b2, 32);
         d2 / c2;
 
         auto prover = composer.create_prover();
@@ -354,11 +384,11 @@ TEST(stdlib_safeuint, test_divide_operator)
     }
     // test failure when range for quotient too small
     {
-        Composer composer = Composer();
-        field_t a(witness_t(&composer, 2));
-        field_t b(witness_t(&composer, 32));
-        suint_t c(a, 2);
-        suint_t d(b, 5);
+        auto composer = Composer();
+        field_ct a(witness_ct(&composer, 2));
+        field_ct b(witness_ct(&composer, 32));
+        suint_ct c(a, 2);
+        suint_ct d(b, 5);
         d = d / c;
         auto prover = composer.create_prover();
         auto verifier = composer.create_verifier();
@@ -368,11 +398,11 @@ TEST(stdlib_safeuint, test_divide_operator)
     }
     // test failure when range for remainder too small
     {
-        Composer composer = Composer();
-        field_t a(witness_t(&composer, 5));
-        field_t b(witness_t(&composer, 19));
-        suint_t c(a, 2);
-        suint_t d(b, 5);
+
+        field_ct a(witness_ct(&composer, 5));
+        field_ct b(witness_ct(&composer, 19));
+        suint_ct c(a, 2);
+        suint_ct d(b, 5);
         d = d / c;
         auto prover = composer.create_prover();
         auto verifier = composer.create_verifier();
@@ -382,11 +412,11 @@ TEST(stdlib_safeuint, test_divide_operator)
     }
     // test failure when quotient and remainder values are wrong
     {
-        Composer composer = Composer();
-        field_t a(witness_t(&composer, 5));
-        field_t b(witness_t(&composer, 19));
-        suint_t c(a, 2);
-        suint_t d(b, 5);
+        auto composer = Composer();
+        field_ct a(witness_ct(&composer, 5));
+        field_ct b(witness_ct(&composer, 19));
+        suint_ct c(a, 2);
+        suint_ct d(b, 5);
         d = d / c;
         auto prover = composer.create_prover();
         auto verifier = composer.create_verifier();
@@ -396,11 +426,11 @@ TEST(stdlib_safeuint, test_divide_operator)
     }
     // test failure when quotient and remainder are only correct mod r
     {
-        Composer composer = Composer();
-        field_t a(witness_t(&composer, 5));
-        field_t b(witness_t(&composer, 19));
-        suint_t c(a, 2);
-        suint_t d(b, 5);
+        auto composer = Composer();
+        field_ct a(witness_ct(&composer, 5));
+        field_ct b(witness_ct(&composer, 19));
+        suint_ct c(a, 2);
+        suint_ct d(b, 5);
         d = d / c;
         auto prover = composer.create_prover();
         auto verifier = composer.create_verifier();
@@ -412,16 +442,18 @@ TEST(stdlib_safeuint, test_divide_operator)
 
 // SLICE
 
-TEST(stdlib_safeuint, test_slice)
+TYPED_TEST(SafeUintTest, TestSlice)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     // 0b11110110101001011
     //         ^      ^
     //        msb    lsb
     //        10      3
     // hi=0x111101, lo=0x011, slice=0x10101001
     //
-    suint_t a(witness_t(&composer, fr(126283)), 17);
+    suint_ct a(witness_ct(&composer, fr(126283)), 17);
     auto slice_data = a.slice(10, 3);
 
     EXPECT_EQ(slice_data[0].get_value(), fr(3));
@@ -436,16 +468,18 @@ TEST(stdlib_safeuint, test_slice)
     EXPECT_TRUE(result);
 }
 
-TEST(stdlib_safeuint, test_slice_equal_msb_lsb)
+TYPED_TEST(SafeUintTest, TestSliceEqualMsbLsb)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
     // 0b11110110101001011
     //             ^
     //         msb = lsb
     //             6
     // hi=0b1111011010, lo=0b001011, slice=0b1
     //
-    suint_t a(witness_t(&composer, fr(126283)), 17);
+    suint_ct a(witness_ct(&composer, fr(126283)), 17);
     auto slice_data = a.slice(6, 6);
 
     EXPECT_EQ(slice_data[0].get_value(), fr(11));
@@ -460,14 +494,15 @@ TEST(stdlib_safeuint, test_slice_equal_msb_lsb)
     EXPECT_TRUE(result);
 }
 
-TEST(stdlib_safeuint, test_slice_random)
+TYPED_TEST(SafeUintTest, TestSliceRandom)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
     uint8_t lsb = 106;
     uint8_t msb = 189;
     fr a_ = fr(uint256_t(fr::random_element()) && ((uint256_t(1) << 252) - 1));
-    suint_t a(witness_t(&composer, a_), 252);
+    suint_ct a(witness_ct(&composer, a_), 252);
     auto slice = a.slice(msb, lsb);
 
     const uint256_t expected0 = uint256_t(a_) & ((uint256_t(1) << uint64_t(lsb)) - 1);
@@ -491,28 +526,29 @@ TEST(stdlib_safeuint, test_slice_random)
  * @brief Make sure we prevent proving v / v = 0 by setting the divison remainder to be v.
  */
 
-TEST(stdlib_safeuint, operator_div_remainder_constraint)
+TYPED_TEST(SafeUintTest, TestOperatorDivRemainderConstraint)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
     uint256_t val = 5;
 
-    suint_t a(witness_t(&composer, val), 32);
-    suint_t b(witness_t(&composer, val), 32);
+    suint_ct a(witness_ct(&composer, val), 32);
+    suint_ct b(witness_ct(&composer, val), 32);
 
     uint256_t quotient_val = 0;
     uint256_t remainder_val = val;
-    field_t quotient_field(witness_t(&composer, quotient_val));
-    field_t remainder_field(witness_t(&composer, remainder_val));
-    suint_t quotient(quotient_field, (size_t)(a.current_max.get_msb() + 1));
-    suint_t remainder(remainder_field, (size_t)(a.current_max.get_msb() + 1));
+    field_ct quotient_field(witness_ct(&composer, quotient_val));
+    field_ct remainder_field(witness_ct(&composer, remainder_val));
+    suint_ct quotient(quotient_field, (size_t)(a.current_max.get_msb() + 1));
+    suint_ct remainder(remainder_field, (size_t)(a.current_max.get_msb() + 1));
     // This line implicitly checks we are not overflowing
-    suint_t int_val = quotient * b + remainder;
+    suint_ct int_val = quotient * b + remainder;
 
     // Idiomatic constraint
     // We constrain divisor - remainder - 1 to be positive to ensure that remainder < divisor.
-    suint_t delta = b - remainder - 1;
-    field_t::from_witness_index(delta.value.context, delta.value.get_witness_index())
+    suint_ct delta = b - remainder - 1;
+    field_ct::from_witness_index(delta.value.context, delta.value.get_witness_index())
         .create_range_constraint(static_cast<size_t>(b.current_max.get_msb() + 1));
 
     // // More rudimentary constraint
@@ -532,7 +568,7 @@ TEST(stdlib_safeuint, operator_div_remainder_constraint)
     // composer.create_add_gate(delta_gate);
 
     // // validate delta is in the correct range
-    // field_t::from_witness_index(&composer, delta_idx).create_range_constraint(b.current_max.get_msb() + 1);
+    // field_ct::from_witness_index(&composer, delta_idx).create_range_constraint(b.current_max.get_msb() + 1);
 
     a.assert_equal(int_val);
 
@@ -547,14 +583,15 @@ TEST(stdlib_safeuint, operator_div_remainder_constraint)
  * @brief Make sure we prevent proving v / v = 0 with remainder set to v.
  */
 
-TEST(stdlib_safeuint, div_remainder_constraint)
+TYPED_TEST(SafeUintTest, TestDivRemainderConstraint)
 {
-    Composer composer = Composer();
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
 
     uint256_t val = 5;
 
-    suint_t a(witness_t(&composer, val), 32);
-    suint_t b(witness_t(&composer, val), 32);
+    suint_ct a(witness_ct(&composer, val), 32);
+    suint_ct b(witness_ct(&composer, val), 32);
 
     // set quotient to 0 and remainder to val.
     auto supply_bad_witnesses = [](uint256_t val, uint256_t divisor) {
@@ -571,18 +608,20 @@ TEST(stdlib_safeuint, div_remainder_constraint)
     EXPECT_EQ(result, false);
 }
 
-TEST(stdlib_safeuint, test_byte_array_conversion)
+TYPED_TEST(SafeUintTest, TestByteArrayConversion)
 {
-    Composer composer = Composer();
-    field_t elt = witness_t(&composer, 0x7f6f5f4f00010203);
-    suint_t safe(elt, 63);
+    STDLIB_TYPE_ALIASES
+    auto composer = Composer();
+
+    field_ct elt = witness_ct(&composer, 0x7f6f5f4f00010203);
+    suint_ct safe(elt, 63);
     // safe.value is a uint256_t, so we serialize to a 32-byte array
     std::string expected = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                              0x00, 0x00, 0x7f, 0x6f, 0x5f, 0x4f, 0x00, 0x01, 0x02, 0x03 };
 
-    byte_array_t arr(&composer);
-    arr.write(static_cast<byte_array_t>(safe));
+    byte_array_ct arr(&composer);
+    arr.write(static_cast<byte_array_ct>(safe));
     EXPECT_EQ(arr.get_string(), expected);
 }
 } // namespace test_stdlib_safe_uint


### PR DESCRIPTION
Make sure all the primitives in stdlib (except the UltraPlonk specific ones) are tested against all composers.  

Work on issues #130 and #78.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
