### PR TITLE
fix(nix): Disable ASM & ADX when building in Nix

### DIFF
--- a/barretenberg.nix
+++ b/barretenberg.nix
@@ -25,6 +25,8 @@ buildEnv.mkDerivation
   cmakeFlags = [
     "-DTESTING=OFF"
     "-DBENCHMARKS=OFF"
+    "-DDISABLE_ASM=ON"
+    "-DDISABLE_ADX=ON"
     "-DCMAKE_TOOLCHAIN_FILE=${toolchain_file}"
     "-DCMAKE_BUILD_TYPE=RelWithAssert"
   ];


### PR DESCRIPTION
# Description

These are 2 cmake variables that we set in the Noir aztec-connect fork because the assembly code frequently crashes with `Illegal instruction` failures. Since switching to upstream barretenberg, we are seeing these failures again, so the ASM code still seems to be broken. Short term, we will just disable the ASM code when consuming via Nix. Long term, the ASM code should be fixed or removed.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
