### PR TITLE
Fix `address` compilation.

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
@@ -7,17 +7,17 @@
 #include "barretenberg/stdlib/primitives/point/point.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
-namespace plonk {
+namespace proof_system::plonk {
 namespace stdlib {
 
 using barretenberg::fr;
 using numeric::uint256_t;
-using plonk::stdlib::bool_t;
-using plonk::stdlib::field_t;
-using plonk::stdlib::group;
-using plonk::stdlib::pedersen_commitment;
-using plonk::stdlib::point;
-using plonk::stdlib::witness_t;
+using stdlib::bool_t;
+using stdlib::field_t;
+using stdlib::group;
+using stdlib::pedersen_commitment;
+using stdlib::point;
+using stdlib::witness_t;
 
 // Native type
 class address {
@@ -139,4 +139,4 @@ template <typename Composer> class address_t {
 };
 
 } // namespace stdlib
-} // namespace plonk
+} // namespace proof_system::plonk


### PR DESCRIPTION
# Description

`stdlib::address` had compilation issues at it wasn't defined in correct namespace. Fixing it.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
