### PR TITLE
`get_limbs` methods on bigfield, biggroup.

### DIFF
--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -90,6 +90,7 @@ if(WASM)
         $<TARGET_OBJECTS:stdlib_pedersen_commitment_objects>
         $<TARGET_OBJECTS:stdlib_blake2s_objects>
         $<TARGET_OBJECTS:stdlib_blake3s_objects>
+        $<TARGET_OBJECTS:stdlib_keccak_objects>
         $<TARGET_OBJECTS:stdlib_sha256_objects>
         $<TARGET_OBJECTS:stdlib_aes128_objects>
         $<TARGET_OBJECTS:stdlib_merkle_tree_objects>
@@ -192,6 +193,7 @@ if(WASM)
         $<TARGET_OBJECTS:stdlib_pedersen_commitment_objects>
         $<TARGET_OBJECTS:stdlib_blake2s_objects>
         $<TARGET_OBJECTS:stdlib_blake3s_objects>
+        $<TARGET_OBJECTS:stdlib_keccak_objects>
         $<TARGET_OBJECTS:stdlib_sha256_objects>
         $<TARGET_OBJECTS:stdlib_aes128_objects>
         $<TARGET_OBJECTS:stdlib_merkle_tree_objects>
@@ -227,6 +229,7 @@ else()
         $<TARGET_OBJECTS:stdlib_pedersen_commitment_objects>
         $<TARGET_OBJECTS:stdlib_blake2s_objects>
         $<TARGET_OBJECTS:stdlib_blake3s_objects>
+        $<TARGET_OBJECTS:stdlib_keccak_objects>
         $<TARGET_OBJECTS:stdlib_sha256_objects>
         $<TARGET_OBJECTS:stdlib_aes128_objects>
         $<TARGET_OBJECTS:stdlib_merkle_tree_objects>

--- a/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -43,6 +43,11 @@ template <typename Fq, typename Fr, typename Params> class alignas(64) affine_el
               typename CompileTimeEnabled = std::enable_if_t<(BaseField::modulus >> 255) == uint256_t(0), void>>
     constexpr uint256_t compress() const noexcept;
 
+    /**
+     * @brief Get the limbs of the x and y coordinates of the group element.
+     *
+     * @return vector of the limbs of x, y coordinates (size 8)
+     */
     std::vector<barretenberg::fr> get_coordinate_limbs() const
     {
         constexpr size_t num_limb_bits = proof_system::plonk::NUM_LIMB_BITS_IN_FIELD_SIMULATION;

--- a/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -45,7 +45,7 @@ template <typename Fq, typename Fr, typename Params> class alignas(64) affine_el
 
     std::vector<barretenberg::fr> get_coordinate_limbs() const
     {
-        constexpr size_t num_limb_bits = plonk::NUM_LIMB_BITS_IN_FIELD_SIMULATION;
+        constexpr size_t num_limb_bits = proof_system::plonk::NUM_LIMB_BITS_IN_FIELD_SIMULATION;
         const auto split_bigfield_limbs = [](const uint256_t& element) {
             std::vector<barretenberg::fr> limbs;
             limbs.push_back(element.slice(0, num_limb_bits));

--- a/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -110,6 +110,7 @@ template <typename Fq, typename Fr, typename Params> class alignas(64) affine_el
                 write(buffer, uint256_t(1) << 255);
             }
         } else {
+            // TODO: Why is y-bytes before x-bytes?
             Fq::serialize_to_buffer(value.y, buffer);
             Fq::serialize_to_buffer(value.x, buffer + sizeof(Fq));
         }

--- a/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -61,6 +61,8 @@ template <typename G1> class test_affine_element : public testing::Test {
         }
     }
 
+    static void test_get_limbs() { affine_element P = affine_element(element::random_element()); }
+
     // Regression test to ensure that the point at infinity is not equal to its coordinate-wise reduction, which may lie
     // on the curve, depending on the y-coordinate.
     // TODO: add corresponding typed test class
@@ -99,5 +101,22 @@ TEST(affine_element, infinity_ordering_regression)
 
     P.self_set_infinity();
     EXPECT_NE(P < Q, Q < P);
+}
+
+TEST(affine_element, get_coordinate_limbs)
+{
+    secp256k1::fq x(uint256_t{ 0x0000000000000001, 0xa00000000000001a, 0xb00000000000011b, 0xc00000000000111c });
+    secp256k1::fq y(uint256_t{ 0x0000000000000002, 0xd00000000000002d, 0xe00000000000022e, 0xf00000000000222f });
+    secp256k1::g1::affine_element P(x, y);
+
+    std::vector<barretenberg::fr> limbs = P.get_coordinate_limbs();
+    EXPECT_EQ(uint256_t(limbs[0]), uint256_t(0x0000000000000001, 0xa, 0, 0));
+    EXPECT_EQ(uint256_t(limbs[1]), uint256_t(0xba00000000000001, 0x1, 0, 0));
+    EXPECT_EQ(uint256_t(limbs[2]), uint256_t(0x1cb0000000000001, 0x1, 0, 0));
+    EXPECT_EQ(uint256_t(limbs[3]), uint256_t(0x000c000000000001, 0x0, 0, 0));
+    EXPECT_EQ(uint256_t(limbs[4]), uint256_t(0x0000000000000002, 0xd, 0, 0));
+    EXPECT_EQ(uint256_t(limbs[5]), uint256_t(0xed00000000000002, 0x2, 0, 0));
+    EXPECT_EQ(uint256_t(limbs[6]), uint256_t(0x2fe0000000000002, 0x2, 0, 0));
+    EXPECT_EQ(uint256_t(limbs[7]), uint256_t(0x000f000000000002, 0x0, 0, 0));
 }
 } // namespace test_affine_element

--- a/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -61,8 +61,6 @@ template <typename G1> class test_affine_element : public testing::Test {
         }
     }
 
-    static void test_get_limbs() { affine_element P = affine_element(element::random_element()); }
-
     // Regression test to ensure that the point at infinity is not equal to its coordinate-wise reduction, which may lie
     // on the curve, depending on the y-coordinate.
     // TODO: add corresponding typed test class

--- a/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -160,7 +160,7 @@ template <typename Composer, typename T> class bigfield {
         field_t<Composer> lo = binary_basis_limbs[0].element + (binary_basis_limbs[1].element * shift_1);
         field_t<Composer> hi = binary_basis_limbs[2].element + (binary_basis_limbs[3].element * shift_1);
         // n.b. this only works if NUM_LIMB_BITS * 2 is divisible by 8
-        ASSERT((NUM_LIMB_BITS / 8) * 8 == NUM_LIMB_BITS);
+        ASSERT((NUM_LIMB_BITS * 2 / 8) * 8 == NUM_LIMB_BITS * 2);
         result.write(byte_array<Composer>(hi, 32 - (NUM_LIMB_BITS / 4)));
         result.write(byte_array<Composer>(lo, (NUM_LIMB_BITS / 4)));
         return result;

--- a/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -312,6 +312,15 @@ template <typename Composer, typename T> class bigfield {
         prime_basis_limb.fix_witness();
     }
 
+    std::vector<field_t<Composer>> get_limbs() const
+    {
+        std::vector<field_t<Composer>> output;
+        for (auto& limb : binary_basis_limbs) {
+            output.push_back(limb.element);
+        }
+        return output;
+    }
+
     Composer* get_context() const { return context; }
 
     static constexpr uint512_t get_maximum_unreduced_value(const size_t num_products = 1)

--- a/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -312,6 +312,11 @@ template <typename Composer, typename T> class bigfield {
         prime_basis_limb.fix_witness();
     }
 
+    /**
+     * @brief Get the binary basis limbs of a bigfield scalar.
+     *
+     * @return vector of the binary basis limbs (circuit type)
+     */
     std::vector<field_t<Composer>> get_limbs() const
     {
         std::vector<field_t<Composer>> output;

--- a/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -221,6 +221,14 @@ template <class Composer, class Fq, class Fr, class NativeGroup> class element {
     template <size_t wnaf_size, size_t staggered_lo_offset = 0, size_t staggered_hi_offset = 0>
     static secp256k1_wnaf_pair compute_secp256k1_endo_wnaf(const Fr& scalar);
 
+    std::vector<field_t<Composer>> get_coordinate_limbs() const
+    {
+        std::vector<field_t<Composer>> output = x.get_limbs();
+        std::vector<field_t<Composer>> y_limbs = y.get_limbs();
+        output.insert(output.end(), y_limbs.begin(), y_limbs.end());
+        return output;
+    }
+
     Composer* get_context() const
     {
         if (x.context != nullptr) {

--- a/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -221,6 +221,11 @@ template <class Composer, class Fq, class Fr, class NativeGroup> class element {
     template <size_t wnaf_size, size_t staggered_lo_offset = 0, size_t staggered_hi_offset = 0>
     static secp256k1_wnaf_pair compute_secp256k1_endo_wnaf(const Fr& scalar);
 
+    /**
+     * @brief Get the binary basis limbs of the x and y coordinates of the biggroup element.
+     *
+     * @return vector of the binary basis limbs of x, y coordinates (size 8)
+     */
     std::vector<field_t<Composer>> get_coordinate_limbs() const
     {
         std::vector<field_t<Composer>> output = x.get_limbs();

--- a/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -830,6 +830,26 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
 
         EXPECT_VERIFICATION(composer);
     }
+
+    static void test_get_coordinate_limbs()
+    {
+        Composer composer = Composer();
+        size_t num_repetitions = 1;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+            affine_element input_a(element::random_element());
+
+            element_ct a = element_ct::from_witness(&composer, input_a);
+
+            auto limbs_ct = a.get_coordinate_limbs();
+            auto limbs = a.get_value().get_coordinate_limbs();
+
+            for (size_t i = 0; i < limbs.size(); i++) {
+                EXPECT_EQ(limbs_ct[i].get_value(), limbs[i]);
+            }
+        }
+
+        EXPECT_VERIFICATION(composer);
+    }
 };
 
 enum UseBigfield { No, Yes };
@@ -895,6 +915,11 @@ HEAVY_TYPED_TEST(stdlib_biggroup, double_montgomery_ladder)
 {
 
     TestFixture::test_double_montgomery_ladder();
+}
+
+HEAVY_TYPED_TEST(stdlib_biggroup, get_coordinate_limbs)
+{
+    TestFixture::test_get_coordinate_limbs();
 }
 
 HEAVY_TYPED_TEST(stdlib_biggroup, compute_naf)


### PR DESCRIPTION
# Description

We need the limbs of bigfield elements for hashing in aztec3-circuits. This PR adds simple methods to get limb values on bigfield and biggroup elements. Need to add tests.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
