### PR TITLE
fix: Change to get_num_gates() inside get_total_circuit_size()

### DIFF
--- a/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
+++ b/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
@@ -353,7 +353,7 @@ class UltraComposer : public ComposerBase {
         }
 
         auto minimum_circuit_size = tables_size + lookups_size;
-        auto num_filled_gates = num_gates + public_inputs.size();
+        auto num_filled_gates = get_num_gates() + public_inputs.size();
         return std::max(minimum_circuit_size, num_filled_gates);
     }
 


### PR DESCRIPTION
# Description

In the DSL package we expose a method `get_total_circuit_size` in the `acir_proofs` folder. In Noir's `aztec_backend` we use this method to estimate the number of G1 points we should take from CRS to set up input to the bberg API such as Pippenger.  This circuit size should match the `total_num_gates` variable at the top of the `compute_proving_key_base` method. This estimation is currently off causing a mismatch between the size of the CRS used for proving and the one computed in the proving key. 

`6_array` in the Noir integrations was having a seg fault due to this mismatch. The minimum circuit size used to set the subgroup size in the proving key was greater than the original number of gates in the circuit (`size_t num_gates` field in the composer). `get_total_circuit_size` should have used `get_num_gates()` internally to fetch the same number of gates used as the proving key. In `compute_proving_key` the method first adds the gates related to ROM arrays and range lists before calling `compute_proving_key_base`. The circuit has not yet been finalized when we call `get_total_circuit_size` and only returns the original number of gates in the circuit. 

# Checklist:

- [X] I have reviewed my diff in github, line by line.
- [X] Every change is related to the PR description.
- [] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [X] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [X] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [X] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [X] The branch has been rebased against the head of its merge target.
- [X] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
