### PR TITLE
Public Key Recovery from ECDSA Signature

### DIFF
--- a/cpp/src/barretenberg/crypto/ecdsa/ecdsa.hpp
+++ b/cpp/src/barretenberg/crypto/ecdsa/ecdsa.hpp
@@ -14,10 +14,14 @@ template <typename Fr, typename G1> struct key_pair {
 struct signature {
     std::array<uint8_t, 32> r;
     std::array<uint8_t, 32> s;
+    uint8_t v;
 };
 
 template <typename Hash, typename Fq, typename Fr, typename G1>
 signature construct_signature(const std::string& message, const key_pair<Fr, G1>& account);
+
+template <typename Hash, typename Fq, typename Fr, typename G1>
+typename G1::affine_element recover_public_key(const std::string& message, const signature& sig);
 
 template <typename Hash, typename Fq, typename Fr, typename G1>
 bool verify_signature(const std::string& message,
@@ -39,12 +43,14 @@ template <typename B> inline void read(B& it, signature& sig)
 {
     read(it, sig.r);
     read(it, sig.s);
+    read(it, sig.v);
 }
 
 template <typename B> inline void write(B& buf, signature const& sig)
 {
     write(buf, sig.r);
     write(buf, sig.s);
+    write(buf, sig.v);
 }
 
 template <typename B> inline void read(B& it, key_pair<secp256k1::fr, secp256k1::g1>& keypair)

--- a/cpp/src/barretenberg/crypto/ecdsa/ecdsa.test.cpp
+++ b/cpp/src/barretenberg/crypto/ecdsa/ecdsa.test.cpp
@@ -40,6 +40,50 @@ TEST(ecdsa, verify_signature_secp256r1_sha256)
     EXPECT_EQ(result, true);
 }
 
+TEST(ecdsa, recover_public_key_secp256k1_sha256)
+{
+    std::string message = "The quick brown dog jumped over the lazy fox.";
+
+    crypto::ecdsa::key_pair<secp256k1::fr, secp256k1::g1> account;
+    account.private_key = secp256k1::fr::random_element();
+    account.public_key = secp256k1::g1::one * account.private_key;
+
+    crypto::ecdsa::signature signature =
+        crypto::ecdsa::construct_signature<Sha256Hasher, secp256k1::fq, secp256k1::fr, secp256k1::g1>(message, account);
+
+    bool result = crypto::ecdsa::verify_signature<Sha256Hasher, secp256k1::fq, secp256k1::fr, secp256k1::g1>(
+        message, account.public_key, signature);
+
+    auto recovered_public_key =
+        crypto::ecdsa::recover_public_key<Sha256Hasher, secp256k1::fq, secp256k1::fr, secp256k1::g1>(message,
+                                                                                                     signature);
+
+    EXPECT_EQ(result, true);
+    EXPECT_EQ(recovered_public_key, account.public_key);
+}
+
+TEST(ecdsa, recover_public_key_secp256r1_sha256)
+{
+    std::string message = "The quick brown dog jumped over the lazy fox.";
+
+    crypto::ecdsa::key_pair<secp256r1::fr, secp256r1::g1> account;
+    account.private_key = secp256r1::fr::random_element();
+    account.public_key = secp256r1::g1::one * account.private_key;
+
+    crypto::ecdsa::signature signature =
+        crypto::ecdsa::construct_signature<Sha256Hasher, secp256r1::fq, secp256r1::fr, secp256r1::g1>(message, account);
+
+    bool result = crypto::ecdsa::verify_signature<Sha256Hasher, secp256r1::fq, secp256r1::fr, secp256r1::g1>(
+        message, account.public_key, signature);
+
+    auto recovered_public_key =
+        crypto::ecdsa::recover_public_key<Sha256Hasher, secp256r1::fq, secp256r1::fr, secp256r1::g1>(message,
+                                                                                                     signature);
+
+    EXPECT_EQ(result, true);
+    EXPECT_EQ(recovered_public_key, account.public_key);
+}
+
 std::vector<uint8_t> HexToBytes(const std::string& hex)
 {
     std::vector<uint8_t> bytes;
@@ -131,7 +175,7 @@ TEST(ecdsa, verify_signature_secp256r1_sha256_NIST_1)
         0xef, 0x97, 0xb2, 0x18, 0xe9, 0x6f, 0x17, 0x5a, 0x3c, 0xcd, 0xda, 0x2a, 0xcc, 0x05, 0x89, 0x03,
     };
 
-    crypto::ecdsa::signature sig{ r, s };
+    crypto::ecdsa::signature sig{ r, s, 27 };
     std::vector<uint8_t> message_vec =
         HexToBytes("5905238877c77421f73e43ee3da6f2d9e2ccad5fc942dcec0cbd25482935faaf416983fe165b1a045ee2bcd2e6dca3bdf46"
                    "c4310a7461f9a37960ca672d3feb5473e253605fb1ddfd28065b53cb5858a8ad28175bf9bd386a5e471ea7a65c17cc934a9"

--- a/cpp/src/barretenberg/crypto/ecdsa/ecdsa_impl.hpp
+++ b/cpp/src/barretenberg/crypto/ecdsa/ecdsa_impl.hpp
@@ -29,7 +29,88 @@ signature construct_signature(const std::string& message, const key_pair<Fr, G1>
     Fr s_fr = (z + r_fr * account.private_key) / k;
 
     Fr::serialize_to_buffer(s_fr, &sig.s[0]);
+
+    // compute recovery_id: given R = (x, y)
+    //   0: y is even  &&  x < |Fr|
+    //   1: y is odd   &&  x < |Fr|
+    //   2: y is even  &&  |Fr| <= x < |Fq|
+    //   3: y is odd   &&  |Fr| <= x < |Fq|
+    // v = offset + recovery_id
+    Fq r_fq = Fq(R.x);
+    bool is_r_finite = (uint256_t(r_fq) == uint256_t(r_fr));
+    bool y_parity = uint256_t(R.y).get_bit(0);
+    constexpr uint8_t offset = 27;
+
+    int value = offset + y_parity + static_cast<uint8_t>(2) * !is_r_finite;
+    ASSERT(value <= UINT8_MAX);
+    sig.v = static_cast<uint8_t>(value);
     return sig;
+}
+
+template <typename Hash, typename Fq, typename Fr, typename G1>
+typename G1::affine_element recover_public_key(const std::string& message, const signature& sig)
+{
+    using serialize::read;
+    uint256_t r_uint;
+    uint256_t s_uint;
+    uint8_t v_uint;
+
+    const auto* r_buf = &sig.r[0];
+    const auto* s_buf = &sig.s[0];
+    const auto* v_buf = &sig.v;
+    read(r_buf, r_uint);
+    read(s_buf, s_uint);
+    read(v_buf, v_uint);
+
+    // We need to check that r and s are in Field according to specification
+    if ((r_uint >= Fr::modulus) || (s_uint >= Fr::modulus)) {
+        throw_or_abort("r or s value exceeds the modulus");
+    }
+    if ((r_uint == 0) || (s_uint == 0)) {
+        throw_or_abort("r or s value is zero");
+    }
+
+    // Check that v must either be in {27, 28, 29, 30}
+    Fr r = Fr(r_uint);
+    Fr s = Fr(s_uint);
+    Fq r_fq = Fq(r_uint);
+    bool is_r_finite = true;
+
+    if ((v_uint == 27) || (v_uint == 28)) {
+        ASSERT(uint256_t(r) == uint256_t(r_fq));
+    } else if ((v_uint == 29) || (v_uint == 30)) {
+        ASSERT(uint256_t(r) < uint256_t(r_fq));
+        is_r_finite = false;
+    } else {
+        throw_or_abort("v value is not in {27, 28, 29, 30}");
+    }
+
+    // Decompress the x-coordinate r_uint to get two possible R points
+    // The first uncompressed R point is selected when r < |Fr|
+    // The second uncompressed R point is selected when |Fr| <= r < |Fq|
+    // Note that the second condition can occur with probability 1/2^128 so its highly unlikely.
+    auto uncompressed_points = G1::affine_element::from_compressed_unsafe(r_uint);
+    typename G1::affine_element point_R = uncompressed_points[!is_r_finite];
+
+    // Negate the y-coordinate point of R based on the parity of v
+    bool y_parity_R = uint256_t(point_R.y).get_bit(0);
+    if ((v_uint & 1) == y_parity_R) {
+        point_R.y = -point_R.y;
+    }
+
+    // Start key recovery algorithm
+    std::vector<uint8_t> message_buffer;
+    std::copy(message.begin(), message.end(), std::back_inserter(message_buffer));
+    auto ev = Hash::hash(message_buffer);
+    Fr z = Fr::serialize_from_buffer(&ev[0]);
+
+    Fr r_inv = r.invert();
+
+    Fr u1 = -(z * r_inv);
+    Fr u2 = s * r_inv;
+
+    typename G1::affine_element recovered_public_key(typename G1::element(point_R) * u2 + G1::one * u1);
+    return recovered_public_key;
 }
 
 template <typename Hash, typename Fq, typename Fr, typename G1>

--- a/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -31,6 +31,19 @@ template <typename Fq, typename Fr, typename Params> class alignas(64) affine_el
               typename CompileTimeEnabled = std::enable_if_t<(BaseField::modulus >> 255) == uint256_t(0), void>>
     static constexpr affine_element from_compressed(const uint256_t& compressed) noexcept;
 
+    /**
+     * @brief Reconstruct a point in affine coordinates from compressed form.
+     * @details #LARGE_MODULUS_AFFINE_POINT_COMPRESSION Point compression is implemented for curves of a prime
+     * field F_p with p being 256 bits.
+     * TODO(Suyash): Check with kesha if this is correct.
+     *
+     * @param compressed compressed point
+     * @return constexpr affine_element
+     */
+    template <typename BaseField = Fq,
+              typename CompileTimeEnabled = std::enable_if_t<(BaseField::modulus >> 255) == uint256_t(1), void>>
+    static constexpr std::array<affine_element, 2> from_compressed_unsafe(const uint256_t& compressed) noexcept;
+
     constexpr affine_element& operator=(const affine_element& other) noexcept;
 
     constexpr affine_element& operator=(affine_element&& other) noexcept;

--- a/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -61,6 +61,19 @@ template <typename G1> class test_affine_element : public testing::Test {
         }
     }
 
+    static void test_point_compression_unsafe()
+    {
+        for (size_t i = 0; i < 100; i++) {
+            affine_element P = affine_element(element::random_element());
+            uint256_t compressed = uint256_t(P.x);
+
+            // Note that we do not check the point Q_points[1] because its highly unlikely to hit a point P on the curve
+            // such that r < P.x < q.
+            std::array<affine_element, 2> Q_points = affine_element::from_compressed_unsafe(compressed);
+            EXPECT_EQ(P, Q_points[0]);
+        }
+    }
+
     // Regression test to ensure that the point at infinity is not equal to its coordinate-wise reduction, which may lie
     // on the curve, depending on the y-coordinate.
     // TODO: add corresponding typed test class
@@ -88,6 +101,15 @@ TYPED_TEST(test_affine_element, point_compression)
         GTEST_SKIP();
     } else {
         TestFixture::test_point_compression();
+    }
+}
+
+TYPED_TEST(test_affine_element, point_compression_unsafe)
+{
+    if constexpr (TypeParam::Fq::modulus.data[3] >= 0x4000000000000000ULL) {
+        TestFixture::test_point_compression_unsafe();
+    } else {
+        GTEST_SKIP();
     }
 }
 

--- a/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
+++ b/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
@@ -47,6 +47,33 @@ constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::from_compressed(c
 }
 
 template <class Fq, class Fr, class T>
+template <typename BaseField, typename CompileTimeEnabled>
+constexpr std::array<affine_element<Fq, Fr, T>, 2> affine_element<Fq, Fr, T>::from_compressed_unsafe(
+    const uint256_t& compressed) noexcept
+{
+    auto get_y_coordinate = [](const uint256_t& x_coordinate) {
+        Fq x = Fq(x_coordinate);
+        Fq y2 = (x.sqr() * x + T::b);
+        if constexpr (T::has_a) {
+            y2 += (x * T::a);
+        }
+        return y2.sqrt();
+    };
+
+    uint256_t x_1 = compressed;
+    uint256_t x_2 = compressed + Fr::modulus;
+    auto [is_quadratic_remainder_1, y_1] = get_y_coordinate(x_1);
+    auto [is_quadratic_remainder_2, y_2] = get_y_coordinate(x_2);
+
+    auto output_1 = is_quadratic_remainder_1 ? affine_element<Fq, Fr, T>(Fq(x_1), y_1)
+                                             : affine_element<Fq, Fr, T>(Fq::zero(), Fq::zero());
+    auto output_2 = is_quadratic_remainder_2 ? affine_element<Fq, Fr, T>(Fq(x_2), y_2)
+                                             : affine_element<Fq, Fr, T>(Fq::zero(), Fq::zero());
+
+    return { output_1, output_2 };
+}
+
+template <class Fq, class Fr, class T>
 constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::operator+(
     const affine_element<Fq, Fr, T>& other) const noexcept
 {


### PR DESCRIPTION
# Description

In Aztec3 as well as generally, it is very useful to recover the public key from the ECDSA signature. This PR implements the native crypto logic to recover a public/signing key from an ECDSA signature. This requires me to modify the ecdsa signature struct to:
```cpp
struct signature {
    std::array<uint8_t, 32> r;
    std::array<uint8_t, 32> s;
    uint8_t v;
};
```
where $v$ is a byte that stores information about the point $R = kG$ in the ECDSA construction. Specifically, we set:
$$v = 27 + \textsf{rec}_{id}$$

where $\textsf{rec}_{id}$ is computed as:

$$\textsf{rec}_{id} := a + 2b$$

$$a = \textsf{parity}(R.y)$$

$$b = 1 \text{ if } (|Fr| < R.y < |Fq|),\ 0 \text{ otherwise}.$$

This information is used to recover the correct public key from a set of 4 possibilities of a public key. Note that curves with cofactor greater than 1 would have more such possibilities.

⚠️ Important note for reviewer: We need to make sure the newly added function `from_compressed_unsafe` for curves with order > 255 bits is correctly implemented.

References:
1. Internal hackmd: https://hackmd.io/feGFQZ3YSNWJMFTndGywkw?view
2. Blog on Ethereum's `ecrecover`: https://coders-errand.com/ecrecover-signature-verification-ethereum/
3. Ethereum yellow paper: https://ethereum.github.io/yellowpaper/paper.pdf 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
