### PR TITLE
doc: Document more thoroughly why fields don't 0-init

### DIFF
--- a/cpp/src/barretenberg/ecc/fields/field.hpp
+++ b/cpp/src/barretenberg/ecc/fields/field.hpp
@@ -28,6 +28,7 @@ template <class Params> struct alignas(32) field {
     // Other alternatives have been noted, such as casting to get around constructors where they matter,
     // however it is felt that sanitizer tools (e.g. MSAN) can detect garbage well, whereas not doing
     // hacky casts where needed would require rework to critical algos like MSM, FFT, Sumcheck.
+    // Instead, the recommended solution is use an explicit = 0 where initialization is important.
     field() noexcept {}
 
     constexpr field(const uint256_t& input) noexcept

--- a/cpp/src/barretenberg/ecc/fields/field.hpp
+++ b/cpp/src/barretenberg/ecc/fields/field.hpp
@@ -26,7 +26,7 @@ template <class Params> struct alignas(32) field {
   public:
     // We don't initialize data by default since we'd lose a lot of time on pointless initializations.
     // Other alternatives have been noted, such as casting to get around constructors where they matter,
-    // however it is felt that sanitizer tools (e.g. MSAN) can detect garbage well, whereas not doing
+    // however it is felt that sanitizer tools (e.g. MSAN) can detect garbage well, whereas doing
     // hacky casts where needed would require rework to critical algos like MSM, FFT, Sumcheck.
     // Instead, the recommended solution is use an explicit = 0 where initialization is important.
     field() noexcept {}

--- a/cpp/src/barretenberg/ecc/fields/field.hpp
+++ b/cpp/src/barretenberg/ecc/fields/field.hpp
@@ -25,6 +25,9 @@ namespace barretenberg {
 template <class Params> struct alignas(32) field {
   public:
     // We don't initialize data by default since we'd lose a lot of time on pointless initializations.
+    // Other alternatives have been noted, such as casting to get around constructors where they matter,
+    // however it is felt that sanitizer tools (e.g. MSAN) can detect garbage well, whereas not doing
+    // hacky casts where needed would require rework to critical algos like MSM, FFT, Sumcheck.
     field() noexcept {}
 
     constexpr field(const uint256_t& input) noexcept


### PR DESCRIPTION
# Description

Based on this internal discussion https://aztecprotocol.slack.com/archives/C01CGB1KUN4/p1681324799735519

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
