### PR TITLE
32-Byte Keccak256 challenges for UltraPlonK

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -105,10 +105,10 @@ TEST(acir_format, test_logic_gate_from_noir_circuit)
 
     std::cout << "made composer" << std::endl;
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     auto proof = prover.construct_proof();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }
@@ -174,10 +174,10 @@ TEST(acir_format, test_schnorr_verify_pass)
           67, 16,  37,  128, 85,  76,  19,  253, 30,  77,  192,   53,    138, 205, 69, 33,  236, 163, 83,  194,
           84, 137, 184, 221, 176, 121, 179, 27,  63,  70,  54,    16,    176, 250, 39, 239, 1,   0,   0,   0 });
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     auto proof = prover.construct_proof();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }
@@ -243,10 +243,10 @@ TEST(acir_format, test_schnorr_verify_small_range)
           67, 16,  37,  128, 85,  76,  19,  253, 30,  77,  192,   53,    138, 205, 69, 33,  236, 163, 83,  194,
           84, 137, 184, 221, 176, 121, 179, 27,  63,  70,  54,    16,    176, 250, 39, 239, 1,   0,   0,   0 });
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     auto proof = prover.construct_proof();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }

--- a/cpp/src/barretenberg/dsl/acir_proofs/acir_proofs.cpp
+++ b/cpp/src/barretenberg/dsl/acir_proofs/acir_proofs.cpp
@@ -117,7 +117,7 @@ size_t new_proof(void* pippenger,
 
     create_circuit_with_witness(composer, constraint_system, witness);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     auto heapProver = new stdlib::types::Prover(std::move(prover));
     auto& proof_data = heapProver->construct_proof().proof_data;
@@ -144,7 +144,7 @@ bool verify_proof(
         create_circuit(composer, constraint_system);
         plonk::proof pp = { std::vector<uint8_t>(proof, proof + length) };
 
-        auto verifier = composer.create_verifier();
+        auto verifier = composer.create_ultra_with_keccak_verifier();
 
         verified = verifier.verify_proof(pp);
 #ifndef __wasm__

--- a/cpp/src/barretenberg/join_split_example/proofs/compute_circuit_data.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/compute_circuit_data.hpp
@@ -229,20 +229,20 @@ circuit_data get_circuit_data(std::string const& name,
 
             Timer timer;
             if (!mock) {
-                auto prover = composer.create_prover();
+                auto prover = composer.create_ultra_with_keccak_prover();
                 auto proof = prover.construct_proof();
                 data.padding_proof = proof.proof_data;
                 data.num_gates = composer.get_num_gates();
                 info(name, ": Circuit size: ", data.num_gates);
-                auto verifier = composer.create_verifier();
+                auto verifier = composer.create_ultra_with_keccak_verifier();
                 info(name, ": Padding verified: ", verifier.verify_proof(proof));
             } else {
-                auto prover = mock_proof_composer.create_prover();
+                auto prover = mock_proof_composer.create_ultra_with_keccak_prover();
                 auto proof = prover.construct_proof();
                 data.padding_proof = proof.proof_data;
                 data.num_gates = mock_proof_composer.get_num_gates();
                 info(name, ": Mock circuit size: ", data.num_gates);
-                auto verifier = mock_proof_composer.create_verifier();
+                auto verifier = mock_proof_composer.create_ultra_with_keccak_verifier();
                 info(name, ": Padding verified: ", verifier.verify_proof(proof));
             }
             info(name, ": Padding proof computed in ", timer.toString(), "s");

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/create_proof.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/create_proof.hpp
@@ -20,7 +20,7 @@ inline std::vector<uint8_t> create_proof(join_split_tx const& tx,
         info("Join-split circuit logic failed: ", composer.err());
     }
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     auto proof = prover.construct_proof();
 
     return proof.proof_data;

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
@@ -79,12 +79,12 @@ stdlib::types::Prover new_join_split_prover(join_split_tx const& tx, bool mock)
 
     if (!mock) {
         info("composer gates: ", composer.get_num_gates());
-        return composer.create_prover();
+        return composer.create_ultra_with_keccak_prover();
     } else {
         Composer mock_proof_composer(proving_key, nullptr);
         join_split_example::proofs::mock::mock_circuit(mock_proof_composer, composer.get_public_inputs());
         info("mock composer gates: ", mock_proof_composer.get_num_gates());
-        return mock_proof_composer.create_prover();
+        return mock_proof_composer.create_ultra_with_keccak_prover();
     }
 }
 

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
@@ -98,14 +98,14 @@ TYPED_TEST(join_split, deposit)
 
     BenchmarkInfoCollator benchmark_collator;
     Timer timer;
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     auto build_time = timer.toString();
     benchmark_collator.benchmark_info_deferred(
         GET_COMPOSER_NAME_STRING(Composer::type), "Core", "join split", "Build time", build_time);
 
     auto proof = prover.construct_proof();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
     bool verified = verifier.verify_proof(proof);
 
     ASSERT_TRUE(verified);

--- a/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.test.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.test.cpp
@@ -20,14 +20,14 @@ TEST(mock_circuit_tests, test_simple_circuit)
     Composer composer = Composer("../srs_db/ignition");
     mock_circuit(composer, public_inputs);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     plonk::proof proof = prover.construct_proof();
 
     std::cout << "gates: " << composer.get_num_gates() << std::endl;
     std::cout << "proof size: " << proof.proof_data.size() << std::endl;
     std::cout << "public inputs size: " << composer.public_inputs.size() << std::endl;
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
     bool result = verifier.verify_proof(proof);
 
     EXPECT_TRUE(result);

--- a/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.test.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.test.cpp
@@ -30,11 +30,11 @@ TEST(value_note, commits)
     auto result = circuit_note.commitment;
     result.assert_equal(expected);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     EXPECT_FALSE(composer.failed());
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -64,11 +64,11 @@ TEST(value_note, commits_with_0_value)
     auto result = circuit_note.commitment;
     result.assert_equal(expected);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     EXPECT_FALSE(composer.failed());
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -96,11 +96,11 @@ TEST(value_note, commit_with_oversized_asset_id_fails)
     auto result = circuit_note.commitment;
     result.assert_equal(expected);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     EXPECT_TRUE(composer.failed());
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 

--- a/cpp/src/barretenberg/join_split_example/proofs/verify.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/verify.hpp
@@ -90,12 +90,12 @@ auto verify_internal(Composer& composer, Tx& tx, CircuitData const& cd, char con
                 auto proof = prover.construct_proof();
                 result.proof_data = proof.proof_data;
             } else {
-                auto prover = composer.create_prover();
+                auto prover = composer.create_ultra_with_keccak_prover();
                 auto proof = prover.construct_proof();
                 result.proof_data = proof.proof_data;
             }
         } else {
-            auto prover = composer.create_prover();
+            auto prover = composer.create_ultra_with_keccak_prover();
             auto proof = prover.construct_proof();
             result.proof_data = proof.proof_data;
         }
@@ -108,12 +108,12 @@ auto verify_internal(Composer& composer, Tx& tx, CircuitData const& cd, char con
                 auto proof = prover.construct_proof();
                 result.proof_data = proof.proof_data;
             } else {
-                auto prover = mock_proof_composer.create_prover();
+                auto prover = mock_proof_composer.create_ultra_with_keccak_prover();
                 auto proof = prover.construct_proof();
                 result.proof_data = proof.proof_data;
             }
         } else {
-            auto prover = mock_proof_composer.create_prover();
+            auto prover = mock_proof_composer.create_ultra_with_keccak_prover();
             auto proof = prover.construct_proof();
             result.proof_data = proof.proof_data;
         }
@@ -126,11 +126,11 @@ auto verify_internal(Composer& composer, Tx& tx, CircuitData const& cd, char con
             auto verifier = composer.create_ultra_to_standard_verifier();
             result.verified = verifier.verify_proof({ result.proof_data });
         } else {
-            auto verifier = composer.create_verifier();
+            auto verifier = composer.create_ultra_with_keccak_verifier();
             result.verified = verifier.verify_proof({ result.proof_data });
         }
     } else {
-        auto verifier = composer.create_verifier();
+        auto verifier = composer.create_ultra_with_keccak_verifier();
         result.verified = verifier.verify_proof({ result.proof_data });
     }
 

--- a/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
@@ -890,6 +890,50 @@ UltraToStandardProver UltraComposer::create_ultra_to_standard_prover()
     return output_state;
 }
 
+/**
+ * @brief Uses slightly different settings from the UltraProver.
+ */
+UltraWithKeccakProver UltraComposer::create_ultra_with_keccak_prover()
+{
+    compute_proving_key();
+    compute_witness();
+
+    UltraWithKeccakProver output_state(circuit_proving_key, create_manifest(public_inputs.size()));
+
+    std::unique_ptr<ProverPermutationWidget<4, true>> permutation_widget =
+        std::make_unique<ProverPermutationWidget<4, true>>(circuit_proving_key.get());
+
+    std::unique_ptr<ProverPlookupWidget<>> plookup_widget =
+        std::make_unique<ProverPlookupWidget<>>(circuit_proving_key.get());
+
+    std::unique_ptr<ProverPlookupArithmeticWidget<ultra_with_keccak_settings>> arithmetic_widget =
+        std::make_unique<ProverPlookupArithmeticWidget<ultra_with_keccak_settings>>(circuit_proving_key.get());
+
+    std::unique_ptr<ProverGenPermSortWidget<ultra_with_keccak_settings>> sort_widget =
+        std::make_unique<ProverGenPermSortWidget<ultra_with_keccak_settings>>(circuit_proving_key.get());
+
+    std::unique_ptr<ProverEllipticWidget<ultra_with_keccak_settings>> elliptic_widget =
+        std::make_unique<ProverEllipticWidget<ultra_with_keccak_settings>>(circuit_proving_key.get());
+
+    std::unique_ptr<ProverPlookupAuxiliaryWidget<ultra_with_keccak_settings>> auxiliary_widget =
+        std::make_unique<ProverPlookupAuxiliaryWidget<ultra_with_keccak_settings>>(circuit_proving_key.get());
+
+    output_state.random_widgets.emplace_back(std::move(permutation_widget));
+    output_state.random_widgets.emplace_back(std::move(plookup_widget));
+
+    output_state.transition_widgets.emplace_back(std::move(arithmetic_widget));
+    output_state.transition_widgets.emplace_back(std::move(sort_widget));
+    output_state.transition_widgets.emplace_back(std::move(elliptic_widget));
+    output_state.transition_widgets.emplace_back(std::move(auxiliary_widget));
+
+    std::unique_ptr<KateCommitmentScheme<ultra_with_keccak_settings>> kate_commitment_scheme =
+        std::make_unique<KateCommitmentScheme<ultra_with_keccak_settings>>();
+
+    output_state.commitment_scheme = std::move(kate_commitment_scheme);
+
+    return output_state;
+}
+
 UltraVerifier UltraComposer::create_verifier()
 {
     compute_verification_key();
@@ -912,6 +956,20 @@ UltraToStandardVerifier UltraComposer::create_ultra_to_standard_verifier()
 
     std::unique_ptr<KateCommitmentScheme<ultra_to_standard_settings>> kate_commitment_scheme =
         std::make_unique<KateCommitmentScheme<ultra_to_standard_settings>>();
+
+    output_state.commitment_scheme = std::move(kate_commitment_scheme);
+
+    return output_state;
+}
+
+UltraWithKeccakVerifier UltraComposer::create_ultra_with_keccak_verifier()
+{
+    compute_verification_key();
+
+    UltraWithKeccakVerifier output_state(circuit_verification_key, create_manifest(public_inputs.size()));
+
+    std::unique_ptr<KateCommitmentScheme<ultra_with_keccak_settings>> kate_commitment_scheme =
+        std::make_unique<KateCommitmentScheme<ultra_with_keccak_settings>>();
 
     output_state.commitment_scheme = std::move(kate_commitment_scheme);
 

--- a/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
+++ b/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
@@ -160,6 +160,9 @@ class UltraComposer : public ComposerBase {
     UltraToStandardProver create_ultra_to_standard_prover();
     UltraToStandardVerifier create_ultra_to_standard_verifier();
 
+    UltraWithKeccakProver create_ultra_with_keccak_prover();
+    UltraWithKeccakVerifier create_ultra_with_keccak_verifier();
+
     void create_add_gate(const add_triple& in) override;
 
     void create_big_add_gate(const add_quad& in, const bool use_next_gate_w_4 = false);

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
@@ -392,4 +392,5 @@ template class KateCommitmentScheme<standard_settings>;
 template class KateCommitmentScheme<turbo_settings>;
 template class KateCommitmentScheme<ultra_settings>;
 template class KateCommitmentScheme<ultra_to_standard_settings>;
+template class KateCommitmentScheme<ultra_with_keccak_settings>;
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.hpp
@@ -43,5 +43,6 @@ extern template class KateCommitmentScheme<standard_settings>;
 extern template class KateCommitmentScheme<turbo_settings>;
 extern template class KateCommitmentScheme<ultra_settings>;
 extern template class KateCommitmentScheme<ultra_to_standard_settings>;
+extern template class KateCommitmentScheme<ultra_with_keccak_settings>;
 
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
@@ -1,5 +1,6 @@
 #include "prover.hpp"
 #include "../public_inputs/public_inputs.hpp"
+#include "barretenberg/plonk/proof_system/types/prover_settings.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 #include <chrono>
 #include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
@@ -639,5 +640,6 @@ template class ProverBase<standard_settings>;
 template class ProverBase<turbo_settings>;
 template class ProverBase<ultra_settings>;
 template class ProverBase<ultra_to_standard_settings>;
+template class ProverBase<ultra_with_keccak_settings>;
 
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
@@ -109,5 +109,6 @@ typedef ProverBase<ultra_settings> UltraProver; // TODO(Mike): maybe just return
                                                 // need separate cases for ultra vs ultra_to_standard...???
                                                 // TODO(Cody): Make this into an issue?
 typedef ProverBase<ultra_to_standard_settings> UltraToStandardProver;
+typedef ProverBase<ultra_with_keccak_settings> UltraWithKeccakProver;
 
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/plonk/proof_system/types/program_settings.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/types/program_settings.hpp
@@ -187,4 +187,20 @@ class ultra_to_standard_verifier_settings : public ultra_verifier_settings {
     static constexpr transcript::HashType hash_type = transcript::HashType::PedersenBlake3s;
 };
 
+// This is neededed for the Noir backend. The ultra verifier contract uses 32-byte challenges generated with Keccak256.
+class ultra_with_keccak_verifier_settings : public ultra_verifier_settings {
+  public:
+    typedef VerifierPlookupArithmeticWidget<fr, g1::affine_element, Transcript, ultra_with_keccak_settings>
+        PlookupArithmeticWidget;
+    typedef VerifierGenPermSortWidget<fr, g1::affine_element, Transcript, ultra_with_keccak_settings> GenPermSortWidget;
+    typedef VerifierTurboLogicWidget<fr, g1::affine_element, Transcript, ultra_with_keccak_settings> TurboLogicWidget;
+    typedef VerifierPermutationWidget<fr, g1::affine_element, Transcript> PermutationWidget;
+    typedef VerifierPlookupWidget<fr, g1::affine_element, Transcript> PlookupWidget;
+    typedef VerifierEllipticWidget<fr, g1::affine_element, Transcript, ultra_with_keccak_settings> EllipticWidget;
+    typedef VerifierPlookupAuxiliaryWidget<fr, g1::affine_element, Transcript, ultra_with_keccak_settings>
+        PlookupAuxiliaryWidget;
+
+    static constexpr size_t num_challenge_bytes = 32;
+    static constexpr transcript::HashType hash_type = transcript::HashType::Keccak256;
+};
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/plonk/proof_system/types/prover_settings.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/types/prover_settings.hpp
@@ -57,4 +57,12 @@ class ultra_to_standard_settings : public ultra_settings {
     static constexpr transcript::HashType hash_type = transcript::HashType::PedersenBlake3s;
 };
 
+// Only needed because ultra-to-standard recursion requires us to use a Pedersen hash which is common to both Ultra &
+// Standard plonk i.e. the non-ultra version.
+class ultra_with_keccak_settings : public ultra_settings {
+  public:
+    static constexpr size_t num_challenge_bytes = 32;
+    static constexpr transcript::HashType hash_type = transcript::HashType::Keccak256;
+};
+
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.cpp
+++ b/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.cpp
@@ -241,5 +241,6 @@ template class VerifierBase<standard_verifier_settings>;
 template class VerifierBase<turbo_verifier_settings>;
 template class VerifierBase<ultra_verifier_settings>;
 template class VerifierBase<ultra_to_standard_verifier_settings>;
+template class VerifierBase<ultra_with_keccak_verifier_settings>;
 
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.hpp
@@ -32,10 +32,11 @@ extern template class VerifierBase<standard_verifier_settings>;
 extern template class VerifierBase<turbo_verifier_settings>;
 extern template class VerifierBase<ultra_verifier_settings>;
 extern template class VerifierBase<ultra_to_standard_verifier_settings>;
+extern template class VerifierBase<ultra_with_keccak_verifier_settings>;
 
 typedef VerifierBase<standard_verifier_settings> Verifier;
 typedef VerifierBase<turbo_verifier_settings> TurboVerifier;
 typedef VerifierBase<ultra_verifier_settings> UltraVerifier;
 typedef VerifierBase<ultra_to_standard_verifier_settings> UltraToStandardVerifier;
-
+typedef VerifierBase<ultra_with_keccak_verifier_settings> UltraWithKeccakVerifier;
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.test.cpp
+++ b/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.test.cpp
@@ -33,10 +33,10 @@ auto run_scalar_mul_test = [](grumpkin::fr scalar_mont, bool expect_verify) {
         EXPECT_EQ(output.y.get_value(), expected.y);
     };
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     info("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -152,10 +152,10 @@ TEST(stdlib_schnorr, convert_field_into_wnaf)
     field_ct input(&composer, scalar);
     convert_field_into_wnaf(&composer, input);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     info("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -208,9 +208,9 @@ TEST(stdlib_schnorr, verify_signature)
         byte_array_ct message(&composer, message_string);
         stdlib::schnorr::verify_signature(message, pub_key, sig);
 
-        auto prover = composer.create_prover();
+        auto prover = composer.create_ultra_with_keccak_prover();
         info("composer gates = %zu\n", composer.get_num_gates());
-        auto verifier = composer.create_verifier();
+        auto verifier = composer.create_ultra_with_keccak_verifier();
         plonk::proof proof = prover.construct_proof();
         bool result = verifier.verify_proof(proof);
         EXPECT_EQ(result, true);
@@ -252,10 +252,10 @@ TEST(stdlib_schnorr, verify_signature_failure)
     byte_array_ct message(&composer, message_string);
     stdlib::schnorr::verify_signature(message, pub_key2_ct, sig);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     info("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -291,9 +291,9 @@ TEST(stdlib_schnorr, signature_verification_result)
     bool_ct signature_result = stdlib::schnorr::signature_verification_result(message, pub_key, sig);
     EXPECT_EQ(signature_result.witness_bool, true);
 
-    plonk::stdlib::types::Prover prover = composer.create_prover();
+    plonk::stdlib::types::Prover prover = composer.create_ultra_with_keccak_prover();
     info("composer gates = %zu\n", composer.get_num_gates());
-    plonk::stdlib::types::Verifier verifier = composer.create_verifier();
+    plonk::stdlib::types::Verifier verifier = composer.create_ultra_with_keccak_verifier();
     plonk::proof proof = prover.construct_proof();
     bool result = verifier.verify_proof(proof);
     EXPECT_EQ(result, true);
@@ -335,9 +335,9 @@ TEST(stdlib_schnorr, signature_verification_result_failure)
     bool_ct signature_result = stdlib::schnorr::signature_verification_result(message, pub_key2_ct, sig);
     EXPECT_EQ(signature_result.witness_bool, false);
 
-    plonk::stdlib::types::Prover prover = composer.create_prover();
+    plonk::stdlib::types::Prover prover = composer.create_ultra_with_keccak_prover();
     info("composer gates = %zu\n", composer.get_num_gates());
-    plonk::stdlib::types::Verifier verifier = composer.create_verifier();
+    plonk::stdlib::types::Verifier verifier = composer.create_ultra_with_keccak_verifier();
     plonk::proof proof = prover.construct_proof();
     bool verification_result = verifier.verify_proof(proof);
     EXPECT_EQ(verification_result, true);

--- a/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -26,10 +26,10 @@ TEST(stdlib_blake2s, test_single_block)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     auto proof = prover.construct_proof();
 
@@ -50,10 +50,10 @@ TEST(stdlib_blake2s, test_single_block_plookup)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     std::cout << "prover gates = " << prover.circuit_size << std::endl;
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     auto proof = prover.construct_proof();
 
@@ -74,10 +74,10 @@ TEST(stdlib_blake2s, test_double_block)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     auto proof = prover.construct_proof();
 
@@ -98,10 +98,10 @@ TEST(stdlib_blake2s, test_double_block_plookup)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     std::cout << "prover gates = " << prover.circuit_size << std::endl;
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     auto proof = prover.construct_proof();
 

--- a/cpp/src/barretenberg/stdlib/hash/sha256/sha256.bench.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/sha256/sha256.bench.cpp
@@ -47,7 +47,7 @@ void preprocess_witnesses_bench(State& state) noexcept
 {
     for (auto _ : state) {
         size_t idx = (static_cast<size_t>((state.range(0))) - START_BYTES) / BYTES_PER_CHUNK;
-        provers[idx] = composers[idx].create_prover();
+        provers[idx] = composers[idx].create_ultra_with_keccak_prover();
         std::cout << "prover subgroup size = " << provers[idx].key->small_domain.size << std::endl;
         // printf("num bytes = %" PRIx64 ", num gates = %zu\n", state.range(0), composers[idx].get_num_gates());
     }
@@ -58,7 +58,7 @@ void construct_instances_bench(State& state) noexcept
 {
     for (auto _ : state) {
         size_t idx = (static_cast<size_t>((state.range(0))) - START_BYTES) / BYTES_PER_CHUNK;
-        verifiers[idx] = composers[idx].create_verifier();
+        verifiers[idx] = composers[idx].create_ultra_with_keccak_verifier();
     }
 }
 BENCHMARK(construct_instances_bench)->DenseRange(START_BYTES, MAX_BYTES, BYTES_PER_CHUNK);

--- a/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
@@ -222,9 +222,9 @@ TEST(stdlib_sha256, test_55_bytes)
     EXPECT_EQ(output[7].get_value(), fr(0x93791fc7ULL));
     printf("composer gates = %zu\n", composer.get_num_gates());
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
     printf("constructing proof \n");
     plonk::proof proof = prover.construct_proof();
     printf("constructed proof \n");
@@ -252,9 +252,9 @@ TEST(stdlib_sha256, test_NIST_vector_one_packed_byte_array)
     EXPECT_EQ(uint256_t(output[7].get_value()).data[0], (uint64_t)0xF20015ADU);
     printf("composer gates = %zu\n", composer.get_num_gates());
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
     printf("constructing proof \n");
     plonk::proof proof = prover.construct_proof();
     printf("constructed proof \n");
@@ -317,9 +317,9 @@ TEST(stdlib_sha256, test_NIST_vector_two)
     EXPECT_EQ(output[7].get_value(), 0x19DB06C1ULL);
     printf("composer gates = %zu\n", composer.get_num_gates());
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
     printf("constructing proof \n");
     plonk::proof proof = prover.construct_proof();
     printf("constructed proof \n");
@@ -349,9 +349,9 @@ TEST(stdlib_sha256, test_NIST_vector_three)
     EXPECT_EQ(output[7].get_value(), 0x8ffe732bULL);
     printf("composer gates = %zu\n", composer.get_num_gates());
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -379,10 +379,10 @@ TEST(stdlib_sha256, test_NIST_vector_four)
     EXPECT_EQ(output[6].get_value(), 0xbd56c61cULL);
     EXPECT_EQ(output[7].get_value(), 0xcccd9504ULL);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 

--- a/cpp/src/barretenberg/stdlib/merkle_tree/membership.test.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/membership.test.cpp
@@ -32,10 +32,10 @@ TEST(stdlib_merkle_tree, test_check_membership)
     bool_ct is_member_ =
         check_membership(root, create_witness_hash_path(composer, db.get_hash_path(1)), field_ct(1), seven);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     printf("composer gates = %zu\n", composer.get_num_gates());
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -66,9 +66,9 @@ TEST(stdlib_merkle_tree, test_batch_update_membership)
     field_ct start_idx = field_ct(witness_ct(&composer, fr(4)));
     batch_update_membership(new_root, old_root, old_hash_path_1, values, start_idx);
     batch_update_membership(new_root, old_root, old_hash_path_2, values, start_idx);
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
     plonk::proof proof = prover.construct_proof();
     bool result = verifier.verify_proof(proof);
     EXPECT_EQ(result, true);
@@ -85,10 +85,10 @@ TEST(stdlib_merkle_tree, test_assert_check_membership)
 
     assert_check_membership(root, create_witness_hash_path(composer, db.get_hash_path(0)), field_ct(0), zero);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     printf("composer gates = %zu\n", composer.get_num_gates());
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -108,10 +108,10 @@ TEST(stdlib_merkle_tree, test_assert_check_membership_fail)
 
     assert_check_membership(root, create_witness_hash_path(composer, db.get_hash_path(0)), field_ct(1), zero);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     printf("composer gates = %zu\n", composer.get_num_gates());
 
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -140,10 +140,10 @@ TEST(stdlib_merkle_tree, test_update_members)
 
         update_membership(new_root, new_value, old_root, old_path, old_value, zero);
 
-        auto prover = composer.create_prover();
+        auto prover = composer.create_ultra_with_keccak_prover();
 
         printf("composer gates = %zu\n", composer.get_num_gates());
-        auto verifier = composer.create_verifier();
+        auto verifier = composer.create_ultra_with_keccak_verifier();
 
         plonk::proof proof = prover.construct_proof();
 
@@ -169,10 +169,10 @@ TEST(stdlib_merkle_tree, test_update_members)
 
         update_membership(new_root, new_value, old_root, new_path, old_value, zero);
 
-        auto prover = composer.create_prover();
+        auto prover = composer.create_ultra_with_keccak_prover();
 
         printf("composer gates = %zu\n", composer.get_num_gates());
-        auto verifier = composer.create_verifier();
+        auto verifier = composer.create_ultra_with_keccak_verifier();
 
         plonk::proof proof = prover.construct_proof();
 
@@ -197,10 +197,10 @@ TEST(stdlib_merkle_tree, test_tree)
 
     assert_check_tree(root, values);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
 
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
 
     plonk::proof proof = prover.construct_proof();
 
@@ -266,9 +266,9 @@ TEST(stdlib_merkle_tree, test_update_memberships)
 
     update_memberships(old_root_ct, new_roots_ct, new_values_ct, old_values_ct, old_hash_paths_ct, old_indices_ct);
 
-    auto prover = composer.create_prover();
+    auto prover = composer.create_ultra_with_keccak_prover();
     printf("composer gates = %zu\n", composer.get_num_gates());
-    auto verifier = composer.create_verifier();
+    auto verifier = composer.create_ultra_with_keccak_verifier();
     plonk::proof proof = prover.construct_proof();
     bool result = verifier.verify_proof(proof);
     EXPECT_EQ(result, true);

--- a/cpp/src/barretenberg/stdlib/types/types.hpp
+++ b/cpp/src/barretenberg/stdlib/types/types.hpp
@@ -3,6 +3,7 @@
 #include "barretenberg/plonk/composer/standard_composer.hpp"
 #include "barretenberg/plonk/composer/turbo_composer.hpp"
 #include "barretenberg/plonk/composer/ultra_composer.hpp"
+#include "barretenberg/plonk/proof_system/prover/prover.hpp"
 #include "barretenberg/stdlib/primitives/bigfield/bigfield.hpp"
 #include "barretenberg/stdlib/primitives/biggroup/biggroup.hpp"
 #include "barretenberg/stdlib/primitives/bit_array/bit_array.hpp"
@@ -39,25 +40,13 @@ typedef std::conditional_t<
 typedef std::conditional_t<
     SYSTEM_COMPOSER == proof_system::STANDARD,
     plonk::Prover,
-    std::conditional_t<SYSTEM_COMPOSER == proof_system::TURBO, plonk::TurboProver, plonk::UltraProver>>
+    std::conditional_t<SYSTEM_COMPOSER == proof_system::TURBO, plonk::TurboProver, plonk::UltraWithKeccakProver>>
     Prover;
 
 typedef std::conditional_t<
     SYSTEM_COMPOSER == proof_system::STANDARD,
     plonk::Verifier,
-    std::conditional_t<SYSTEM_COMPOSER == proof_system::TURBO, plonk::TurboVerifier, plonk::UltraVerifier>>
-    Verifier;
-
-typedef std::conditional_t<
-    SYSTEM_COMPOSER == proof_system::STANDARD,
-    plonk::Prover,
-    std::conditional_t<SYSTEM_COMPOSER == proof_system::TURBO, plonk::TurboProver, plonk::UltraProver>>
-    Prover;
-
-typedef std::conditional_t<
-    SYSTEM_COMPOSER == proof_system::STANDARD,
-    plonk::Verifier,
-    std::conditional_t<SYSTEM_COMPOSER == proof_system::TURBO, plonk::TurboVerifier, plonk::UltraVerifier>>
+    std::conditional_t<SYSTEM_COMPOSER == proof_system::TURBO, plonk::TurboVerifier, plonk::UltraWithKeccakVerifier>>
     Verifier;
 
 typedef stdlib::witness_t<Composer> witness_ct;


### PR DESCRIPTION
# Description
Adds prover and verifier settings to generate verifier 32-byte verifier challenges using Keccak256. We follow the model set by @iAmMichaelConnor and @suyash67 in their work on standard plonk verification of ultra plonk proofs.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
