### PR TITLE
feat(packages): Add debug output to nix builds

### DIFF
--- a/barretenberg-wasm.nix
+++ b/barretenberg-wasm.nix
@@ -1,11 +1,13 @@
-{ stdenv, cmake, ninja, binaryen, callPackage }:
+{ lib, stdenv, cmake, ninja, binaryen, callPackage, debug ? false }:
 let
+  optionals = lib.lists.optionals;
+
   toolchain_file = ./cpp/cmake/toolchains/wasm32-wasi.cmake;
   wasi-sdk = callPackage ./wasi-sdk.nix { };
 in
 stdenv.mkDerivation
 {
-  pname = "barretenberg.wasm";
+  pname = if debug then "barretenberg-debug.wasm" else "barretenberg.wasm";
   version = "0.1.0";
 
   src = ./cpp;
@@ -29,7 +31,11 @@ stdenv.mkDerivation
     "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY"
     "-DCMAKE_C_COMPILER_WORKS=ON"
     "-DCMAKE_CXX_COMPILER_WORKS=ON"
-  ];
+    
+  ] ++ (if debug then [ "-DCMAKE_BUILD_TYPE=Debug" ] else [ "-DCMAKE_BUILD_TYPE=Release" ]);
+  
+
+  CXXFLAGS = optionals (debug) [ "-ggdb -O1" ];
 
   enableParallelBuilding = true;
 }

--- a/barretenberg-wasm.nix
+++ b/barretenberg-wasm.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cmake, ninja, binaryen, callPackage, debug ? false }:
+{ lib, stdenv, cmake, ninja, binaryen, callPackage, DEBUG ? false }:
 let
   optionals = lib.lists.optionals;
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,8 @@
       barretenbergOverlay = final: prev: {
         barretenberg = prev.callPackage ./barretenberg.nix { };
         barretenberg-wasm = prev.callPackage ./barretenberg-wasm.nix { };
+        barretenberg-wasm-debug = prev.callPackage ./barretenberg-wasm.nix { debug = true; };
+
         barretenberg-transcript00 = prev.fetchurl {
           url = "http://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/monomial/transcript00.dat";
           sha256 = "sha256-D5SzlCb1pX0aF3QmJPfTFwoy4Z1sXhbyAigUOdvkhpU=";
@@ -63,6 +65,15 @@
               llvmPackages = pkgs.llvmPackages_14;
             };
             wasm32 = pkgs.barretenberg-wasm;
+
+            # Produced artifact will referrence source files from
+            # `/build/...` path which is incorrect in context of debugger loading those sources
+            # Use 
+            # GDB's set substitute-path 
+            # LLDB's set target.source-map
+            # Chrome's [C/C++ DevTools Support (DWARF)](https://chrome.google.com/webstore/detail/cc%20%20-devtools-support-dwa/pdcpmagijalfljmkmjngeonclgbbannb)
+            # to correct it
+            wasm32-debug = pkgs.barretenberg-wasm-debug;
 
             default = packages.llvm11;
           } // crossTargets;


### PR DESCRIPTION
# Description

Adding new package output for `nix build` command to allow for easy wasm target with debug symbols. Among others this allow to debug cpp code in browser.

Use with `nix build git+https://github.com/AztecProtocol/barretenberg#wasm32`

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
