### PR TITLE
feat(nullifier_tree): make empty nullifier tree leaves hash be 0

### DIFF
--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
@@ -45,26 +45,47 @@ struct nullifier_leaf {
  * @brief Wrapper for the Nullifier leaf class that allows for 0 values
  *
  */
-// TODO: clean up semantics
-class NullifierLeaf {
+class WrappedNullifierLeaf {
 
   public:
-    NullifierLeaf(nullifier_leaf value)
+    // Initialise with a nullifier leaf
+    WrappedNullifierLeaf(nullifier_leaf value)
         : data(value)
     {}
-    NullifierLeaf()
+    // Initialise an empty leaf
+    WrappedNullifierLeaf()
         : data(std::nullopt)
     {}
 
-    bool operator==(NullifierLeaf const&) const = default;
+    bool operator==(WrappedNullifierLeaf const&) const = default;
 
+    /**
+     * @brief Pass through the underlying std::optional method
+     *
+     * @return true
+     * @return false
+     */
     bool has_value() const { return data.has_value(); }
 
+    /**
+     * @brief Return the wrapped nullifier_leaf object
+     *
+     * @return nullifier_leaf
+     */
     nullifier_leaf unwrap() const { return data.value(); }
 
+    /**
+     * @brief Set the wrapped nullifier_leaf object value
+     *
+     * @param value
+     */
     void set(nullifier_leaf value) { data.emplace(value); }
 
-    // TODO: work out how to serialise this whole object
+    /**
+     * @brief Return the hash of the wrapped object, other return the zero hash of 0
+     *
+     * @return barretenberg::fr
+     */
     barretenberg::fr hash() const
     {
         if (data.has_value()) {
@@ -74,13 +95,19 @@ class NullifierLeaf {
         }
     }
 
-    static NullifierLeaf zero() { return NullifierLeaf(); }
+    /**
+     * @brief Generate a zero leaf (call the constructor with no arguments)
+     *
+     * @return NullifierLeaf
+     */
+    static WrappedNullifierLeaf zero() { return WrappedNullifierLeaf(); }
 
   private:
+    // Underlying data
     std::optional<nullifier_leaf> data;
 };
 
-inline std::pair<size_t, bool> find_closest_leaf(std::vector<NullifierLeaf> const& leaves_, fr const& new_value)
+inline std::pair<size_t, bool> find_closest_leaf(std::vector<WrappedNullifierLeaf> const& leaves_, fr const& new_value)
 {
     std::vector<uint256_t> diff;
     bool repeated = false;

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
@@ -3,7 +3,6 @@
 
 namespace proof_system::plonk {
 namespace stdlib {
-
 namespace merkle_tree {
 
 using namespace barretenberg;
@@ -86,14 +85,7 @@ class WrappedNullifierLeaf {
      *
      * @return barretenberg::fr
      */
-    barretenberg::fr hash() const
-    {
-        if (data.has_value()) {
-            return data.value().hash();
-        } else {
-            return barretenberg::fr::zero();
-        }
-    }
+    barretenberg::fr hash() const { return data.has_value() ? data.value().hash() : barretenberg::fr::zero(); }
 
     /**
      * @brief Generate a zero leaf (call the constructor with no arguments)

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -12,11 +12,8 @@ NullifierMemoryTree::NullifierMemoryTree(size_t depth)
     total_size_ = 1UL << depth_;
     hashes_.resize(total_size_ * 2 - 2);
 
-    // Build the entire tree.
-    nullifier_leaf zero_leaf = { 0, 0, 0 };
-    leaves_.push_back(zero_leaf);
-    auto current = zero_leaf.hash();
-    update_element(0, current);
+    // Build the entire tree and fill with 0 hashes.
+    auto current = NullifierLeaf::zero().hash();
     size_t layer_size = total_size_;
     for (size_t offset = 0; offset < hashes_.size(); offset += layer_size, layer_size /= 2) {
         for (size_t i = 0; i < layer_size; ++i) {
@@ -25,7 +22,10 @@ NullifierMemoryTree::NullifierMemoryTree(size_t depth)
         current = hash_pair_native(current, current);
     }
 
-    root_ = current;
+    // Insert the initial leaf at index 0
+    auto initial_leaf = NullifierLeaf(nullifier_leaf{ .value = 0, .nextIndex = 0, .nextValue = 0 });
+    leaves_.push_back(initial_leaf);
+    root_ = update_element(0, initial_leaf.hash());
 }
 
 fr NullifierMemoryTree::update_element(fr const& value)
@@ -35,20 +35,24 @@ fr NullifierMemoryTree::update_element(fr const& value)
     bool is_already_present;
     std::tie(current, is_already_present) = find_closest_leaf(leaves_, value);
 
+    nullifier_leaf current_leaf = leaves_[current].unwrap();
     nullifier_leaf new_leaf = { .value = value,
-                                .nextIndex = leaves_[current].nextIndex,
-                                .nextValue = leaves_[current].nextValue };
+                                .nextIndex = current_leaf.nextIndex,
+                                .nextValue = current_leaf.nextValue };
+
     if (!is_already_present) {
         // Update the current leaf to point it to the new leaf
-        leaves_[current].nextIndex = leaves_.size();
-        leaves_[current].nextValue = value;
+        current_leaf.nextIndex = leaves_.size();
+        current_leaf.nextValue = value;
+
+        leaves_[current].set(current_leaf);
 
         // Insert the new leaf with (nextIndex, nextValue) of the current leaf
         leaves_.push_back(new_leaf);
     }
 
     // Update the old leaf in the tree
-    auto old_leaf_hash = leaves_[current].hash();
+    auto old_leaf_hash = current_leaf.hash();
     size_t old_leaf_index = current;
     auto root = update_element(old_leaf_index, old_leaf_hash);
 

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -31,6 +31,14 @@ NullifierMemoryTree::NullifierMemoryTree(size_t depth)
 fr NullifierMemoryTree::update_element(fr const& value)
 {
     // Find the leaf with the value closest and less than `value`
+    
+    // If value is 0 we simply append 0 a null NullifierLeaf to the tree
+    if (value == 0) {
+        NullifierLeaf zero_leaf = NullifierLeaf::zero();
+        leaves_.push_back(zero_leaf);
+        return update_element(leaves_.size() - 1, zero_leaf.hash());
+    }
+
     size_t current;
     bool is_already_present;
     std::tie(current, is_already_present) = find_closest_leaf(leaves_, value);

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -13,7 +13,7 @@ NullifierMemoryTree::NullifierMemoryTree(size_t depth)
     hashes_.resize(total_size_ * 2 - 2);
 
     // Build the entire tree and fill with 0 hashes.
-    auto current = NullifierLeaf::zero().hash();
+    auto current = WrappedNullifierLeaf::zero().hash();
     size_t layer_size = total_size_;
     for (size_t offset = 0; offset < hashes_.size(); offset += layer_size, layer_size /= 2) {
         for (size_t i = 0; i < layer_size; ++i) {
@@ -23,7 +23,7 @@ NullifierMemoryTree::NullifierMemoryTree(size_t depth)
     }
 
     // Insert the initial leaf at index 0
-    auto initial_leaf = NullifierLeaf(nullifier_leaf{ .value = 0, .nextIndex = 0, .nextValue = 0 });
+    auto initial_leaf = WrappedNullifierLeaf(nullifier_leaf{ .value = 0, .nextIndex = 0, .nextValue = 0 });
     leaves_.push_back(initial_leaf);
     root_ = update_element(0, initial_leaf.hash());
 }

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -31,10 +31,10 @@ NullifierMemoryTree::NullifierMemoryTree(size_t depth)
 fr NullifierMemoryTree::update_element(fr const& value)
 {
     // Find the leaf with the value closest and less than `value`
-    
+
     // If value is 0 we simply append 0 a null NullifierLeaf to the tree
     if (value == 0) {
-        NullifierLeaf zero_leaf = NullifierLeaf::zero();
+        auto zero_leaf = WrappedNullifierLeaf::zero();
         leaves_.push_back(zero_leaf);
         return update_element(leaves_.size() - 1, zero_leaf.hash());
     }

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
@@ -79,15 +79,15 @@ class NullifierMemoryTree : public MemoryTree {
     fr update_element(fr const& value);
 
     const std::vector<barretenberg::fr>& get_hashes() { return hashes_; }
-    const std::vector<NullifierLeaf>& get_leaves() { return leaves_; }
-    const NullifierLeaf& get_leaf(size_t index) { return leaves_[index]; }
+    const std::vector<WrappedNullifierLeaf>& get_leaves() { return leaves_; }
+    const WrappedNullifierLeaf& get_leaf(size_t index) { return leaves_[index]; }
 
   protected:
     using MemoryTree::depth_;
     using MemoryTree::hashes_;
     using MemoryTree::root_;
     using MemoryTree::total_size_;
-    std::vector<NullifierLeaf> leaves_;
+    std::vector<WrappedNullifierLeaf> leaves_;
 };
 
 } // namespace merkle_tree

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
@@ -79,8 +79,11 @@ class NullifierMemoryTree : public MemoryTree {
     fr update_element(fr const& value);
 
     const std::vector<barretenberg::fr>& get_hashes() { return hashes_; }
+    const WrappedNullifierLeaf get_leaf(size_t index)
+    {
+        return (index < leaves_.size()) ? leaves_[index] : WrappedNullifierLeaf::zero();
+    }
     const std::vector<WrappedNullifierLeaf>& get_leaves() { return leaves_; }
-    const WrappedNullifierLeaf& get_leaf(size_t index) { return leaves_[index]; }
 
   protected:
     using MemoryTree::depth_;

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
@@ -68,6 +68,7 @@ using namespace barretenberg;
  *  nextVal   10      50      20      30       0       0       0       0
  */
 class NullifierMemoryTree : public MemoryTree {
+
   public:
     NullifierMemoryTree(size_t depth);
 
@@ -78,15 +79,15 @@ class NullifierMemoryTree : public MemoryTree {
     fr update_element(fr const& value);
 
     const std::vector<barretenberg::fr>& get_hashes() { return hashes_; }
-    const std::vector<nullifier_leaf>& get_leaves() { return leaves_; }
-    const nullifier_leaf& get_leaf(size_t index) { return leaves_[index]; }
+    const std::vector<NullifierLeaf>& get_leaves() { return leaves_; }
+    const NullifierLeaf& get_leaf(size_t index) { return leaves_[index]; }
 
   protected:
     using MemoryTree::depth_;
     using MemoryTree::hashes_;
     using MemoryTree::root_;
     using MemoryTree::total_size_;
-    std::vector<nullifier_leaf> leaves_;
+    std::vector<NullifierLeaf> leaves_;
 };
 
 } // namespace merkle_tree

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
@@ -127,9 +127,9 @@ TEST(crypto_nullifier_tree, test_nullifier_memory)
     auto e010 = tree.get_leaves()[2].hash();
     auto e011 = tree.get_leaves()[3].hash();
     auto e100 = tree.get_leaves()[4].hash();
-    auto e101 = NullifierLeaf::zero().hash();
-    auto e110 = NullifierLeaf::zero().hash();
-    auto e111 = NullifierLeaf::zero().hash();
+    auto e101 = WrappedNullifierLeaf::zero().hash();
+    auto e110 = WrappedNullifierLeaf::zero().hash();
+    auto e111 = WrappedNullifierLeaf::zero().hash();
 
     auto e00 = hash_pair_native(e000, e001);
     auto e01 = hash_pair_native(e010, e011);

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
@@ -62,8 +62,8 @@ TEST(crypto_nullifier_tree, test_nullifier_memory)
      */
     tree.update_element(30);
     EXPECT_EQ(tree.get_leaves().size(), 2);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), nullifier_leaf({ 0, 1, 30 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), nullifier_leaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
 
     /**
      * Add new value 10:
@@ -76,9 +76,9 @@ TEST(crypto_nullifier_tree, test_nullifier_memory)
      */
     tree.update_element(10);
     EXPECT_EQ(tree.get_leaves().size(), 3);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), nullifier_leaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), nullifier_leaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), nullifier_leaf({ 10, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 1, 30 }).hash());
 
     /**
      * Add new value 20:
@@ -91,18 +91,18 @@ TEST(crypto_nullifier_tree, test_nullifier_memory)
      */
     tree.update_element(20);
     EXPECT_EQ(tree.get_leaves().size(), 4);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), nullifier_leaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), nullifier_leaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), nullifier_leaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), nullifier_leaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
 
     // Adding the same value must not affect anything
     tree.update_element(20);
     EXPECT_EQ(tree.get_leaves().size(), 4);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), nullifier_leaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), nullifier_leaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), nullifier_leaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), nullifier_leaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
 
     /**
      * Add new value 50:
@@ -115,11 +115,11 @@ TEST(crypto_nullifier_tree, test_nullifier_memory)
      */
     tree.update_element(50);
     EXPECT_EQ(tree.get_leaves().size(), 5);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), nullifier_leaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), nullifier_leaf({ 30, 4, 50 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), nullifier_leaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), nullifier_leaf({ 20, 1, 30 }).hash());
-    EXPECT_EQ(tree.get_leaves()[4].hash(), nullifier_leaf({ 50, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 4, 50 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[4].hash(), WrappedNullifierLeaf({ 50, 0, 0 }).hash());
 
     // Manually compute the node values
     auto e000 = tree.get_leaves()[0].hash();
@@ -176,7 +176,7 @@ TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
      *  nextIdx   0       0       0       0        0       0       0       0
      *  nextVal   0       0       0       0        0       0       0       0
      */
-    nullifier_leaf zero_leaf = { 0, 0, 0 };
+    WrappedNullifierLeaf zero_leaf = WrappedNullifierLeaf({ 0, 0, 0 });
     EXPECT_EQ(tree.get_leaves().size(), 1);
     EXPECT_EQ(tree.get_leaves()[0], zero_leaf);
 
@@ -191,8 +191,8 @@ TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
      */
     tree.update_element(30);
     EXPECT_EQ(tree.get_leaves().size(), 2);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 1, 30 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
 
     /**
      * Add new value 10:
@@ -205,9 +205,9 @@ TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
      */
     tree.update_element(10);
     EXPECT_EQ(tree.get_leaves().size(), 3);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 1, 30 }).hash());
 
     /**
      * Add new value 20:
@@ -220,18 +220,18 @@ TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
      */
     tree.update_element(20);
     EXPECT_EQ(tree.get_leaves().size(), 4);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
 
     // Adding the same value must not affect anything
     tree.update_element(20);
     EXPECT_EQ(tree.get_leaves().size(), 4);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
 
     /**
      * Add new value 0:
@@ -244,11 +244,11 @@ TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
      */
     tree.update_element(0);
     EXPECT_EQ(tree.get_leaves().size(), 5);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
-    EXPECT_EQ(tree.get_leaves()[4].hash(), NullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[4].hash(), WrappedNullifierLeaf::zero().hash());
 
     /*
      * Add new value 0:
@@ -261,12 +261,12 @@ TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
      */
     tree.update_element(0);
     EXPECT_EQ(tree.get_leaves().size(), 6);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
-    EXPECT_EQ(tree.get_leaves()[4].hash(), NullifierLeaf::zero().hash());
-    EXPECT_EQ(tree.get_leaves()[5].hash(), NullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaves()[0].hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), WrappedNullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[4].hash(), WrappedNullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaves()[5].hash(), WrappedNullifierLeaf::zero().hash());
 
     /**
      * Add new value 50:
@@ -279,23 +279,24 @@ TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
      */
     tree.update_element(50);
     EXPECT_EQ(tree.get_leaves().size(), 7);
-    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
-    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 6, 50 }).hash());
-    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
-    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
-    EXPECT_EQ(tree.get_leaves()[4].hash(), NullifierLeaf::zero().hash());
-    EXPECT_EQ(tree.get_leaves()[5].hash(), NullifierLeaf::zero().hash());
-    EXPECT_EQ(tree.get_leaves()[6].hash(), NullifierLeaf({ 50, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaf(0).hash(), WrappedNullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaf(1).hash(), WrappedNullifierLeaf({ 30, 6, 50 }).hash());
+    EXPECT_EQ(tree.get_leaf(2).hash(), WrappedNullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaf(3).hash(), WrappedNullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaf(4).hash(), WrappedNullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaf(5).hash(), WrappedNullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaf(6).hash(), WrappedNullifierLeaf({ 50, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaf(7).hash(), WrappedNullifierLeaf::zero().hash());
 
     // Manually compute the node values
-    auto e000 = tree.get_leaves()[0].hash();
-    auto e001 = tree.get_leaves()[1].hash();
-    auto e010 = tree.get_leaves()[2].hash();
-    auto e011 = tree.get_leaves()[3].hash();
-    auto e100 = tree.get_leaves()[4].hash();
-    auto e101 = tree.get_leaves()[5].hash();
-    auto e110 = tree.get_leaves()[6].hash();
-    auto e111 = tree.get_leaves()[7].hash();
+    auto e000 = tree.get_leaf(0).hash();
+    auto e001 = tree.get_leaf(1).hash();
+    auto e010 = tree.get_leaf(2).hash();
+    auto e011 = tree.get_leaf(3).hash();
+    auto e100 = tree.get_leaf(4).hash();
+    auto e101 = tree.get_leaf(5).hash();
+    auto e110 = tree.get_leaf(6).hash();
+    auto e111 = tree.get_leaf(7).hash();
 
     auto e00 = hash_pair_native(e000, e001);
     auto e01 = hash_pair_native(e010, e011);

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
@@ -127,9 +127,9 @@ TEST(crypto_nullifier_tree, test_nullifier_memory)
     auto e010 = tree.get_leaves()[2].hash();
     auto e011 = tree.get_leaves()[3].hash();
     auto e100 = tree.get_leaves()[4].hash();
-    auto e101 = nullifier_leaf({ 0, 0, 0 }).hash();
-    auto e110 = nullifier_leaf({ 0, 0, 0 }).hash();
-    auto e111 = nullifier_leaf({ 0, 0, 0 }).hash();
+    auto e101 = NullifierLeaf::zero().hash();
+    auto e110 = NullifierLeaf::zero().hash();
+    auto e111 = NullifierLeaf::zero().hash();
 
     auto e00 = hash_pair_native(e000, e001);
     auto e01 = hash_pair_native(e010, e011);
@@ -190,8 +190,10 @@ TEST(crypto_nullifier_tree, test_nullifier_tree)
     const auto& leaves = tree.get_leaves();
     std::vector<uint256_t> differences;
     for (size_t i = 0; i < leaves.size(); i++) {
-        uint256_t diff_hi = abs_diff(uint256_t(new_member), uint256_t(leaves[i].value));
-        uint256_t diff_lo = abs_diff(uint256_t(new_member), uint256_t(leaves[i].nextValue));
+        uint256_t diff_hi =
+            abs_diff(uint256_t(new_member), uint256_t(leaves[i].has_value() ? leaves[i].unwrap().value : 0));
+        uint256_t diff_lo =
+            abs_diff(uint256_t(new_member), uint256_t(leaves[i].has_value() ? leaves[i].unwrap().nextValue : 0));
         differences.push_back(diff_hi + diff_lo);
     }
     auto it = std::min_element(differences.begin(), differences.end());
@@ -199,5 +201,5 @@ TEST(crypto_nullifier_tree, test_nullifier_tree)
 
     // Merkle proof at `index` proves non-membership of `new_member`
     auto hash_path = tree.get_hash_path(index);
-    EXPECT_TRUE(check_hash_path(tree.root(), hash_path, leaves[index], index));
+    EXPECT_TRUE(check_hash_path(tree.root(), hash_path, leaves[index].unwrap(), index));
 }

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
@@ -161,6 +161,171 @@ TEST(crypto_nullifier_tree, test_nullifier_memory)
     EXPECT_EQ(tree.get_hash_path(7), expected);
 }
 
+TEST(crypto_nullifier_tree, test_nullifier_memory_appending_zero)
+{
+    // Create a depth-3 indexed merkle tree
+    constexpr size_t depth = 3;
+    NullifierMemoryTree tree(depth);
+
+    /**
+     * Intial state:
+     *
+     *  index     0       1       2       3        4       5       6       7
+     *  ---------------------------------------------------------------------
+     *  val       0       0       0       0        0       0       0       0
+     *  nextIdx   0       0       0       0        0       0       0       0
+     *  nextVal   0       0       0       0        0       0       0       0
+     */
+    nullifier_leaf zero_leaf = { 0, 0, 0 };
+    EXPECT_EQ(tree.get_leaves().size(), 1);
+    EXPECT_EQ(tree.get_leaves()[0], zero_leaf);
+
+    /**
+     * Add new value 30:
+     *
+     *  index     0       1       2       3        4       5       6       7
+     *  ---------------------------------------------------------------------
+     *  val       0       30      0       0        0       0       0       0
+     *  nextIdx   1       0       0       0        0       0       0       0
+     *  nextVal   30      0       0       0        0       0       0       0
+     */
+    tree.update_element(30);
+    EXPECT_EQ(tree.get_leaves().size(), 2);
+    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
+
+    /**
+     * Add new value 10:
+     *
+     *  index     0       1       2       3        4       5       6       7
+     *  ---------------------------------------------------------------------
+     *  val       0       30      10      0        0       0       0       0
+     *  nextIdx   2       0       1       0        0       0       0       0
+     *  nextVal   10      0       30      0        0       0       0       0
+     */
+    tree.update_element(10);
+    EXPECT_EQ(tree.get_leaves().size(), 3);
+    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 1, 30 }).hash());
+
+    /**
+     * Add new value 20:
+     *
+     *  index     0       1       2       3        4       5       6       7
+     *  ---------------------------------------------------------------------
+     *  val       0       30      10      20       0       0       0       0
+     *  nextIdx   2       0       3       1        0       0       0       0
+     *  nextVal   10      0       20      30       0       0       0       0
+     */
+    tree.update_element(20);
+    EXPECT_EQ(tree.get_leaves().size(), 4);
+    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
+
+    // Adding the same value must not affect anything
+    tree.update_element(20);
+    EXPECT_EQ(tree.get_leaves().size(), 4);
+    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
+
+    /**
+     * Add new value 0:
+     *
+     *  index     0       1       2       3        4       5       6       7
+     *  ---------------------------------------------------------------------
+     *  val       0       30      10      20       0       0       0       0
+     *  nextIdx   2       0       3       1        0       0       0       0
+     *  nextVal   10      0       20      30       0       0       0       0
+     */
+    tree.update_element(0);
+    EXPECT_EQ(tree.get_leaves().size(), 5);
+    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[4].hash(), NullifierLeaf::zero().hash());
+
+    /*
+     * Add new value 0:
+     *
+     *  index     0       1       2       3        4       5       6       7
+     *  ---------------------------------------------------------------------
+     *  val       0       30      10      20       0       0       0       0
+     *  nextIdx   2       0       3       1        0       0       0       0
+     *  nextVal   10      0       20      30       0       0       0       0
+     */
+    tree.update_element(0);
+    EXPECT_EQ(tree.get_leaves().size(), 6);
+    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 0, 0 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[4].hash(), NullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaves()[5].hash(), NullifierLeaf::zero().hash());
+
+    /**
+     * Add new value 50:
+     *
+     *  index     0       1       2       3        4       5       6       7
+     *  ---------------------------------------------------------------------
+     *  val       0       30      10      20       0       0      50       0
+     *  nextIdx   2       6       3       1        0       0       0       0
+     *  nextVal   10      50      20      30       0       0       0       0
+     */
+    tree.update_element(50);
+    EXPECT_EQ(tree.get_leaves().size(), 7);
+    EXPECT_EQ(tree.get_leaves()[0].hash(), NullifierLeaf({ 0, 2, 10 }).hash());
+    EXPECT_EQ(tree.get_leaves()[1].hash(), NullifierLeaf({ 30, 6, 50 }).hash());
+    EXPECT_EQ(tree.get_leaves()[2].hash(), NullifierLeaf({ 10, 3, 20 }).hash());
+    EXPECT_EQ(tree.get_leaves()[3].hash(), NullifierLeaf({ 20, 1, 30 }).hash());
+    EXPECT_EQ(tree.get_leaves()[4].hash(), NullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaves()[5].hash(), NullifierLeaf::zero().hash());
+    EXPECT_EQ(tree.get_leaves()[6].hash(), NullifierLeaf({ 50, 0, 0 }).hash());
+
+    // Manually compute the node values
+    auto e000 = tree.get_leaves()[0].hash();
+    auto e001 = tree.get_leaves()[1].hash();
+    auto e010 = tree.get_leaves()[2].hash();
+    auto e011 = tree.get_leaves()[3].hash();
+    auto e100 = tree.get_leaves()[4].hash();
+    auto e101 = tree.get_leaves()[5].hash();
+    auto e110 = tree.get_leaves()[6].hash();
+    auto e111 = tree.get_leaves()[7].hash();
+
+    auto e00 = hash_pair_native(e000, e001);
+    auto e01 = hash_pair_native(e010, e011);
+    auto e10 = hash_pair_native(e100, e101);
+    auto e11 = hash_pair_native(e110, e111);
+
+    auto e0 = hash_pair_native(e00, e01);
+    auto e1 = hash_pair_native(e10, e11);
+    auto root = hash_pair_native(e0, e1);
+
+    // Check the hash path at index 2 and 3
+    // Note: This merkle proof would also serve as a non-membership proof of values in (10, 20) and (20, 30)
+    fr_hash_path expected = {
+        std::make_pair(e010, e011),
+        std::make_pair(e00, e01),
+        std::make_pair(e0, e1),
+    };
+    EXPECT_EQ(tree.get_hash_path(2), expected);
+    EXPECT_EQ(tree.get_hash_path(3), expected);
+    EXPECT_EQ(tree.root(), root);
+
+    // Check the hash path at index 6 and 7
+    expected = {
+        std::make_pair(e110, e111),
+        std::make_pair(e10, e11),
+        std::make_pair(e0, e1),
+    };
+    EXPECT_EQ(tree.get_hash_path(6), expected);
+    EXPECT_EQ(tree.get_hash_path(7), expected);
+}
 TEST(crypto_nullifier_tree, test_nullifier_tree)
 {
     // Create a depth-8 indexed merkle tree

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.cpp
@@ -29,12 +29,13 @@ NullifierTree<Store>::NullifierTree(Store& store, size_t depth, uint8_t tree_id)
 
     // Compute the zero values at each layer.
     // Insert the zero leaf to the `leaves` and also to the tree at index 0.
-    NullifierLeaf initial_leaf = NullifierLeaf(nullifier_leaf{ .value = 0, .nextIndex = 0, .nextValue = 0 });
+    WrappedNullifierLeaf initial_leaf =
+        WrappedNullifierLeaf(nullifier_leaf{ .value = 0, .nextIndex = 0, .nextValue = 0 });
     leaves.push_back(initial_leaf);
     update_element(0, initial_leaf.hash());
 
     // Create the zero hashes for the tree
-    auto current = NullifierLeaf::zero().hash();
+    auto current = WrappedNullifierLeaf::zero().hash();
     for (size_t i = 0; i < depth; ++i) {
         zero_hashes_[i] = current;
         current = hash_pair_native(current, current);
@@ -56,9 +57,8 @@ template <typename Store> fr NullifierTree<Store>::update_element(fr const& valu
     std::tie(current, is_already_present) = find_closest_leaf(leaves, value);
 
     nullifier_leaf current_leaf = leaves[current].unwrap();
-    nullifier_leaf new_leaf = { .value = value,
-                                .nextIndex = current_leaf.nextIndex,
-                                .nextValue = current_leaf.nextValue };
+    WrappedNullifierLeaf new_leaf = WrappedNullifierLeaf(
+        { .value = value, .nextIndex = current_leaf.nextIndex, .nextValue = current_leaf.nextValue });
     if (!is_already_present) {
         // Update the current leaf to point it to the new leaf
         current_leaf.nextIndex = leaves.size();

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.cpp
@@ -29,10 +29,12 @@ NullifierTree<Store>::NullifierTree(Store& store, size_t depth, uint8_t tree_id)
 
     // Compute the zero values at each layer.
     // Insert the zero leaf to the `leaves` and also to the tree at index 0.
-    auto zero_leaf = nullifier_leaf{ .value = 0, .nextIndex = 0, .nextValue = 0 };
-    leaves.push_back(zero_leaf);
-    auto current = zero_leaf.hash();
-    update_element(0, current);
+    NullifierLeaf initial_leaf = NullifierLeaf(nullifier_leaf{ .value = 0, .nextIndex = 0, .nextValue = 0 });
+    leaves.push_back(initial_leaf);
+    update_element(0, initial_leaf.hash());
+
+    // Create the zero hashes for the tree
+    auto current = NullifierLeaf::zero().hash();
     for (size_t i = 0; i < depth; ++i) {
         zero_hashes_[i] = current;
         current = hash_pair_native(current, current);
@@ -53,13 +55,16 @@ template <typename Store> fr NullifierTree<Store>::update_element(fr const& valu
     bool is_already_present;
     std::tie(current, is_already_present) = find_closest_leaf(leaves, value);
 
+    nullifier_leaf current_leaf = leaves[current].unwrap();
     nullifier_leaf new_leaf = { .value = value,
-                                .nextIndex = leaves[current].nextIndex,
-                                .nextValue = leaves[current].nextValue };
+                                .nextIndex = current_leaf.nextIndex,
+                                .nextValue = current_leaf.nextValue };
     if (!is_already_present) {
         // Update the current leaf to point it to the new leaf
-        leaves[current].nextIndex = leaves.size();
-        leaves[current].nextValue = value;
+        current_leaf.nextIndex = leaves.size();
+        current_leaf.nextValue = value;
+
+        leaves[current].set(current_leaf);
 
         // Insert the new leaf with (nextIndex, nextValue) of the current leaf
         leaves.push_back(new_leaf);

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp
@@ -35,7 +35,7 @@ template <typename Store> class NullifierTree : public MerkleTree<Store> {
     using MerkleTree<Store>::zero_hashes_;
     using MerkleTree<Store>::depth_;
     using MerkleTree<Store>::tree_id_;
-    std::vector<nullifier_leaf> leaves;
+    std::vector<NullifierLeaf> leaves;
 };
 
 extern template class NullifierTree<MemoryStore>;

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp
@@ -35,7 +35,7 @@ template <typename Store> class NullifierTree : public MerkleTree<Store> {
     using MerkleTree<Store>::zero_hashes_;
     using MerkleTree<Store>::depth_;
     using MerkleTree<Store>::tree_id_;
-    std::vector<NullifierLeaf> leaves;
+    std::vector<WrappedNullifierLeaf> leaves;
 };
 
 extern template class NullifierTree<MemoryStore>;


### PR DESCRIPTION
# Description

## Related Issue: https://github.com/AztecProtocol/aztec3-circuits/issues/161

Currently the Nullifier Tree implementation has an empty leaf hash which has a known preimage of (0,0,0). There are some concerns that as this is a valid preimage. The 0,0,0 preimage is sent as the empty low nullifier in the base rollup circuit. A malicious sequener may be able to construct kernel circuit proofs that reference this preimage.

A wrapper type has been used so that `.hash()` can be called without many changes. Otherwise a nasty if statement would need to be preset everytime in the code.

### Questions
In this PR I model that a nullifier leaf can be empty by creating a wrapper type `NullifierLeaf` that contains a `std::optional<nullifier_leaf>` within it. Can a more senior c++ engineer let me know how they feel about this, as I've modelled this around patterns I'm more familiar with from the rust ecosystem. 

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
