### PR TITLE
updating IPA to use transcript

### DIFF
--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -12,6 +12,7 @@
 #include "barretenberg/ecc/curves/bn254/pairing.hpp"
 #include "barretenberg/numeric/bitop/pow.hpp"
 
+#include <cstddef>
 #include <string_view>
 #include <memory>
 

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
@@ -36,26 +36,21 @@ TYPED_TEST(IpaCommitmentTest, commit)
 TYPED_TEST(IpaCommitmentTest, open)
 {
     using IPA = InnerProductArgument<TypeParam>;
-    using PubInput = typename IPA::PubInput;
     // generate a random polynomial, degree needs to be a power of two
     size_t n = 128;
     auto poly = this->random_polynomial(n);
     auto [x, eval] = this->random_eval(poly);
-    barretenberg::g1::element commitment = this->commit(poly);
-    PubInput pub_input;
-    pub_input.commitment = commitment;
-    pub_input.challenge_point = x;
-    pub_input.evaluation = eval;
-    pub_input.poly_degree = n;
-    auto aux_scalar = fr::random_element();
-    pub_input.aux_generator = barretenberg::g1::one * aux_scalar;
-    const size_t log_n = static_cast<size_t>(numeric::get_msb(n));
-    pub_input.round_challenges = std::vector<barretenberg::fr>(log_n);
-    for (size_t i = 0; i < log_n; i++) {
-        pub_input.round_challenges[i] = barretenberg::fr::random_element();
-    }
-    auto proof = IPA::reduce_prove(this->ck(), pub_input, poly);
-    auto result = IPA::reduce_verify(this->vk(), proof, pub_input);
+    auto commitment = this->commit(poly);
+    const OpeningPair<TypeParam> opening_pair{ x, eval };
+
+    auto prover_transcript = ProverTranscript<Fr>::init_empty();
+    prover_transcript.send_to_verifier("IPA:C", commitment);
+
+    IPA::reduce_prove(this->ck(), opening_pair, poly, prover_transcript);
+
+    auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
+
+    auto result = IPA::reduce_verify(this->vk(), opening_pair, n, verifier_transcript);
     EXPECT_TRUE(result);
 }
 } // namespace proof_system::honk::pcs::ipa

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
@@ -43,14 +43,19 @@ TYPED_TEST(IpaCommitmentTest, open)
     auto commitment = this->commit(poly);
     const OpeningPair<TypeParam> opening_pair{ x, eval };
 
-    auto prover_transcript = ProverTranscript<Fr>::init_empty();
+    // initialize empty prover transcript
+    ProverTranscript<Fr> prover_transcript;
+
     prover_transcript.send_to_verifier("IPA:C", commitment);
 
     IPA::reduce_prove(this->ck(), opening_pair, poly, prover_transcript);
 
-    auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
+    // initialize verifier transcript from proof data
+    VerifierTranscript<Fr> verifier_transcript{ prover_transcript.proof_data };
 
     auto result = IPA::reduce_verify(this->vk(), opening_pair, n, verifier_transcript);
     EXPECT_TRUE(result);
+
+    EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
 }
 } // namespace proof_system::honk::pcs::ipa


### PR DESCRIPTION
# Description

Updating IPA to use `ProverTranscript` and `VerifierTranscript` (which implies use of Fiat-Shamir to produce challenges) and brings the interfaces closer to the rest of the Honk codebase.


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
