### PR TITLE
Copy of #371 - Add Mutex to global initialisation of generators

### DIFF
--- a/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
+++ b/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
@@ -12,6 +12,8 @@ std::array<std::vector<grumpkin::g1::affine_element>, NUM_PEDERSEN_TABLES> peder
 std::vector<grumpkin::g1::affine_element> pedersen_iv_table;
 std::array<grumpkin::g1::affine_element, NUM_PEDERSEN_TABLES> generators;
 
+// Mutex is not available in the WASM context.
+// WASM runs in a single-thread so this is acceptable.
 #if !defined(__wasm__)
 std::mutex init_mutex;
 #endif

--- a/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
+++ b/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
@@ -1,5 +1,7 @@
 #include "./pedersen_lookup.hpp"
 
+#include <mutex>
+
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 
 namespace crypto {
@@ -9,6 +11,10 @@ namespace lookup {
 std::array<std::vector<grumpkin::g1::affine_element>, NUM_PEDERSEN_TABLES> pedersen_tables;
 std::vector<grumpkin::g1::affine_element> pedersen_iv_table;
 std::array<grumpkin::g1::affine_element, NUM_PEDERSEN_TABLES> generators;
+
+#if !defined(__wasm__)
+std::mutex init_mutex;
+#endif
 
 static bool inited = false;
 
@@ -66,6 +72,11 @@ void init()
 {
     ASSERT(BITS_PER_TABLE < BITS_OF_BETA);
     ASSERT(BITS_PER_TABLE + BITS_OF_BETA < BITS_ON_CURVE);
+
+#if !defined(__wasm__)
+    const std::lock_guard<std::mutex> lock(init_mutex);
+#endif
+
     if (inited) {
         return;
     }


### PR DESCRIPTION
# Description

When calling barretenberg in Rust test's we were getting memory corruption because tests are ran in multiple threads. The culprit seems to be the fact that we are using globals for generators, this PR applies a mutex around initialization of these globals.

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
