### PR TITLE
chore: Add cachix action for uploading binary cache artifacts

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,8 @@ name: Nix builds
 
 on:
   push:
+    branches:
+      - master
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   workflow_dispatch:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - phated/*
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   workflow_dispatch:
@@ -34,9 +35,7 @@ jobs:
 
       - uses: cachix/cachix-action@v12
         with:
-          # TODO: Setup a cache with this name
-          name: barretenberg-cache
-          # TODO: Add this token to secrets
+          name: barretenberg
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Check nix flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - phated/*
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   workflow_dispatch:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,8 +2,6 @@ name: Nix builds
 
 on:
   push:
-    branches:
-      - phated/**
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   workflow_dispatch:
@@ -31,6 +29,13 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: cachix/cachix-action@v12
+        with:
+          # TODO: Setup a cache with this name
+          name: barretenberg-cache
+          # TODO: Add this token to secrets
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Check nix flake
         run: |


### PR DESCRIPTION
# Description

This adds the cachix action to upload barretenberg artifacts to a cachix binary cache. It also updates the nix action to run on master.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
