### PR TITLE
Reduce occurence of `using namespace..` in header files

### DIFF
--- a/cpp/src/barretenberg/crypto/pedersen_commitment/pedersen.cpp
+++ b/cpp/src/barretenberg/crypto/pedersen_commitment/pedersen.cpp
@@ -6,7 +6,7 @@
 #include <omp.h>
 #endif
 
-// using namespace crypto::generators;
+using namespace crypto::generators;
 
 namespace crypto {
 namespace pedersen_commitment {

--- a/cpp/src/barretenberg/crypto/pedersen_commitment/pedersen.hpp
+++ b/cpp/src/barretenberg/crypto/pedersen_commitment/pedersen.hpp
@@ -4,16 +4,15 @@
 #include "../generators/generator_data.hpp"
 #include "../generators/fixed_base_scalar_mul.hpp"
 
-using namespace crypto::generators;
-
 namespace crypto {
 namespace pedersen_commitment {
 
-grumpkin::g1::element commit_single(const barretenberg::fr& in, generator_index_t const& index);
+grumpkin::g1::element commit_single(const barretenberg::fr& in, generators::generator_index_t const& index);
 
 grumpkin::g1::affine_element commit_native(const std::vector<grumpkin::fq>& inputs, const size_t hash_index = 0);
 
-grumpkin::g1::affine_element commit_native(const std::vector<std::pair<grumpkin::fq, generator_index_t>>& input_pairs);
+grumpkin::g1::affine_element commit_native(
+    const std::vector<std::pair<grumpkin::fq, generators::generator_index_t>>& input_pairs);
 
 grumpkin::fq compress_native(const std::vector<grumpkin::fq>& inputs, const size_t hash_index = 0);
 
@@ -25,7 +24,7 @@ template <size_t T> grumpkin::fq compress_native(const std::array<grumpkin::fq, 
 
 grumpkin::fq compress_native(const std::vector<uint8_t>& input);
 
-grumpkin::fq compress_native(const std::vector<std::pair<grumpkin::fq, generator_index_t>>& input_pairs);
+grumpkin::fq compress_native(const std::vector<std::pair<grumpkin::fq, generators::generator_index_t>>& input_pairs);
 
 } // namespace pedersen_commitment
 } // namespace crypto

--- a/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.cpp
+++ b/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.cpp
@@ -8,6 +8,8 @@
 namespace crypto {
 namespace pedersen_hash {
 
+using namespace generators;
+
 grumpkin::g1::element hash_single(const barretenberg::fr& in, generator_index_t const& index)
 {
     auto gen_data = get_generator_data(index);
@@ -18,7 +20,7 @@ grumpkin::g1::element hash_single(const barretenberg::fr& in, generator_index_t 
     constexpr size_t num_quads = ((num_quads_base << 1) + 1 < num_bits) ? num_quads_base + 1 : num_quads_base;
     constexpr size_t num_wnaf_bits = (num_quads << 1) + 1;
 
-    const crypto::generators::fixed_base_ladder* ladder = gen_data.get_hash_ladder(num_bits);
+    const fixed_base_ladder* ladder = gen_data.get_hash_ladder(num_bits);
 
     uint64_t wnaf_entries[num_quads + 2] = { 0 };
     bool skew = false;

--- a/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.hpp
+++ b/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.hpp
@@ -4,12 +4,10 @@
 #include "../generators/generator_data.hpp"
 #include "../generators/fixed_base_scalar_mul.hpp"
 
-using namespace crypto::generators;
-
 namespace crypto {
 namespace pedersen_hash {
 
-grumpkin::g1::element hash_single(const barretenberg::fr& in, generator_index_t const& index);
+grumpkin::g1::element hash_single(const barretenberg::fr& in, generators::generator_index_t const& index);
 
 grumpkin::fq hash_multiple(const std::vector<grumpkin::fq>& inputs, const size_t hash_index = 0);
 

--- a/cpp/src/barretenberg/join_split_example/proofs/compute_circuit_data.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/compute_circuit_data.hpp
@@ -84,7 +84,7 @@ circuit_data get_circuit_data(std::string const& name,
         info(name, ": Circuit size: ", composer.get_num_gates());
         if (mock) {
             auto public_inputs = composer.get_public_inputs();
-            mock::mock_circuit(mock_proof_composer, public_inputs);
+            ::join_split_example::proofs::mock::mock_circuit(mock_proof_composer, public_inputs);
             info(name, ": Mock circuit size: ", mock_proof_composer.get_num_gates());
             benchmark_collator.benchmark_info_deferred(GET_COMPOSER_NAME_STRING(proof_system::ComposerType),
                                                        "Core",

--- a/cpp/src/barretenberg/join_split_example/proofs/inner_proof_data/inner_proof_data.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/inner_proof_data/inner_proof_data.cpp
@@ -3,6 +3,8 @@
 namespace join_split_example {
 namespace proofs {
 
+using namespace barretenberg;
+
 inner_proof_data::inner_proof_data(std::vector<uint8_t> const& proof_data)
 {
     proof_id = from_buffer<uint256_t>(proof_data, InnerProofOffsets::PROOF_ID);

--- a/cpp/src/barretenberg/join_split_example/proofs/inner_proof_data/inner_proof_data.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/inner_proof_data/inner_proof_data.hpp
@@ -8,8 +8,6 @@
 namespace join_split_example {
 namespace proofs {
 
-using namespace barretenberg;
-
 namespace InnerProofFields {
 enum {
     PROOF_ID,

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.hpp
@@ -7,8 +7,6 @@ namespace join_split_example {
 namespace proofs {
 namespace join_split {
 
-using namespace proof_system::plonk::stdlib::merkle_tree;
-
 void init_proving_key(std::shared_ptr<proof_system::ReferenceStringFactory> const& crs_factory, bool mock);
 
 void init_proving_key(std::shared_ptr<proof_system::ProverReferenceString> const& crs,

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
@@ -13,6 +13,8 @@
 
 namespace join_split_example::proofs::join_split {
 
+using namespace proof_system::plonk::stdlib::merkle_tree;
+
 template <typename Composer> class join_split : public testing::Test {
 
   protected:

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_circuit.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_circuit.cpp
@@ -15,6 +15,7 @@ namespace join_split {
 using namespace proof_system::plonk;
 using namespace notes::circuit;
 using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace crypto::schnorr;
 
 /**
  * Check that the input note data, follows the given hash paths, to the publically given merkle root.

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/sign_join_split_tx.cpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/sign_join_split_tx.cpp
@@ -6,6 +6,8 @@ namespace join_split_example {
 namespace proofs {
 namespace join_split {
 
+using namespace crypto::schnorr;
+
 signature sign_join_split_tx(join_split_tx const& tx, key_pair<grumpkin::fr, grumpkin::g1> const& keys)
 {
     fr compressed = compute_signing_data(tx);

--- a/cpp/src/barretenberg/join_split_example/proofs/join_split/sign_join_split_tx.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/join_split/sign_join_split_tx.hpp
@@ -7,10 +7,8 @@ namespace join_split_example {
 namespace proofs {
 namespace join_split {
 
-using namespace crypto::schnorr;
-
-signature sign_join_split_tx(proofs::join_split::join_split_tx const& tx,
-                             key_pair<grumpkin::fr, grumpkin::g1> const& keys);
+crypto::schnorr::signature sign_join_split_tx(proofs::join_split::join_split_tx const& tx,
+                                              crypto::schnorr::key_pair<grumpkin::fr, grumpkin::g1> const& keys);
 
 } // namespace join_split
 } // namespace proofs

--- a/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.hpp
@@ -2,7 +2,6 @@
 #include "barretenberg/common/map.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/commitment/pedersen/pedersen.hpp"
-
 namespace join_split_example {
 namespace proofs {
 namespace mock {

--- a/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/account/commit.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/account/commit.hpp
@@ -10,8 +10,6 @@ namespace notes {
 namespace circuit {
 namespace account {
 
-using namespace proof_system::plonk::stdlib;
-
 inline auto commit(field_ct const& account_alias_hash,
                    point_ct const& account_public_key,
                    point_ct const& signing_pub_key)

--- a/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/create_partial_commitment.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/create_partial_commitment.hpp
@@ -9,8 +9,6 @@ namespace notes {
 namespace circuit {
 namespace claim {
 
-using namespace proof_system::plonk::stdlib;
-
 inline auto create_partial_commitment(field_ct const& deposit_value,
                                       field_ct const& bridge_call_data,
                                       field_ct const& value_note_partial_commitment,

--- a/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/complete_partial_commitment.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/complete_partial_commitment.hpp
@@ -9,8 +9,6 @@ namespace notes {
 namespace circuit {
 namespace value {
 
-using namespace proof_system::plonk::stdlib;
-
 inline auto complete_partial_commitment(field_ct const& value_note_partial_commitment,
                                         suint_ct const& value,
                                         suint_ct const& asset_id,

--- a/cpp/src/barretenberg/join_split_example/proofs/notes/native/account/compute_account_alias_hash_nullifier.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/notes/native/account/compute_account_alias_hash_nullifier.hpp
@@ -9,7 +9,7 @@ namespace notes {
 namespace native {
 namespace account {
 
-using namespace barretenberg;
+using fr = barretenberg::fr;
 
 inline fr compute_account_alias_hash_nullifier(fr const& alias_hash)
 {

--- a/cpp/src/barretenberg/join_split_example/proofs/notes/native/claim/compute_nullifier.hpp
+++ b/cpp/src/barretenberg/join_split_example/proofs/notes/native/claim/compute_nullifier.hpp
@@ -10,8 +10,6 @@ namespace notes {
 namespace native {
 namespace claim {
 
-using namespace barretenberg;
-
 inline auto compute_nullifier(grumpkin::fq const& note_commitment)
 {
     return crypto::pedersen_commitment::compress_native({ note_commitment }, GeneratorIndex::CLAIM_NOTE_NULLIFIER);

--- a/cpp/src/barretenberg/plonk/composer/turbo_composer.test.cpp
+++ b/cpp/src/barretenberg/plonk/composer/turbo_composer.test.cpp
@@ -6,6 +6,7 @@
 using namespace barretenberg;
 using namespace proof_system;
 using namespace crypto::pedersen_commitment;
+using namespace crypto::generators;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();

--- a/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.hpp
+++ b/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.hpp
@@ -5,13 +5,11 @@
 #include "../types/commitment_open_proof.hpp"
 #include "../types/program_settings.hpp"
 
-using namespace barretenberg;
-
 namespace proof_system::plonk {
 
 class CommitmentScheme {
   public:
-    typedef barretenberg::fr fr;
+    using fr = barretenberg::fr;
 
     // Constructors for CommitmentScheme
     CommitmentScheme() {}

--- a/cpp/src/barretenberg/srs/reference_string/env_reference_string.hpp
+++ b/cpp/src/barretenberg/srs/reference_string/env_reference_string.hpp
@@ -19,8 +19,6 @@
 #include <cstddef>
 namespace proof_system {
 
-using namespace barretenberg;
-
 class EnvReferenceString : public ProverReferenceString {
   public:
     EnvReferenceString(const size_t num_points)

--- a/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.cpp
+++ b/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.cpp
@@ -9,6 +9,7 @@
 namespace proof_system::plonk {
 namespace stdlib {
 
+using namespace crypto::generators;
 using namespace barretenberg;
 using namespace crypto::pedersen_commitment;
 

--- a/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.hpp
+++ b/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.hpp
@@ -5,8 +5,6 @@
 #include "../../primitives/point/point.hpp"
 #include "../../primitives/byte_array/byte_array.hpp"
 
-using namespace crypto::generators;
-
 namespace proof_system::plonk {
 namespace stdlib {
 
@@ -23,9 +21,9 @@ template <typename ComposerContext> class pedersen_commitment {
     static point commit(const std::vector<field_t>& inputs, const size_t hash_index = 0);
 
     static point commit(const std::vector<field_t>& inputs,
-                        const std::vector<generator_index_t>& hash_generator_indices);
+                        const std::vector<crypto::generators::generator_index_t>& hash_generator_indices);
 
-    static point commit(const std::vector<std::pair<field_t, generator_index_t>>& input_pairs);
+    static point commit(const std::vector<std::pair<field_t, crypto::generators::generator_index_t>>& input_pairs);
 
     static field_t compress_unsafe(const field_t& left,
                                    const field_t& right,
@@ -40,9 +38,9 @@ template <typename ComposerContext> class pedersen_commitment {
     static field_t compress(const std::vector<field_t>& inputs, const size_t hash_index = 0);
 
     static field_t compress(const std::vector<field_t>& inputs,
-                            const std::vector<generator_index_t>& hash_generator_indices);
+                            const std::vector<crypto::generators::generator_index_t>& hash_generator_indices);
 
-    static field_t compress(const std::vector<std::pair<field_t, generator_index_t>>& input_pairs);
+    static field_t compress(const std::vector<std::pair<field_t, crypto::generators::generator_index_t>>& input_pairs);
 
     template <size_t T> static field_t compress(const std::array<field_t, T>& inputs)
     {

--- a/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen_plookup.cpp
+++ b/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen_plookup.cpp
@@ -10,6 +10,7 @@
 namespace proof_system::plonk {
 namespace stdlib {
 
+using namespace plookup;
 using namespace barretenberg;
 
 template <typename C>

--- a/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.cpp
+++ b/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.cpp
@@ -15,24 +15,26 @@ namespace proof_system::plonk {
 namespace stdlib {
 namespace aes128 {
 
+using namespace plookup;
+
 constexpr uint32_t AES128_BASE = 9;
-typedef stdlib::field_t<plonk::UltraComposer> field_t;
-typedef stdlib::witness_t<plonk::UltraComposer> witness_t;
+typedef stdlib::field_t<UltraComposer> field_t;
+typedef stdlib::witness_t<UltraComposer> witness_t;
 
 typedef std::pair<field_t, field_t> byte_pair;
 
-field_t normalize_sparse_form(plonk::UltraComposer*, field_t& byte)
+field_t normalize_sparse_form(UltraComposer*, field_t& byte)
 {
     auto result = plookup_read::read_from_1_to_2_table(AES_NORMALIZE, byte);
     return result;
 }
 
-byte_pair apply_aes_sbox_map(plonk::UltraComposer*, field_t& input)
+byte_pair apply_aes_sbox_map(UltraComposer*, field_t& input)
 {
     return plookup_read::read_pair_from_table(AES_SBOX, input);
 }
 
-std::array<field_t, 16> convert_into_sparse_bytes(plonk::UltraComposer*, const field_t& block_data)
+std::array<field_t, 16> convert_into_sparse_bytes(UltraComposer*, const field_t& block_data)
 {
     // `block_data` must be a 128 bit variable
     std::array<field_t, 16> sparse_bytes;
@@ -46,7 +48,7 @@ std::array<field_t, 16> convert_into_sparse_bytes(plonk::UltraComposer*, const f
     return sparse_bytes;
 }
 
-field_t convert_from_sparse_bytes(plonk::UltraComposer* ctx, field_t* sparse_bytes)
+field_t convert_from_sparse_bytes(UltraComposer* ctx, field_t* sparse_bytes)
 {
     std::array<field_t, 16> bytes;
 
@@ -69,7 +71,7 @@ field_t convert_from_sparse_bytes(plonk::UltraComposer* ctx, field_t* sparse_byt
     return result;
 }
 
-std::array<field_t, 176> expand_key(plonk::UltraComposer* ctx, const field_t& key)
+std::array<field_t, 176> expand_key(UltraComposer* ctx, const field_t& key)
 {
     constexpr uint8_t round_constants[11] = { 0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36 };
     std::array<field_t, 11> sparse_round_constants{
@@ -210,7 +212,7 @@ void mix_columns_and_add_round_key(byte_pair* state_pairs, field_t* round_key, u
     mix_column_and_add_round_key(state_pairs + 12, round_key + 12, round);
 }
 
-void sub_bytes(plonk::UltraComposer* ctx, byte_pair* state_pairs)
+void sub_bytes(UltraComposer* ctx, byte_pair* state_pairs)
 {
     for (size_t i = 0; i < 16; ++i) {
         state_pairs[i] = apply_aes_sbox_map(ctx, state_pairs[i].first);
@@ -233,7 +235,7 @@ void xor_with_iv(byte_pair* state, field_t* iv)
     }
 }
 
-void aes128_cipher(plonk::UltraComposer* ctx, byte_pair* state, field_t* sparse_round_key)
+void aes128_cipher(UltraComposer* ctx, byte_pair* state, field_t* sparse_round_key)
 {
     add_round_key(state, sparse_round_key, 0);
     for (size_t i = 0; i < 16; ++i) {
@@ -256,7 +258,7 @@ void aes128_cipher(plonk::UltraComposer* ctx, byte_pair* state, field_t* sparse_
 
 std::vector<field_t> encrypt_buffer_cbc(const std::vector<field_t>& input, const field_t& iv, const field_t& key)
 {
-    plonk::UltraComposer* ctx = key.get_context();
+    UltraComposer* ctx = key.get_context();
 
     auto round_key = expand_key(ctx, key);
 

--- a/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s_plookup.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s_plookup.cpp
@@ -22,6 +22,7 @@ namespace stdlib {
 namespace blake2s_plookup {
 
 using plookup::ColumnIdx;
+using namespace blake_util;
 
 constexpr uint32_t blake2s_IV[8] = { 0x6A09E667UL, 0xBB67AE85UL, 0x3C6EF372UL, 0xA54FF53AUL,
                                      0x510E527FUL, 0x9B05688CUL, 0x1F83D9ABUL, 0x5BE0CD19UL };

--- a/cpp/src/barretenberg/stdlib/hash/blake2s/blake_util.hpp
+++ b/cpp/src/barretenberg/stdlib/hash/blake2s/blake_util.hpp
@@ -11,6 +11,8 @@ namespace stdlib {
 
 namespace blake_util {
 
+using namespace plookup;
+
 // constants
 enum blake_constant { BLAKE3_STATE_SIZE = 16 };
 

--- a/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s_plookup.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s_plookup.cpp
@@ -13,6 +13,8 @@ namespace stdlib {
 
 namespace blake3s_plookup {
 
+using namespace blake_util;
+
 /*
  * Constants and more.
  */

--- a/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -6,6 +6,8 @@
 namespace proof_system::plonk {
 namespace stdlib {
 
+using namespace plookup;
+
 /**
  * @brief Normalize a base-11 limb and left-rotate by keccak::ROTATIONS[lane_index] bits.
  *        This method also extracts the most significant bit of the normalised rotated limb.

--- a/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.cpp
@@ -9,6 +9,7 @@ namespace stdlib {
 
 using namespace barretenberg;
 using namespace crypto::pedersen_hash;
+using namespace crypto::generators;
 using namespace proof_system;
 
 /**

--- a/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.hpp
+++ b/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.hpp
@@ -8,8 +8,6 @@ namespace proof_system::plonk {
 namespace stdlib {
 
 using namespace barretenberg;
-using namespace crypto::pedersen_hash;
-
 template <typename ComposerContext> class pedersen_hash {
 
   private:

--- a/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_plookup.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_plookup.cpp
@@ -12,6 +12,7 @@ namespace proof_system::plonk {
 namespace stdlib {
 
 using namespace barretenberg;
+using namespace plookup;
 
 /**
  * Add two curve points in one of the following ways:

--- a/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
@@ -14,6 +14,8 @@ namespace proof_system::plonk {
 namespace stdlib {
 namespace sha256_plookup {
 
+using namespace plookup;
+
 namespace internal {
 
 constexpr size_t get_num_blocks(const size_t num_bits)

--- a/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
@@ -1,13 +1,14 @@
 #pragma once
+#include "barretenberg/proof_system/plookup_tables/types.hpp"
 namespace proof_system::plonk {
 namespace stdlib {
 
+using plookup::MultiTableId;
 template <typename C, class Fq, class Fr, class G>
 template <size_t num_elements, typename>
 std::array<twin_rom_table<C>, 5> element<C, Fq, Fr, G>::create_group_element_rom_tables(
     const std::array<element, num_elements>& rom_data)
 {
-
     std::vector<std::array<field_t<C>, 2>> x_lo_limbs;
     std::vector<std::array<field_t<C>, 2>> x_hi_limbs;
     std::vector<std::array<field_t<C>, 2>> y_lo_limbs;

--- a/cpp/src/barretenberg/stdlib/primitives/group/group.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/group/group.hpp
@@ -8,13 +8,11 @@
 #include "../../hash/pedersen/pedersen.hpp"
 #include "../../hash/pedersen/pedersen_gates.hpp"
 
-using namespace proof_system;
-
 namespace proof_system::plonk {
 namespace stdlib {
 
 using namespace barretenberg;
-using namespace crypto::pedersen_hash;
+using namespace crypto::generators;
 
 template <typename ComposerContext> class group {
   public:
@@ -137,7 +135,7 @@ auto group<ComposerContext>::fixed_base_scalar_mul_internal(const field_t<Compos
     fr three = ((one + one) + one);
 
     for (size_t i = 0; i < num_quads; ++i) {
-        uint64_t entry = wnaf_entries[i + 1] & crypto::generators::WNAF_MASK;
+        uint64_t entry = wnaf_entries[i + 1] & WNAF_MASK;
 
         fr prev_accumulator = accumulator_transcript[i] + accumulator_transcript[i];
         prev_accumulator = prev_accumulator + prev_accumulator;

--- a/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
@@ -14,7 +14,7 @@ namespace proof_system::plonk::stdlib {
  *
  * @details Defaults to basic Composer method if not using plookup-compatible composer. If the left and right operands
  * are larger than num_bit, the result will be truncated to num_bits. However, the two operands could be
- * range-constrained to num_bits before the call which would remove the need to range constrain inside this function.
+ * range-constrained to num_bits before the call, which would remove the need to range constrain inside this function.
  *
  * @tparam Composer
  * @param a

--- a/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.cpp
@@ -10,6 +10,8 @@ class UltraComposer;
 namespace proof_system::plonk {
 namespace stdlib {
 
+using plookup::ColumnIdx;
+using plookup::MultiTableId;
 using namespace barretenberg;
 
 template <typename Composer>

--- a/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.hpp
@@ -9,21 +9,21 @@
 namespace proof_system::plonk {
 namespace stdlib {
 
-using namespace plookup;
-
 template <typename Composer> class plookup_ {
     typedef field_t<Composer> field_pt;
 
   public:
-    static std::pair<field_pt, field_pt> read_pair_from_table(const MultiTableId id, const field_pt& key);
+    static std::pair<field_pt, field_pt> read_pair_from_table(const plookup::MultiTableId id, const field_pt& key);
 
-    static field_pt read_from_2_to_1_table(const MultiTableId id, const field_pt& key_a, const field_pt& key_b);
-    static field_pt read_from_1_to_2_table(const MultiTableId id, const field_pt& key_a);
+    static field_pt read_from_2_to_1_table(const plookup::MultiTableId id,
+                                           const field_pt& key_a,
+                                           const field_pt& key_b);
+    static field_pt read_from_1_to_2_table(const plookup::MultiTableId id, const field_pt& key_a);
 
-    static ReadData<field_pt> get_lookup_accumulators(const MultiTableId id,
-                                                      const field_pt& key_a,
-                                                      const field_pt& key_b = 0,
-                                                      const bool is_2_to_1_lookup = false);
+    static plookup::ReadData<field_pt> get_lookup_accumulators(const plookup::MultiTableId id,
+                                                               const field_pt& key_a,
+                                                               const field_pt& key_b = 0,
+                                                               const bool is_2_to_1_lookup = false);
 };
 
 extern template class plookup_<plonk::UltraComposer>;

--- a/cpp/src/barretenberg/stdlib/primitives/uint/plookup/logic.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/uint/plookup/logic.cpp
@@ -6,6 +6,8 @@ using namespace barretenberg;
 namespace proof_system::plonk {
 namespace stdlib {
 
+using namespace plookup;
+
 template <typename Composer, typename Native>
 uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator&(const uint_plookup& other) const
 {


### PR DESCRIPTION
Addresses issue #277 

Limit the usage of `using namespace..` in header files (where possible) to reduce chance of ambiguities or potential bugs caused by having many namespaces implicitly included in files that include the header file.
# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
