### PR TITLE
fix: throw -> throw_or_abort in sol gen

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,9 +1,9 @@
 name: Nix builds
 
 on:
-  push:
-    branches:
-      - master
+  push
+    # branches:
+      # - master
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   workflow_dispatch:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - md/*
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   workflow_dispatch:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,9 +1,10 @@
 name: Nix builds
 
 on:
-  push
-    # branches:
-      # - master
+  push:
+    branches:
+      - master
+      - md/*
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   workflow_dispatch:

--- a/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
+++ b/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
@@ -88,7 +88,7 @@ template <typename OuterComposer> class RecursiveCircuit {
             }
             auto native_result = native_verifier.verify_proof(recursive_proof);
             if (native_result == false) {
-                throw std::runtime_error("Native verification failed");
+                throw_or_abort("Native verification failed");
             }
         }
 
@@ -122,13 +122,13 @@ template <typename OuterComposer> class RecursiveCircuit {
             P, circuit_output.verification_key->reference_string->get_precomputed_g2_lines(), 2);
 
         if (inner_proof_result != barretenberg::fq12::one()) {
-            throw std::runtime_error("inner proof result != 1");
+            throw_or_abort("inner proof result != 1");
         }
 
         circuit_output.aggregation_state.add_proof_outputs_as_public_inputs();
 
         if (outer_composer.failed()) {
-            throw std::runtime_error("outer composer failed");
+            throw_or_abort("outer composer failed");
         }
 
         return outer_composer;

--- a/cpp/src/barretenberg/solidity_helpers/proof_gen.cpp
+++ b/cpp/src/barretenberg/solidity_helpers/proof_gen.cpp
@@ -24,7 +24,7 @@ template <typename Composer, typename Circuit> void generate_proof(std::string s
         auto verifier = composer.create_ultra_with_keccak_verifier();
 
         if (!verifier.verify_proof(proof)) {
-            throw std::runtime_error("Verification failed");
+            throw_or_abort("Verification failed");
         }
 
         std::string proof_bytes = bytes_to_hex_string(proof.proof_data);


### PR DESCRIPTION
# Description

Master CI was failing in nix wasm builds for not using throw_or_abort. Thank you blaine for the spot 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
