### PR TITLE
Small change that was left out of construct_addition_chains fix

### DIFF
--- a/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.test.cpp
+++ b/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.test.cpp
@@ -482,7 +482,7 @@ TEST(scalar_multiplication, construct_addition_chains)
                                                                        bucket_counts,
                                                                        &bit_offsets[0],
                                                                        state.point_schedule,
-                                                                       num_points,
+                                                                       static_cast<uint32_t>(state.round_counts[0]),
                                                                        static_cast<uint32_t>(num_buckets),
                                                                        bucket_empty_status };
 

--- a/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.test.cpp
+++ b/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.test.cpp
@@ -488,9 +488,9 @@ TEST(scalar_multiplication, construct_addition_chains)
 
     start = std::chrono::steady_clock::now();
     scalar_multiplication::construct_addition_chains(product_state, true);
-    // scalar_multiplication::scalar_multiplication_internal<num_points>(state, monomials);
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    info("construct addition chains: ", diff.count(), "ms");
     std::cout << "scalar mul: " << diff.count() << "ms" << std::endl;
 
     aligned_free(bucket_empty_status);


### PR DESCRIPTION
# Description

This should fix the segfault in construct_addition_chains (https://github.com/AztecProtocol/barretenberg/issues/403)

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
