### PR TITLE
chore(ci): Add Noir CI that runs with a github label

### DIFF
--- a/.github/workflows/noir.yml
+++ b/.github/workflows/noir.yml
@@ -1,0 +1,38 @@
+name: Noir CI
+
+on:
+  pull_request:
+    types: ["labeled", "opened", "synchronize", "reopened"]
+
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  noir-ci:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'noir-ci') }}
+    name: Test Noir against PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Noir
+        uses: actions/checkout@v3
+        with:
+          repository: noir-lang/noir
+
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # The GITHUB_SHA doesn't match the last commit on the PR but is instead a merge commit of the PR into master.
+      # As per GitHub docs:
+      #   Note that GITHUB_SHA for this event is the last merge commit of the pull request merge branch.
+      - name: Update barretenberg commit in flake.lock
+        run: |
+          nix flake lock --override-input barretenberg github:AztecProtocol/barretenberg/${{ env.GITHUB_SHA }}
+
+      - name: Build and test Noir
+        run: |
+          nix flake check -L


### PR DESCRIPTION
# Description

This adds a workflow for building and running all tests of Noir against a specific PR. Since it builds Barretenberg from scratch it takes >50 minutes to run. With that in mind, I've made it so the workflow only runs if you add the "noir-ci" label to a PR (as I've done on this PR to demonstrate).

This also uses the Nix build process that the Noir team uses so running this CI also ensures that nothing was broken with usage of the Nix package manager.

Closes #431

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
