### PR TITLE
Ensure all sizes of operand are tried in the logic gate tests

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
@@ -86,7 +86,7 @@ TYPED_TEST(LogicTest, TestCorrectLogic)
 
     auto composer = Composer();
     for (size_t i = 8; i < 248; i += 8) {
-        run_test(8, composer);
+        run_test(i, composer);
     }
     auto prover = composer.create_prover();
     plonk::proof proof = prover.construct_proof();


### PR DESCRIPTION
# Description

Small fix in the  ogic gate test in which previously only 8-bit operands were tested.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
