### PR TITLE
DSL: Add valid verifier dummy data for ecdsa

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -234,7 +234,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system,
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints<true>(composer, constraint);
     }
 
     // Add blake2s constraints
@@ -320,7 +320,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system, std::
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints<true>(composer, constraint);
     }
 
     // Add blake2s constraints
@@ -404,7 +404,7 @@ void create_circuit_with_witness(Composer& composer, const acir_format& constrai
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints<true>(composer, constraint);
     }
 
     // Add blake2s constraints

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -13,6 +13,11 @@ void read_witness(Composer& composer, std::vector<barretenberg::fr> witness)
 }
 using curve = proof_system::plonk::stdlib::secp256k1<Composer>;
 
+// Add dummy constraints for ECDSA because when the verifier creates the
+// constraint system, they usually use zeroes for witness values.
+//
+// This does not work for ECDSA as the signature, r, s and public key need
+// to be valid.
 void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& input)
 {
 

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -1,6 +1,5 @@
 #include "acir_format.hpp"
 #include "barretenberg/common/log.hpp"
-#include "barretenberg/crypto/ecdsa/ecdsa.hpp"
 
 namespace acir_format {
 
@@ -9,56 +8,6 @@ void read_witness(Composer& composer, std::vector<barretenberg::fr> witness)
     composer.variables[0] = 0;
     for (size_t i = 0; i < witness.size(); ++i) {
         composer.variables[i + 1] = witness[i];
-    }
-}
-
-// Add dummy constraints for ECDSA because when the verifier creates the
-// constraint system, they usually use zeroes for witness values.
-//
-// This does not work for ECDSA as the signature, r, s and public key need
-// to be valid.
-void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& input)
-{
-
-    std::vector<uint32_t> pub_x_indices_;
-    std::vector<uint32_t> pub_y_indices_;
-    std::vector<uint32_t> signature_;
-    signature_.resize(64);
-
-    // Create a valid signature with a valid public key
-    crypto::ecdsa::key_pair<secp256k1_ct::fr, secp256k1_ct::g1> account;
-    account.private_key = 10;
-    account.public_key = secp256k1_ct::g1::one * account.private_key;
-    uint256_t pub_x_value = account.public_key.x;
-    uint256_t pub_y_value = account.public_key.y;
-    std::string message_string = "Instructions unclear, ask again later.";
-    crypto::ecdsa::signature signature =
-        crypto::ecdsa::construct_signature<Sha256Hasher, secp256k1_ct::fq, secp256k1_ct::fr, secp256k1_ct::g1>(
-            message_string, account);
-
-    // Create new variables which will reference the valid public key and signature.
-    // We don't use them in a gate, so when we call assert_equal, they will be
-    // replaced as if they never existed.
-    for (size_t i = 0; i < 32; ++i) {
-        uint32_t x_wit = composer.add_variable(pub_x_value.slice(248 - i * 8, 256 - i * 8));
-        uint32_t y_wit = composer.add_variable(pub_y_value.slice(248 - i * 8, 256 - i * 8));
-        uint32_t r_wit = composer.add_variable(signature.r[i]);
-        uint32_t s_wit = composer.add_variable(signature.s[i]);
-        pub_x_indices_.emplace_back(x_wit);
-        pub_y_indices_.emplace_back(y_wit);
-        signature_[i] = r_wit;
-        signature_[i + 32] = s_wit;
-    }
-
-    // Call assert_equal(from, to) to replace the value in `to` by the value in `from`
-    for (size_t i = 0; i < input.pub_x_indices.size(); ++i) {
-        composer.assert_equal(pub_x_indices_[i], input.pub_x_indices[i]);
-    }
-    for (size_t i = 0; i < input.pub_y_indices.size(); ++i) {
-        composer.assert_equal(pub_y_indices_[i], input.pub_y_indices[i]);
-    }
-    for (size_t i = 0; i < input.signature.size(); ++i) {
-        composer.assert_equal(signature_[i], input.signature[i]);
     }
 }
 
@@ -112,8 +61,7 @@ void create_circuit(Composer& composer, const acir_format& constraint_system)
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        dummy_ecdsa_constraint(composer, constraint);
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints(composer, constraint, false);
     }
 
     // Add blake2s constraints
@@ -196,8 +144,7 @@ Composer create_circuit(const acir_format& constraint_system,
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        dummy_ecdsa_constraint(composer, constraint);
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints(composer, constraint, false);
     }
 
     // Add blake2s constraints
@@ -286,7 +233,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system,
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints(composer, constraint, true);
     }
 
     // Add blake2s constraints
@@ -372,7 +319,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system, std::
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints(composer, constraint, true);
     }
 
     // Add blake2s constraints
@@ -456,7 +403,7 @@ void create_circuit_with_witness(Composer& composer, const acir_format& constrai
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint);
+        create_ecdsa_verify_constraints(composer, constraint, true);
     }
 
     // Add blake2s constraints

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -25,6 +25,7 @@ void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& 
     std::vector<uint32_t> signature_;
     signature_.resize(64);
 
+    // Create a valid signature with a valid public key
     crypto::ecdsa::key_pair<secp256k1_ct::fr, secp256k1_ct::g1> account;
     account.private_key = 10;
     account.public_key = secp256k1_ct::g1::one * account.private_key;
@@ -34,6 +35,10 @@ void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& 
     crypto::ecdsa::signature signature =
         crypto::ecdsa::construct_signature<Sha256Hasher, secp256k1_ct::fq, secp256k1_ct::fr, secp256k1_ct::g1>(
             message_string, account);
+
+    // Create new variables which will reference the valid public key and signature.
+    // We don't use them in a gate, so when we call assert_equal, they will be
+    // replaced as if they never existed.
     for (size_t i = 0; i < 32; ++i) {
         uint32_t x_wit = composer.add_variable(pub_x_value.slice(248 - i * 8, 256 - i * 8));
         uint32_t y_wit = composer.add_variable(pub_y_value.slice(248 - i * 8, 256 - i * 8));
@@ -45,6 +50,7 @@ void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& 
         signature_[i + 32] = s_wit;
     }
 
+    // Call assert_equal(from, to) to replace the value in `to` by the value in `from`
     for (size_t i = 0; i < input.pub_x_indices.size(); ++i) {
         composer.assert_equal(pub_x_indices_[i], input.pub_x_indices[i]);
     }
@@ -68,7 +74,6 @@ void create_circuit(Composer& composer, const acir_format& constraint_system)
         if (std::find(constraint_system.public_inputs.begin(), constraint_system.public_inputs.end(), i) !=
             constraint_system.public_inputs.end()) {
             composer.add_public_variable(0);
-
         } else {
             composer.add_variable(0);
         }

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -11,7 +11,6 @@ void read_witness(Composer& composer, std::vector<barretenberg::fr> witness)
         composer.variables[i + 1] = witness[i];
     }
 }
-using curve = proof_system::plonk::stdlib::secp256k1<Composer>;
 
 // Add dummy constraints for ECDSA because when the verifier creates the
 // constraint system, they usually use zeroes for witness values.
@@ -26,14 +25,15 @@ void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& 
     std::vector<uint32_t> signature_;
     signature_.resize(64);
 
-    crypto::ecdsa::key_pair<curve::fr, curve::g1> account;
+    crypto::ecdsa::key_pair<secp256k1_ct::fr, secp256k1_ct::g1> account;
     account.private_key = 10;
-    account.public_key = curve::g1::one * account.private_key;
+    account.public_key = secp256k1_ct::g1::one * account.private_key;
     uint256_t pub_x_value = account.public_key.x;
     uint256_t pub_y_value = account.public_key.y;
     std::string message_string = "Instructions unclear, ask again later.";
     crypto::ecdsa::signature signature =
-        crypto::ecdsa::construct_signature<Sha256Hasher, curve::fq, curve::fr, curve::g1>(message_string, account);
+        crypto::ecdsa::construct_signature<Sha256Hasher, secp256k1_ct::fq, secp256k1_ct::fr, secp256k1_ct::g1>(
+            message_string, account);
     for (size_t i = 0; i < 32; ++i) {
         uint32_t x_wit = composer.add_variable(pub_x_value.slice(248 - i * 8, 256 - i * 8));
         uint32_t y_wit = composer.add_variable(pub_y_value.slice(248 - i * 8, 256 - i * 8));

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -233,7 +233,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system,
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint, true);
+        create_ecdsa_verify_constraints(composer, constraint);
     }
 
     // Add blake2s constraints
@@ -319,7 +319,7 @@ Composer create_circuit_with_witness(const acir_format& constraint_system, std::
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint, true);
+        create_ecdsa_verify_constraints(composer, constraint);
     }
 
     // Add blake2s constraints
@@ -403,7 +403,7 @@ void create_circuit_with_witness(Composer& composer, const acir_format& constrai
 
     // Add ECDSA constraints
     for (const auto& constraint : constraint_system.ecdsa_constraints) {
-        create_ecdsa_verify_constraints(composer, constraint, true);
+        create_ecdsa_verify_constraints(composer, constraint);
     }
 
     // Add blake2s constraints

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -5,6 +5,7 @@
 namespace acir_format {
 
 using namespace proof_system::plonk;
+using curve = proof_system::plonk::stdlib::secp256k1<acir_format::Composer>;
 
 crypto::ecdsa::signature ecdsa_convert_signature(Composer& composer, std::vector<uint32_t> signature)
 {
@@ -84,9 +85,56 @@ witness_ct ecdsa_index_to_witness(Composer& composer, uint32_t index)
     return { &composer, value };
 }
 
+template <bool has_witness>
 void create_ecdsa_verify_constraints(Composer& composer, const EcdsaSecp256k1Constraint& input)
 {
-
+    {
+        std::vector<uint32_t> pub_x_indices_;
+        std::vector<uint32_t> pub_y_indices_;
+        std::vector<uint32_t> signature_;
+        signature_.resize(64);
+        if constexpr (has_witness) {
+            for (size_t i = 0; i < 32; ++i) {
+                uint32_t x_wit = composer.add_variable(composer.get_variable(input.pub_x_indices[i]));
+                uint32_t y_wit = composer.add_variable(composer.get_variable(input.pub_y_indices[i]));
+                uint32_t r_wit = composer.add_variable(composer.get_variable(input.signature[i]));
+                uint32_t s_wit = composer.add_variable(composer.get_variable(input.signature[i + 32]));
+                pub_x_indices_.emplace_back(x_wit);
+                pub_y_indices_.emplace_back(y_wit);
+                signature_[i] = r_wit;
+                signature_[i + 32] = s_wit;
+            }
+        } else {
+            crypto::ecdsa::key_pair<curve::fr, curve::g1> account;
+            account.private_key = 10;
+            account.public_key = curve::g1::one * account.private_key;
+            uint256_t pub_x_value = account.public_key.x;
+            uint256_t pub_y_value = account.public_key.y;
+            std::string message_string = "Instructions unclear, ask again later.";
+            crypto::ecdsa::signature signature =
+                crypto::ecdsa::construct_signature<Sha256Hasher, curve::fq, curve::fr, curve::g1>(message_string,
+                                                                                                  account);
+            for (size_t i = 0; i < 32; ++i) {
+                uint32_t x_wit = composer.add_variable(pub_x_value.slice(248 - i * 8, 256 - i * 8));
+                uint32_t y_wit = composer.add_variable(pub_y_value.slice(248 - i * 8, 256 - i * 8));
+                uint32_t r_wit = composer.add_variable(signature.r[i]);
+                uint32_t s_wit = composer.add_variable(signature.s[i]);
+                pub_x_indices_.emplace_back(x_wit);
+                pub_y_indices_.emplace_back(y_wit);
+                signature_[i] = r_wit;
+                signature_[i + 32] = s_wit;
+            }
+        }
+        for (size_t i = 0; i < input.pub_x_indices.size(); ++i) {
+            composer.assert_equal(pub_x_indices_[i], input.pub_x_indices[i]);
+        }
+        for (size_t i = 0; i < input.pub_y_indices.size(); ++i) {
+            composer.assert_equal(pub_y_indices_[i], input.pub_y_indices[i]);
+        }
+        for (size_t i = 0; i < input.signature.size(); ++i) {
+            composer.assert_equal(signature_[i], input.signature[i]);
+        }
+    }
     auto new_sig = ecdsa_convert_signature(composer, input.signature);
 
     auto message = ecdsa_vector_of_bytes_to_byte_array(composer, input.hashed_message);
@@ -126,5 +174,7 @@ void create_ecdsa_verify_constraints(Composer& composer, const EcdsaSecp256k1Con
     bool_ct signature_result_normalized = signature_result.normalize();
     composer.assert_equal(signature_result_normalized.witness_index, input.result);
 }
+template void create_ecdsa_verify_constraints<true>(Composer& composer, const EcdsaSecp256k1Constraint& input);
+template void create_ecdsa_verify_constraints<false>(Composer& composer, const EcdsaSecp256k1Constraint& input);
 
 } // namespace acir_format

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -5,7 +5,6 @@
 namespace acir_format {
 
 using namespace proof_system::plonk;
-using curve = proof_system::plonk::stdlib::secp256k1<acir_format::Composer>;
 
 crypto::ecdsa::signature ecdsa_convert_signature(Composer& composer, std::vector<uint32_t> signature)
 {

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
@@ -26,11 +26,7 @@ struct EcdsaSecp256k1Constraint {
     friend bool operator==(EcdsaSecp256k1Constraint const& lhs, EcdsaSecp256k1Constraint const& rhs) = default;
 };
 
-template <bool has_witness = false>
 void create_ecdsa_verify_constraints(Composer& composer, const EcdsaSecp256k1Constraint& input);
-
-extern template void create_ecdsa_verify_constraints<true>(Composer& composer, const EcdsaSecp256k1Constraint& input);
-extern template void create_ecdsa_verify_constraints<false>(Composer& composer, const EcdsaSecp256k1Constraint& input);
 
 template <typename B> inline void read(B& buf, EcdsaSecp256k1Constraint& constraint)
 {

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
@@ -26,7 +26,11 @@ struct EcdsaSecp256k1Constraint {
     friend bool operator==(EcdsaSecp256k1Constraint const& lhs, EcdsaSecp256k1Constraint const& rhs) = default;
 };
 
+template <bool has_witness = false>
 void create_ecdsa_verify_constraints(Composer& composer, const EcdsaSecp256k1Constraint& input);
+
+extern template void create_ecdsa_verify_constraints<true>(Composer& composer, const EcdsaSecp256k1Constraint& input);
+extern template void create_ecdsa_verify_constraints<false>(Composer& composer, const EcdsaSecp256k1Constraint& input);
 
 template <typename B> inline void read(B& buf, EcdsaSecp256k1Constraint& constraint)
 {

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
@@ -26,7 +26,11 @@ struct EcdsaSecp256k1Constraint {
     friend bool operator==(EcdsaSecp256k1Constraint const& lhs, EcdsaSecp256k1Constraint const& rhs) = default;
 };
 
-void create_ecdsa_verify_constraints(Composer& composer, const EcdsaSecp256k1Constraint& input);
+void create_ecdsa_verify_constraints(Composer& composer,
+                                     const EcdsaSecp256k1Constraint& input,
+                                     bool has_valid_witness_assignments);
+
+void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& input);
 
 template <typename B> inline void read(B& buf, EcdsaSecp256k1Constraint& constraint)
 {

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
@@ -28,7 +28,7 @@ struct EcdsaSecp256k1Constraint {
 
 void create_ecdsa_verify_constraints(Composer& composer,
                                      const EcdsaSecp256k1Constraint& input,
-                                     bool has_valid_witness_assignments);
+                                     bool has_valid_witness_assignments = true);
 
 void dummy_ecdsa_constraint(Composer& composer, EcdsaSecp256k1Constraint const& input);
 

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
@@ -40,7 +40,6 @@ size_t generate_ecdsa_constraint(acir_format::EcdsaSecp256k1Constraint& ecdsa_co
         const auto byte = static_cast<uint8_t>(hashed_message[i]);
         witness_values.emplace_back(byte);
     }
-    std::cout << message_in.size() << std::endl;
     offset += message_in.size();
 
     for (size_t i = 0; i < 32; ++i) {

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
@@ -110,7 +110,10 @@ TEST(ECDSASecp256k1, TestECDSAConstraintSucceed)
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }
 
-TEST(ECDSASecp256k1, TestECDSAConstraintSucceedSeparate)
+// Test that the verifier can create an ECDSA circuit.
+// The ECDSA circuit requires that certain dummy data is valid
+// even though we are just building the circuit.
+TEST(ECDSASecp256k1, TestECDSACompilesForVerifier)
 {
     acir_format::EcdsaSecp256k1Constraint ecdsa_constraint;
     std::vector<fr> witness_values;

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
@@ -40,6 +40,7 @@ size_t generate_ecdsa_constraint(acir_format::EcdsaSecp256k1Constraint& ecdsa_co
         const auto byte = static_cast<uint8_t>(hashed_message[i]);
         witness_values.emplace_back(byte);
     }
+    std::cout << message_in.size() << std::endl;
     offset += message_in.size();
 
     for (size_t i = 0; i < 32; ++i) {
@@ -108,6 +109,31 @@ TEST(ECDSASecp256k1, TestECDSAConstraintSucceed)
     auto proof = prover.construct_proof();
     auto verifier = composer.create_verifier();
     EXPECT_EQ(verifier.verify_proof(proof), true);
+}
+
+TEST(ECDSASecp256k1, TestECDSAConstraintSucceedSeparate)
+{
+    acir_format::EcdsaSecp256k1Constraint ecdsa_constraint;
+    std::vector<fr> witness_values;
+    size_t num_variables = generate_ecdsa_constraint(ecdsa_constraint, witness_values);
+    acir_format::acir_format constraint_system{
+        .varnum = static_cast<uint32_t>(num_variables),
+        .public_inputs = {},
+        .fixed_base_scalar_mul_constraints = {},
+        .logic_constraints = {},
+        .range_constraints = {},
+        .schnorr_constraints = {},
+        .ecdsa_constraints = { ecdsa_constraint },
+        .sha256_constraints = {},
+        .blake2s_constraints = {},
+        .keccak_constraints = {},
+        .hash_to_field_constraints = {},
+        .pedersen_constraints = {},
+        .compute_merkle_root_constraints = {},
+        .constraints = {},
+    };
+    auto crs_factory = std::make_unique<proof_system::ReferenceStringFactory>();
+    auto composer = create_circuit(constraint_system, std::move(crs_factory));
 }
 
 TEST(ECDSASecp256k1, TestECDSAConstraintFail)


### PR DESCRIPTION

# Description

When the verifier creates a constraint system, they will use 0s as the witness values. This will cause panics since a lot of the ecdsa code adds assertions to ensure that certain data is not zero or valid. One of these being the r, s values need to be non-zero and the public key, signatures need to valid.

This PR creates a dummy signature for the verifier. 

Note: A problem with this approach and wherever else in the codebase this is applied. If the prover passes in a zero intentionally/accidentally, then their program will crash. 

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
