### PR TITLE
Add partial-fix for ecdsa signature construction malleability

### DIFF
--- a/cpp/src/barretenberg/crypto/ecdsa/ecdsa_impl.hpp
+++ b/cpp/src/barretenberg/crypto/ecdsa/ecdsa_impl.hpp
@@ -28,6 +28,15 @@ signature construct_signature(const std::string& message, const key_pair<Fr, G1>
     Fr r_fr = Fr::serialize_from_buffer(&sig.r[0]);
     Fr s_fr = (z + r_fr * account.private_key) / k;
 
+    // Ensures that the s value chosen is "low".
+    // For more details, see:
+    // https://github.com/bitcoin-core/secp256k1/blob/d644dda5c9dbdecee52d1aa259235510fdc2d4ee/include/secp256k1.h#L483-L513
+    uint256_t s_u256(s_fr);
+    bool s_hi = ((s_u256 >> 255) & 1ULL) == 1ULL;
+    if (s_hi) {
+        s_fr = -s_fr;
+    }
+
     Fr::serialize_to_buffer(s_fr, &sig.s[0]);
 
     // compute recovery_id: given R = (x, y)


### PR DESCRIPTION
# Description

This does not fix the issue because the verification logic does not check that s is "low". This is only a partial fix for the problems encountered in DSL.

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
