### PR TITLE
chore(ci): Add explicit ref for Noir checkout

### DIFF
--- a/.github/workflows/noir.yml
+++ b/.github/workflows/noir.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: noir-lang/noir
+          # This reference can be changed to test against a different version of Noir (such as a WIP branch)
+          ref: master
 
       - uses: cachix/install-nix-action@v20
         with:


### PR DESCRIPTION
# Description

This adds an explicit `ref` option when checking out Noir with a comment for people dev'ing against a branch.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
