### PR TITLE
fix: Add block_constraints field into new DSL EcDSA test

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
@@ -133,6 +133,7 @@ TEST(ECDSASecp256k1, TestECDSACompilesForVerifier)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .compute_merkle_root_constraints = {},
+        .block_constraints = {},
         .constraints = {},
     };
     auto crs_factory = std::make_unique<proof_system::ReferenceStringFactory>();


### PR DESCRIPTION
# Description

add block_constraint to the new test case

This happened because the PR was merged into master without master being merged into the PR first. Adding this requirement into the CI would stop this from happening in the future.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
