### PR TITLE
Unify pcs interfaces, fix IPA and make Honk commitment agnostic

### DIFF
--- a/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.cpp
+++ b/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.cpp
@@ -352,9 +352,11 @@ void add_affine_points_with_edge_cases(g1::affine_element* points, const size_t 
 
     for (size_t i = 0; i < num_points; i += 2) {
         if (points[i].is_point_at_infinity() || points[i + 1].is_point_at_infinity()) {
+            info("POINT AT INFINIT? at ", i);
             continue;
         }
         if (points[i].x == points[i + 1].x) {
+            info("EQUAL POINTS ", i);
             if (points[i].y == points[i + 1].y) {
                 // double
                 scratch_space[i >> 1] = points[i].x + points[i].x; // 2x
@@ -916,14 +918,14 @@ g1::element pippenger(fr* scalars,
  * We use affine-addition formula in this method, which paradoxically is ~45% faster than the mixed addition formulae.
  * See `scalar_multiplication.cpp` for a more detailed description.
  *
- * It's...unsafe, because we assume that the incomplete addition formula exceptions are not triggered.
+ * It's...unsafe, because we assume that the incomplete addition formula exceptions are not triggered i.e. that all the
+ * points provided as arguments to the msm are distinct.
  * We don't bother to check for this to avoid conditional branches in a critical section of our code.
- * This is fine for situations where your bases are linearly independent (i.e. KZG10 polynomial commitments),
- * because triggering the incomplete addition exceptions is about as hard as solving the disrete log problem.
- *
- * This is ok for the prover, but GIANT RED CLAXON WARNINGS FOR THE VERIFIER
- * Don't use this in a verification algorithm! That would be a really bad idea.
- * Unless you're a malicious adversary, then it would be a great idea!
+ * This is fine for situations where your bases are linearly independent (i.e. KZG10 polynomial commitments where
+ * there should be no equal points in the SRS), because triggering the incomplete addition exceptions is about as hard
+ *as solving the disrete log problem. This is ok for the prover, but GIANT RED CLAXON WARNINGS FOR THE VERIFIER Don't
+ *use this in a verification algorithm! That would be a really bad idea. Unless you're a malicious adversary, then it
+ *would be a great idea!
  *
  **/
 g1::element pippenger_unsafe(fr* scalars,

--- a/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.cpp
+++ b/cpp/src/barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.cpp
@@ -101,6 +101,10 @@
 namespace barretenberg {
 namespace scalar_multiplication {
 
+/**
+ * The pippppenger point table computes for each point P = (x,y), a point P' = (\beta * x, -y) which enables us
+ * to use the curve endomorphism for faster scalar multiplication. See below for more details.
+ */
 void generate_pippenger_point_table(g1::affine_element* points, g1::affine_element* table, size_t num_points)
 {
     // iterate backwards, so that `points` and `table` can point to the same memory location
@@ -352,11 +356,9 @@ void add_affine_points_with_edge_cases(g1::affine_element* points, const size_t 
 
     for (size_t i = 0; i < num_points; i += 2) {
         if (points[i].is_point_at_infinity() || points[i + 1].is_point_at_infinity()) {
-            info("POINT AT INFINIT? at ", i);
             continue;
         }
         if (points[i].x == points[i + 1].x) {
-            info("EQUAL POINTS ", i);
             if (points[i].y == points[i + 1].y) {
                 // double
                 scratch_space[i >> 1] = points[i].x + points[i].x; // 2x

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
@@ -15,6 +15,7 @@ namespace proof_system::honk {
 class StandardHonkComposerHelper {
   public:
     using Flavor = flavor::Standard;
+    using PCSParams = Flavor::PCSParams;
     using CircuitConstructor = Flavor::CircuitConstructor;
     using ProvingKey = Flavor::ProvingKey;
     using VerificationKey = Flavor::VerificationKey;
@@ -63,7 +64,7 @@ class StandardHonkComposerHelper {
     // This needs to be static as it may be used only to compute the selector commitments.
 
     static std::shared_ptr<VerificationKey> compute_verification_key_base(
-        std::shared_ptr<ProvingKey> const& proving_key, std::shared_ptr<VerifierReferenceString> const& vrs);
+        std::shared_ptr<ProvingKey> const& proving_key);
 
     void compute_witness(const CircuitConstructor& circuit_constructor, const size_t minimum_circuit_size = 0);
 };

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
@@ -19,6 +19,10 @@ class UltraHonkComposerHelper {
     using CircuitConstructor = Flavor::CircuitConstructor;
     using ProvingKey = Flavor::ProvingKey;
     using VerificationKey = Flavor::VerificationKey;
+    using PCSParams = Flavor::PCSParams;
+    using PCS = Flavor::PCS;
+    using PCSCommitmentKey = PCSParams::CommitmentKey;
+    using PCSVerificationKey = PCSParams::VerificationKey;
 
     static constexpr size_t NUM_RESERVED_GATES = 4; // equal to the number of multilinear evaluations leaked
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -6,7 +6,12 @@
 #include <type_traits>
 #include <vector>
 #include "barretenberg/honk/pcs/commitment_key.hpp"
+<<<<<<< HEAD
 #include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
+=======
+#include "barretenberg/honk/pcs/ipa/ipa.hpp"
+#include "barretenberg/honk/pcs/kzg/kzg.hpp"
+>>>>>>> wip
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"
@@ -40,6 +45,7 @@ class Standard {
     using Commitment = G1::affine_element;
     using CommitmentHandle = G1::affine_element;
     using PCSParams = pcs::kzg::Params;
+    using PCS = pcs::kzg::KZG<PCSParams>;
 
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 #include "barretenberg/honk/pcs/commitment_key.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
-#include "barretenberg/honk/pcs/ipa/ipa.hpp"
 #include "barretenberg/honk/pcs/kzg/kzg.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -6,12 +6,9 @@
 #include <type_traits>
 #include <vector>
 #include "barretenberg/honk/pcs/commitment_key.hpp"
-<<<<<<< HEAD
 #include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
-=======
 #include "barretenberg/honk/pcs/ipa/ipa.hpp"
 #include "barretenberg/honk/pcs/kzg/kzg.hpp"
->>>>>>> wip
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -44,7 +44,7 @@ class Ultra {
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often
     // need containers of this size to hold related data, so we choose a name more agnostic than `NUM_POLYNOMIALS`.
-    // Note: this number does not include the individual ultra list polynomials.
+    // Note: this number does not include the individual sorted list polynomials.
     static constexpr size_t NUM_ALL_ENTITIES = 43;
     // The number of polynomials precomputed to describe a circuit and to aid a prover in constructing a satisfying
     // assignment of witnesses. We again choose a neutral name.

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -37,8 +37,8 @@ class Ultra {
     using GroupElement = G1::element;
     using Commitment = G1::affine_element;
     using CommitmentHandle = G1::affine_element;
-    using PCSParams = pcs::ipa::Params;
-    using PCS = pcs::ipa::IPA<PCSParams>;
+    using PCSParams = pcs::kzg::Params;
+    using PCS = pcs::kzg::KZG<PCSParams>;
 
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -7,6 +7,8 @@
 #include <vector>
 #include "barretenberg/honk/pcs/commitment_key.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
+#include "barretenberg/honk/pcs/ipa/ipa.hpp"
+#include "barretenberg/honk/pcs/kzg/kzg.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
@@ -35,12 +37,13 @@ class Ultra {
     using GroupElement = G1::element;
     using Commitment = G1::affine_element;
     using CommitmentHandle = G1::affine_element;
-    using PCSParams = pcs::kzg::Params;
+    using PCSParams = pcs::ipa::Params;
+    using PCS = pcs::ipa::IPA<PCSParams>;
 
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often
     // need containers of this size to hold related data, so we choose a name more agnostic than `NUM_POLYNOMIALS`.
-    // Note: this number does not include the individual sorted list polynomials.
+    // Note: this number does not include the individual P list polynomials.
     static constexpr size_t NUM_ALL_ENTITIES = 43;
     // The number of polynomials precomputed to describe a circuit and to aid a prover in constructing a satisfying
     // assignment of witnesses. We again choose a neutral name.

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -36,8 +36,9 @@ class Ultra {
     using GroupElement = G1::element;
     using Commitment = G1::affine_element;
     using CommitmentHandle = G1::affine_element;
-    // Note: UltraHonk will be run with KZG by default but temporarily we set the commitment to IPA to
+    // UltraHonk will be run with KZG by default but temporarily we set the commitment to IPA to
     // be able to do e2e tests with this pcs as well
+    // TODO: instantiate this with but IPA and KZG when the templating work is finished
     using PCSParams = pcs::ipa::Params;
     using PCS = pcs::ipa::IPA<PCSParams>;
 

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -8,7 +8,6 @@
 #include "barretenberg/honk/pcs/commitment_key.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
 #include "barretenberg/honk/pcs/ipa/ipa.hpp"
-#include "barretenberg/honk/pcs/kzg/kzg.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
@@ -37,13 +36,13 @@ class Ultra {
     using GroupElement = G1::element;
     using Commitment = G1::affine_element;
     using CommitmentHandle = G1::affine_element;
-    using PCSParams = pcs::kzg::Params;
-    using PCS = pcs::kzg::KZG<PCSParams>;
+    using PCSParams = pcs::ipa::Params;
+    using PCS = pcs::ipa::IPA<PCSParams>;
 
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often
     // need containers of this size to hold related data, so we choose a name more agnostic than `NUM_POLYNOMIALS`.
-    // Note: this number does not include the individual P list polynomials.
+    // Note: this number does not include the individual ultra list polynomials.
     static constexpr size_t NUM_ALL_ENTITIES = 43;
     // The number of polynomials precomputed to describe a circuit and to aid a prover in constructing a satisfying
     // assignment of witnesses. We again choose a neutral name.

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -36,6 +36,8 @@ class Ultra {
     using GroupElement = G1::element;
     using Commitment = G1::affine_element;
     using CommitmentHandle = G1::affine_element;
+    // Note: UltraHonk will be run with KZG by default but temporarily we set the commitment to IPA to
+    // be able to do e2e tests with this pcs as well
     using PCSParams = pcs::ipa::Params;
     using PCS = pcs::ipa::IPA<PCSParams>;
 

--- a/cpp/src/barretenberg/honk/pcs/claim.hpp
+++ b/cpp/src/barretenberg/honk/pcs/claim.hpp
@@ -26,15 +26,15 @@ template <typename Params> class OpeningPair {
  * @tparam Params for the given commitment scheme
  */
 template <typename Params> class OpeningClaim {
-    using CK = typename Params::CK;
-    using CommitmentAffine = typename Params::C;
+    using CK = typename Params::CommitmentKey;
+    using Commitment = typename Params::Commitment;
     using Fr = typename Params::Fr;
 
   public:
     // (challenge r, evaluation v = p(r))
     OpeningPair<Params> opening_pair;
     // commitment to univariate polynomial p(X)
-    CommitmentAffine commitment;
+    Commitment commitment;
 
     /**
      * @brief inefficiently check that the claim is correct by recomputing the commitment
@@ -44,7 +44,7 @@ template <typename Params> class OpeningClaim {
      * @param polynomial the claimed witness polynomial p(X)
      * @return C = Commit(p(X)) && p(r) = v
      */
-    bool verify(CK* ck, const barretenberg::Polynomial<Fr>& polynomial) const
+    bool verify(std::shared_ptr<CK> ck, const barretenberg::Polynomial<Fr>& polynomial) const
     {
         Fr real_eval = polynomial.evaluate(opening_pair.challenge);
         if (real_eval != opening_pair.evaluation) {
@@ -78,14 +78,14 @@ template <typename Params> class OpeningClaim {
  * @tparam CommitmentKey
  */
 template <typename Params> class MLEOpeningClaim {
-    using CommitmentAffine = typename Params::C;
+    using Commitment = typename Params::Commitment;
     using Fr = typename Params::Fr;
 
   public:
     // commitment to a univariate polynomial
     // whose coefficients are the multi-linear evaluations
     // of C = [f]
-    CommitmentAffine commitment;
+    Commitment commitment;
     // v  = f(u) = ∑ᵢ aᵢ⋅Lᵢ(u)
     // v↺ = g(u) = a₁⋅L₀(u) + … + aₙ₋₁⋅Lₙ₋₂(u)
     Fr evaluation;

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -30,10 +30,9 @@ namespace kzg {
 class CommitmentKey {
     using Fr = typename barretenberg::g1::Fr;
     // C is a "raw commitment" resulting to be fed to the transcript.
-    using C = typename barretenberg::g1::affine_element;
+    using Commitment = typename barretenberg::g1::affine_element;
     // Commitment represent's a homomorphically computed group element.
-    using Commitment = barretenberg::g1::element;
-
+    using GroupElement = barretenberg::g1::element;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
   public:
@@ -55,9 +54,9 @@ class CommitmentKey {
      * @brief Uses the ProverSRS to create a commitment to p(X)
      *
      * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
-     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁
+     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁ where x is the secret trapdoor
      */
-    C commit(std::span<const Fr> polynomial)
+    Commitment commit(std::span<const Fr> polynomial)
     {
         const size_t degree = polynomial.size();
         ASSERT(degree <= srs.get_monomial_size());
@@ -65,29 +64,27 @@ class CommitmentKey {
             const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
     };
 
-  private:
+    //   private:
     barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
     proof_system::FileReferenceString srs;
 };
 
 class VerificationKey {
-    using Fr = typename barretenberg::g1::Fr;
-    using C = typename barretenberg::g1::affine_element;
-
-    using Commitment = barretenberg::g1::element;
-    using Polynomial = barretenberg::Polynomial<Fr>;
+    using GroupElement = typename barretenberg::g1::element;
+    using Commitment = typename barretenberg::g1::affine_element;
 
   public:
     VerificationKey() = delete;
 
     /**
-     * @brief Construct a new Kate Commitment Key object from existing SRS
+     * @brief Construct a new Kate Verification Key object from existing SRS
      *
-     *
+     * @param num_points
      * @param verifier_srs verifier G2 point
      */
-    VerificationKey(std::string_view path)
-        : verifier_srs(std::string(path))
+    VerificationKey(size_t num_points, std::string_view path)
+        : pippenger_runtime_state(num_points)
+        , verifier_srs(std::string(path))
     {}
 
     /**
@@ -97,9 +94,9 @@ class VerificationKey {
      * @param p1 = P₁
      * @return e(P₀,[1]₁)e(P₁,[x]₂) ≡ [1]ₜ
      */
-    bool pairing_check(const Commitment& p0, const Commitment& p1)
+    bool pairing_check(const GroupElement& p0, const GroupElement& p1)
     {
-        C pairing_points[2]{ p0, p1 };
+        Commitment pairing_points[2]{ p0, p1 };
         // The final pairing check of step 12.
         // TODO(Adrian): try to template parametrise the pairing + fq12 output :/
         barretenberg::fq12 result = barretenberg::pairing::reduced_ate_pairing_batch_precomputed(
@@ -108,19 +105,19 @@ class VerificationKey {
         return (result == barretenberg::fq12::one());
     }
 
-  private:
+    barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
     proof_system::VerifierFileReferenceString verifier_srs;
 };
 
 struct Params {
     using Fr = typename barretenberg::g1::Fr;
-    using C = typename barretenberg::g1::affine_element;
+    using Commitment = typename barretenberg::g1::affine_element;
+    using GroupElement = barretenberg::g1::element;
 
-    using Commitment = barretenberg::g1::element;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-    using CK = CommitmentKey;
-    using VK = VerificationKey;
+    using CommitmentKey = CommitmentKey;
+    using VerificationKey = VerificationKey;
 };
 
 } // namespace kzg
@@ -140,9 +137,9 @@ template <typename G> constexpr typename G::Fr trapdoor(5);
  */
 template <typename G> class CommitmentKey {
     using Fr = typename G::Fr;
-    using C = typename G::affine_element;
+    using Commitment = typename G::affine_element;
 
-    using Commitment = typename G::element;
+    using GroupElement = typename G::element;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
   public:
@@ -154,19 +151,15 @@ template <typename G> class CommitmentKey {
      * @param polynomial a univariate polynomial p(X)
      * @return Commitment computed as C = p(secret)•[1]_1 .
      */
-    C commit(std::span<const Fr> polynomial)
+    Commitment commit(std::span<const Fr> polynomial)
     {
         const Fr eval_secret = barretenberg::polynomial_arithmetic::evaluate(polynomial, trapdoor<G>);
-        return C::one() * eval_secret;
+        return Commitment::one() * eval_secret;
     };
 };
 
 template <typename G> class VerificationKey {
-    using Fr = typename G::Fr;
-    using C = typename G::affine_element;
-
-    using Commitment = typename G::element;
-    using Polynomial = barretenberg::Polynomial<Fr>;
+    using Commitment = typename G::affine_element;
 
   public:
     /**
@@ -185,13 +178,13 @@ template <typename G> class VerificationKey {
 
 template <typename G> struct Params {
     using Fr = typename G::Fr;
-    using C = typename G::affine_element;
+    using Commitment = typename G::affine_element;
+    using GroupElement = typename G::element;
 
-    using Commitment = typename G::element;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-    using CK = CommitmentKey<G>;
-    using VK = VerificationKey<G>;
+    using CommitmentKey = CommitmentKey<G>;
+    using VerificationKey = VerificationKey<G>;
 };
 } // namespace fake
 
@@ -199,17 +192,17 @@ namespace ipa {
 
 /**
  * @brief CommitmentKey object over a group 𝔾₁, using a structured reference string (SRS).
- * The SRS is given as a list of 𝔾₁ points
- *  { [xʲ]₁ }ⱼ where 'x' is unknown.
+ * The SRS is given as a list of uniquely derived and random 𝔾₁ points of a specified size.
  *
  * @todo This class should take ownership of the SRS, and handle reading the file from disk.
+ *
  */
 class CommitmentKey {
     using Fr = typename barretenberg::g1::Fr;
     // C is a "raw commitment" resulting to be fed to the transcript.
-    using C = typename barretenberg::g1::affine_element;
+    using Commitment = typename barretenberg::g1::affine_element;
     // Commitment represent's a homomorphically computed group element.
-    using Commitment = barretenberg::g1::element;
+    using GroupElement = barretenberg::g1::element;
 
     using Polynomial = barretenberg::Polynomial<Fr>;
 
@@ -217,12 +210,11 @@ class CommitmentKey {
     CommitmentKey() = delete;
 
     /**
-     * @brief Construct a new Kate Commitment Key object from existing SRS
+     * @brief Construct a new IPA Commitment Key object from existing SRS
      *
-     * @param n
+     * @param num_points
      * @param path
      *
-     * @todo change path to string_view
      */
     CommitmentKey(const size_t num_points, std::string_view path)
         : pippenger_runtime_state(num_points)
@@ -230,12 +222,12 @@ class CommitmentKey {
     {}
 
     /**
-     * @brief Uses the ProverSRS to create a commitment to p(X)
+     * @brief Uses the ProverSRS to create an unblinded commitment to p(X)
      *
      * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
-     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁
+     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅Gᵢ where Gᵢ is the i-th element of the SRS
      */
-    C commit(std::span<const Fr> polynomial)
+    Commitment commit(std::span<const Fr> polynomial)
     {
         const size_t degree = polynomial.size();
         ASSERT(degree <= srs.get_monomial_size());
@@ -249,19 +241,22 @@ class CommitmentKey {
 
 class VerificationKey {
     using Fr = typename barretenberg::g1::Fr;
-    using C = typename barretenberg::g1::affine_element;
+    // C is a "raw commitment" resulting to be fed to the transcript.
+    using Commitment = typename barretenberg::g1::affine_element;
+    // Commitment represent's a homomorphically computed group element.
+    using GroupElement = barretenberg::g1::element;
 
-    using Commitment = barretenberg::g1::element;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
   public:
     VerificationKey() = delete;
 
     /**
-     * @brief Construct a new Kate Commitment Key object from existing SRS
+     * @brief Construct a new IPA Verification Key object from existing SRS
      *
      *
-     * @param verifier_srs verifier G2 point
+     * @param num_points specifies the length of the SRS
+     * @param path is the location to the SRS file
      */
     VerificationKey(const size_t num_points, std::string_view path)
         : pippenger_runtime_state(num_points)
@@ -274,13 +269,13 @@ class VerificationKey {
 
 struct Params {
     using Fr = typename barretenberg::g1::Fr;
-    using C = typename barretenberg::g1::affine_element;
+    using Commitment = typename barretenberg::g1::affine_element;
+    using GroupElement = barretenberg::g1::element;
 
-    using Commitment = barretenberg::g1::element;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-    using CK = CommitmentKey;
-    using VK = VerificationKey;
+    using CommitmentKey = CommitmentKey;
+    using VerificationKey = VerificationKey;
 };
 
 } // namespace ipa

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -3,6 +3,8 @@
 /**
  * @brief Provides interfaces for different 'CommitmentKey' classes.
  *
+ * TODO(#218)(Adrian / Mara): This class should take ownership of the SRS, and handle reading the file from disk as well
+ * as carrying out any modification to the SRS (e.g compute pippenger point table) to simplify the codebase.
  */
 
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
@@ -22,10 +24,10 @@ namespace kzg {
 
 /**
  * @brief CommitmentKey object over a pairing group 𝔾₁, using a structured reference string (SRS).
- * The SRS is given as a list of 𝔾₁ points
- *  { [xʲ]₁ }ⱼ where 'x' is unknown.
+ * The SRS is given as a list of 𝔾₁ points { [xʲ]₁ }ⱼ where 'x' is unknown. The SRS stored in the commitment key is
+ * after applying the pippenger_point_table thus being double the size of what is loaded from path.
  *
- * TODO(#218)(Adrian): This class should take ownership of the SRS, and handle reading the file from disk.
+ *
  */
 class CommitmentKey {
     using Fr = typename barretenberg::g1::Fr;
@@ -192,9 +194,10 @@ namespace ipa {
 
 /**
  * @brief CommitmentKey object over a group 𝔾₁, using a structured reference string (SRS).
- * The SRS is given as a list of uniquely derived and random 𝔾₁ points of a specified size.
+ * The SRS contains a list of uniquely derived and random 𝔾₁ points of a specified size.
+ * The SRS stored in the commitment key is after applying the pippenger_point_table
+ * thus being double the size of what is loaded from memory.
  *
- * @todo This class should take ownership of the SRS, and handle reading the file from disk.
  *
  */
 class CommitmentKey {
@@ -210,7 +213,7 @@ class CommitmentKey {
     CommitmentKey() = delete;
 
     /**
-     * @brief Construct a new IPA Commitment Key object from existing SRS
+     * @brief Construct a new IPA Commitment Key object from existing SRS..
      *
      * @param num_points
      * @param path

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -22,95 +22,6 @@ namespace proof_system::honk::pcs {
 
 namespace kzg {
 
-/**
- * @brief CommitmentKey object over a pairing group 𝔾₁, using a structured reference string (SRS).
- * The SRS is given as a list of 𝔾₁ points { [xʲ]₁ }ⱼ where 'x' is unknown. The SRS stored in the commitment key is
- * after applying the pippenger_point_table thus being double the size of what is loaded from path.
- *
- *
- */
-class CommitmentKey {
-    using Fr = typename barretenberg::g1::Fr;
-    // C is a "raw commitment" resulting to be fed to the transcript.
-    using Commitment = typename barretenberg::g1::affine_element;
-    // Commitment represent's a homomorphically computed group element.
-    using GroupElement = barretenberg::g1::element;
-    using Polynomial = barretenberg::Polynomial<Fr>;
-
-  public:
-    CommitmentKey() = delete;
-
-    /**
-     * @brief Construct a new Kate Commitment Key object from existing SRS
-     *
-     * @param n
-     * @param path
-     *
-     */
-    CommitmentKey(const size_t num_points, std::string_view path)
-        : pippenger_runtime_state(num_points)
-        , srs(num_points, std::string(path))
-    {}
-
-    /**
-     * @brief Uses the ProverSRS to create a commitment to p(X)
-     *
-     * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
-     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁ where x is the secret trapdoor
-     */
-    Commitment commit(std::span<const Fr> polynomial)
-    {
-        const size_t degree = polynomial.size();
-        ASSERT(degree <= srs.get_monomial_size());
-        return barretenberg::scalar_multiplication::pippenger_unsafe(
-            const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
-    };
-
-    //   private:
-    barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
-    proof_system::FileReferenceString srs;
-};
-
-class VerificationKey {
-    using GroupElement = typename barretenberg::g1::element;
-    using Commitment = typename barretenberg::g1::affine_element;
-
-  public:
-    VerificationKey() = delete;
-
-    /**
-     * @brief Construct a new Kate Verification Key object from existing SRS
-     *
-     * @param num_points
-     * @param verifier_srs verifier G2 point
-     */
-    VerificationKey(size_t num_points, std::string_view path)
-        : pippenger_runtime_state(num_points)
-        , verifier_srs(std::string(path))
-    {}
-
-    /**
-     * @brief verifies a pairing equation over 2 points using the verifier SRS
-     *
-     * @param p0 = P₀
-     * @param p1 = P₁
-     * @return e(P₀,[1]₁)e(P₁,[x]₂) ≡ [1]ₜ
-     */
-    bool pairing_check(const GroupElement& p0, const GroupElement& p1)
-    {
-        Commitment pairing_points[2]{ p0, p1 };
-        // The final pairing check of step 12.
-        // TODO(Adrian): try to template parametrise the pairing + fq12 output :/
-        barretenberg::fq12 result = barretenberg::pairing::reduced_ate_pairing_batch_precomputed(
-            pairing_points, verifier_srs.get_precomputed_g2_lines(), 2);
-
-        return (result == barretenberg::fq12::one());
-    }
-
-    barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
-    proof_system::VerifierFileReferenceString verifier_srs;
-};
-
 struct Params {
     using Fr = typename barretenberg::g1::Fr;
     using Commitment = typename barretenberg::g1::affine_element;
@@ -118,8 +29,87 @@ struct Params {
 
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-    using CommitmentKey = CommitmentKey;
-    using VerificationKey = VerificationKey;
+    class CommitmentKey;
+    class VerificationKey;
+    /**
+     * @brief CommitmentKey object over a pairing group 𝔾₁, using a structured reference string (SRS).
+     * The SRS is given as a list of 𝔾₁ points { [xʲ]₁ }ⱼ where 'x' is unknown. The SRS stored in the commitment key is
+     * after applying the pippenger_point_table thus being double the size of what is loaded from path.
+     *
+     *
+     */
+    class CommitmentKey {
+
+      public:
+        CommitmentKey() = delete;
+
+        /**
+         * @brief Construct a new Kate Commitment Key object from existing SRS
+         *
+         * @param n
+         * @param path
+         *
+         */
+        CommitmentKey(const size_t num_points, std::string_view path)
+            : pippenger_runtime_state(num_points)
+            , srs(num_points, std::string(path))
+        {}
+
+        /**
+         * @brief Uses the ProverSRS to create a commitment to p(X)
+         *
+         * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
+         * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅[xⁱ]₁ where x is the secret trapdoor
+         */
+        Commitment commit(std::span<const Fr> polynomial)
+        {
+            const size_t degree = polynomial.size();
+            ASSERT(degree <= srs.get_monomial_size());
+            return barretenberg::scalar_multiplication::pippenger_unsafe(
+                const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
+        };
+
+        barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
+        proof_system::FileReferenceString srs;
+    };
+
+    class VerificationKey {
+
+      public:
+        VerificationKey() = delete;
+
+        /**
+         * @brief Construct a new Kate Verification Key object from existing SRS
+         *
+         * @param num_points
+         * @param verifier_srs verifier G2 point
+         */
+        VerificationKey(size_t num_points, std::string_view path)
+            : pippenger_runtime_state(num_points)
+            , verifier_srs(std::string(path))
+        {}
+
+        /**
+         * @brief verifies a pairing equation over 2 points using the verifier SRS
+         *
+         * @param p0 = P₀
+         * @param p1 = P₁
+         * @return e(P₀,[1]₁)e(P₁,[x]₂) ≡ [1]ₜ
+         */
+        bool pairing_check(const GroupElement& p0, const GroupElement& p1)
+        {
+            Commitment pairing_points[2]{ p0, p1 };
+            // The final pairing check of step 12.
+            // TODO(Adrian): try to template parametrise the pairing + fq12 output :/
+            barretenberg::fq12 result = barretenberg::pairing::reduced_ate_pairing_batch_precomputed(
+                pairing_points, verifier_srs.get_precomputed_g2_lines(), 2);
+
+            return (result == barretenberg::fq12::one());
+        }
+
+        barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
+        proof_system::VerifierFileReferenceString verifier_srs;
+    };
 };
 
 } // namespace kzg
@@ -131,53 +121,6 @@ namespace {
 template <typename G> constexpr typename G::Fr trapdoor(5);
 }
 
-/**
- * @brief Simulates a KZG CommitmentKey, but where we know the secret trapdoor
- * which allows us to commit to polynomials using a single group multiplication.
- *
- * @tparam G the commitment group
- */
-template <typename G> class CommitmentKey {
-    using Fr = typename G::Fr;
-    using Commitment = typename G::affine_element;
-
-    using GroupElement = typename G::element;
-    using Polynomial = barretenberg::Polynomial<Fr>;
-
-  public:
-    /**
-     * @brief efficiently create a KZG commitment to p(X) using the trapdoor 'secret'
-     * Uses only 1 group scalar multiplication, and 1 polynomial evaluation
-     *
-     *
-     * @param polynomial a univariate polynomial p(X)
-     * @return Commitment computed as C = p(secret)•[1]_1 .
-     */
-    Commitment commit(std::span<const Fr> polynomial)
-    {
-        const Fr eval_secret = barretenberg::polynomial_arithmetic::evaluate(polynomial, trapdoor<G>);
-        return Commitment::one() * eval_secret;
-    };
-};
-
-template <typename G> class VerificationKey {
-    using Commitment = typename G::affine_element;
-
-  public:
-    /**
-     * @brief verifies a pairing equation over 2 points using the trapdoor
-     *
-     * @param p0 = P₀
-     * @param p1 = P₁
-     * @return P₀ - x⋅P₁ ≡ [1]
-     */
-    bool pairing_check(const Commitment& p0, const Commitment& p1)
-    {
-        Commitment result = p0 + p1 * trapdoor<G>;
-        return result.is_point_at_infinity();
-    }
-};
-
 template <typename G> struct Params {
     using Fr = typename G::Fr;
     using Commitment = typename G::affine_element;
@@ -185,90 +128,53 @@ template <typename G> struct Params {
 
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-    using CommitmentKey = CommitmentKey<G>;
-    using VerificationKey = VerificationKey<G>;
+    template <G> class CommitmentKey;
+    template <G> class VerificationKey;
+
+    /**
+     * @brief Simulates a KZG CommitmentKey, but where we know the secret trapdoor
+     * which allows us to commit to polynomials using a single group multiplication.
+     *
+     * @tparam G the commitment group
+     */
+    template <G> class CommitmentKey {
+
+      public:
+        /**
+         * @brief efficiently create a KZG commitment to p(X) using the trapdoor 'secret'
+         * Uses only 1 group scalar multiplication, and 1 polynomial evaluation
+         *
+         *
+         * @param polynomial a univariate polynomial p(X)
+         * @return Commitment computed as C = p(secret)•[1]_1 .
+         */
+        Commitment commit(std::span<const Fr> polynomial)
+        {
+            const Fr eval_secret = barretenberg::polynomial_arithmetic::evaluate(polynomial, trapdoor<G>);
+            return Commitment::one() * eval_secret;
+        };
+    };
+
+    template <G> class VerificationKey {
+
+      public:
+        /**
+         * @brief verifies a pairing equation over 2 points using the trapdoor
+         *
+         * @param p0 = P₀
+         * @param p1 = P₁
+         * @return P₀ - x⋅P₁ ≡ [1]
+         */
+        bool pairing_check(const Commitment& p0, const Commitment& p1)
+        {
+            Commitment result = p0 + p1 * trapdoor<G>;
+            return result.is_point_at_infinity();
+        }
+    };
 };
 } // namespace fake
 
 namespace ipa {
-
-/**
- * @brief CommitmentKey object over a group 𝔾₁, using a structured reference string (SRS).
- * The SRS contains a list of uniquely derived and random 𝔾₁ points of a specified size.
- * The SRS stored in the commitment key is after applying the pippenger_point_table
- * thus being double the size of what is loaded from memory.
- *
- *
- */
-class CommitmentKey {
-    using Fr = typename barretenberg::g1::Fr;
-    // C is a "raw commitment" resulting to be fed to the transcript.
-    using Commitment = typename barretenberg::g1::affine_element;
-    // Commitment represent's a homomorphically computed group element.
-    using GroupElement = barretenberg::g1::element;
-
-    using Polynomial = barretenberg::Polynomial<Fr>;
-
-  public:
-    CommitmentKey() = delete;
-
-    /**
-     * @brief Construct a new IPA Commitment Key object from existing SRS..
-     *
-     * @param num_points
-     * @param path
-     *
-     */
-    CommitmentKey(const size_t num_points, std::string_view path)
-        : pippenger_runtime_state(num_points)
-        , srs(num_points, std::string(path))
-    {}
-
-    /**
-     * @brief Uses the ProverSRS to create an unblinded commitment to p(X)
-     *
-     * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
-     * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅Gᵢ where Gᵢ is the i-th element of the SRS
-     */
-    Commitment commit(std::span<const Fr> polynomial)
-    {
-        const size_t degree = polynomial.size();
-        ASSERT(degree <= srs.get_monomial_size());
-        return barretenberg::scalar_multiplication::pippenger_unsafe(
-            const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
-    };
-
-    barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
-    proof_system::FileReferenceString srs;
-};
-
-class VerificationKey {
-    using Fr = typename barretenberg::g1::Fr;
-    // C is a "raw commitment" resulting to be fed to the transcript.
-    using Commitment = typename barretenberg::g1::affine_element;
-    // Commitment represent's a homomorphically computed group element.
-    using GroupElement = barretenberg::g1::element;
-
-    using Polynomial = barretenberg::Polynomial<Fr>;
-
-  public:
-    VerificationKey() = delete;
-
-    /**
-     * @brief Construct a new IPA Verification Key object from existing SRS
-     *
-     *
-     * @param num_points specifies the length of the SRS
-     * @param path is the location to the SRS file
-     */
-    VerificationKey(const size_t num_points, std::string_view path)
-        : pippenger_runtime_state(num_points)
-        , srs(num_points, std::string(path))
-    {}
-
-    barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
-    proof_system::FileReferenceString srs;
-};
 
 struct Params {
     using Fr = typename barretenberg::g1::Fr;
@@ -277,8 +183,63 @@ struct Params {
 
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-    using CommitmentKey = CommitmentKey;
-    using VerificationKey = VerificationKey;
+    class CommitmentKey;
+    class VerificationKey;
+
+    class CommitmentKey {
+
+      public:
+        CommitmentKey() = delete;
+
+        /**
+         * @brief Construct a new IPA Commitment Key object from existing SRS..
+         *
+         * @param num_points
+         * @param path
+         *
+         */
+        CommitmentKey(const size_t num_points, std::string_view path)
+            : pippenger_runtime_state(num_points)
+            , srs(num_points, std::string(path))
+        {}
+
+        /**
+         * @brief Uses the ProverSRS to create an unblinded commitment to p(X)
+         *
+         * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ ()
+         * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅Gᵢ where Gᵢ is the i-th element of the SRS
+         */
+        Commitment commit(std::span<const Fr> polynomial)
+        {
+            const size_t degree = polynomial.size();
+            ASSERT(degree <= srs.get_monomial_size());
+            return barretenberg::scalar_multiplication::pippenger_unsafe(
+                const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
+        };
+
+        barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
+        proof_system::FileReferenceString srs;
+    };
+
+    class VerificationKey {
+      public:
+        VerificationKey() = delete;
+
+        /**
+         * @brief Construct a new IPA Verification Key object from existing SRS
+         *
+         *
+         * @param num_points specifies the length of the SRS
+         * @param path is the location to the SRS file
+         */
+        VerificationKey(const size_t num_points, std::string_view path)
+            : pippenger_runtime_state(num_points)
+            , srs(num_points, std::string(path))
+        {}
+
+        barretenberg::scalar_multiplication::pippenger_runtime_state pippenger_runtime_state;
+        proof_system::FileReferenceString srs;
+    };
 };
 
 } // namespace ipa

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -231,7 +231,7 @@ class CommitmentKey {
     {
         const size_t degree = polynomial.size();
         ASSERT(degree <= srs.get_monomial_size());
-        return barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
+        return barretenberg::scalar_multiplication::pippenger_unsafe(
             const_cast<Fr*>(polynomial.data()), srs.get_monomial_points(), degree, pippenger_runtime_state);
     };
 

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
@@ -47,7 +47,8 @@ template <class VK> inline std::shared_ptr<VK> CreateVerificationKey();
 
 template <> inline std::shared_ptr<kzg::VerificationKey> CreateVerificationKey<kzg::VerificationKey>()
 {
-    return std::make_shared<kzg::VerificationKey>(kzg_srs_path);
+    const size_t n = 128;
+    return std::make_shared<kzg::VerificationKey>(n, kzg_srs_path);
 }
 // For IPA
 template <> inline std::shared_ptr<ipa::VerificationKey> CreateVerificationKey<ipa::VerificationKey>()
@@ -61,29 +62,30 @@ template <typename VK> inline std::shared_ptr<VK> CreateVerificationKey()
     return std::make_shared<VK>();
 }
 template <typename Params> class CommitmentTest : public ::testing::Test {
-    using CK = typename Params::CK;
-    using VK = typename Params::VK;
+    using CK = typename Params::CommitmentKey;
+    using VK = typename Params::VerificationKey;
 
     using Fr = typename Params::Fr;
-    using CommitmentAffine = typename Params::C;
+    using Commitment = typename Params::Commitment;
     using Polynomial = typename Params::Polynomial;
     using Transcript = transcript::StandardTranscript;
 
   public:
     CommitmentTest()
-        : engine{ &numeric::random::get_debug_engine() }
+        : engine{ &numeric::random::get_engine() }
     {}
 
     std::shared_ptr<CK> ck() { return commitment_key; }
     std::shared_ptr<VK> vk() { return verification_key; }
 
-    CommitmentAffine commit(const Polynomial& polynomial) { return commitment_key->commit(polynomial); }
+    Commitment commit(const Polynomial& polynomial) { return commitment_key->commit(polynomial); }
 
     Polynomial random_polynomial(const size_t n)
     {
         Polynomial p(n);
         for (size_t i = 0; i < n; ++i) {
             p[i] = Fr::random_element(engine);
+            // p[i] = Fr::one();
         }
         return p;
     }
@@ -121,7 +123,7 @@ template <typename Params> class CommitmentTest : public ::testing::Test {
         auto& [x, y] = claim.opening_pair;
         Fr y_expected = witness.evaluate(x);
         EXPECT_EQ(y, y_expected) << "OpeningClaim: evaluations mismatch";
-        CommitmentAffine commitment_expected = commit(witness);
+        Commitment commitment_expected = commit(witness);
         EXPECT_EQ(commitment, commitment_expected) << "OpeningClaim: commitment mismatch";
     }
 
@@ -186,14 +188,14 @@ template <typename Params> class CommitmentTest : public ::testing::Test {
     // Can be omitted if not needed.
     static void TearDownTestSuite() {}
 
-    static typename std::shared_ptr<typename Params::CK> commitment_key;
-    static typename std::shared_ptr<typename Params::VK> verification_key;
+    static typename std::shared_ptr<typename Params::CommitmentKey> commitment_key;
+    static typename std::shared_ptr<typename Params::VerificationKey> verification_key;
 };
 
 template <typename Params>
-typename std::shared_ptr<typename Params::CK> CommitmentTest<Params>::commitment_key = nullptr;
+typename std::shared_ptr<typename Params::CommitmentKey> CommitmentTest<Params>::commitment_key = nullptr;
 template <typename Params>
-typename std::shared_ptr<typename Params::VK> CommitmentTest<Params>::verification_key = nullptr;
+typename std::shared_ptr<typename Params::VerificationKey> CommitmentTest<Params>::verification_key = nullptr;
 
 using CommitmentSchemeParams = ::testing::Types<kzg::Params>;
 using IpaCommitmentSchemeParams = ::testing::Types<ipa::Params>;

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
@@ -25,16 +25,16 @@ constexpr std::string_view kzg_srs_path = "../srs_db/ignition";
 
 template <class CK> inline std::shared_ptr<CK> CreateCommitmentKey();
 
-template <> inline std::shared_ptr<kzg::CommitmentKey> CreateCommitmentKey<kzg::CommitmentKey>()
+template <> inline std::shared_ptr<kzg::Params::CommitmentKey> CreateCommitmentKey<kzg::Params::CommitmentKey>()
 {
     const size_t n = 128;
-    return std::make_shared<kzg::CommitmentKey>(n, kzg_srs_path);
+    return std::make_shared<kzg::Params::CommitmentKey>(n, kzg_srs_path);
 }
 // For IPA
-template <> inline std::shared_ptr<ipa::CommitmentKey> CreateCommitmentKey<ipa::CommitmentKey>()
+template <> inline std::shared_ptr<ipa::Params::CommitmentKey> CreateCommitmentKey<ipa::Params::CommitmentKey>()
 {
     const size_t n = 128;
-    return std::make_shared<ipa::CommitmentKey>(n, kzg_srs_path);
+    return std::make_shared<ipa::Params::CommitmentKey>(n, kzg_srs_path);
 }
 
 template <typename CK> inline std::shared_ptr<CK> CreateCommitmentKey()
@@ -45,16 +45,17 @@ template <typename CK> inline std::shared_ptr<CK> CreateCommitmentKey()
 
 template <class VK> inline std::shared_ptr<VK> CreateVerificationKey();
 
-template <> inline std::shared_ptr<kzg::VerificationKey> CreateVerificationKey<kzg::VerificationKey>()
+template <> inline std::shared_ptr<kzg::Params::VerificationKey> CreateVerificationKey<kzg::Params::VerificationKey>()
 {
     const size_t n = 128;
-    return std::make_shared<kzg::VerificationKey>(n, kzg_srs_path);
+    return std::make_shared<kzg::Params::VerificationKey>(n, kzg_srs_path);
 }
 // For IPA
-template <> inline std::shared_ptr<ipa::VerificationKey> CreateVerificationKey<ipa::VerificationKey>()
+template <> inline std::shared_ptr<ipa::Params::VerificationKey> CreateVerificationKey<ipa::Params::VerificationKey>()
 {
     const size_t n = 128;
-    return std::make_shared<ipa::VerificationKey>(n, kzg_srs_path);
+    //
+    return std::make_shared<ipa::Params::VerificationKey>(n, kzg_srs_path);
 }
 template <typename VK> inline std::shared_ptr<VK> CreateVerificationKey()
 // requires std::default_initializable<VK>

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
@@ -85,7 +85,6 @@ template <typename Params> class CommitmentTest : public ::testing::Test {
         Polynomial p(n);
         for (size_t i = 0; i < n; ++i) {
             p[i] = Fr::random_element(engine);
-            // p[i] = Fr::one();
         }
         return p;
     }

--- a/cpp/src/barretenberg/honk/pcs/gemini/gemini.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/gemini/gemini.test.cpp
@@ -12,7 +12,7 @@ namespace proof_system::honk::pcs::gemini {
 template <class Params> class GeminiTest : public CommitmentTest<Params> {
     using Gemini = MultilinearReductionScheme<Params>;
     using Fr = typename Params::Fr;
-    using Commitment = typename Params::Commitment;
+    using GroupElement = typename Params::GroupElement;
     using Polynomial = typename barretenberg::Polynomial<Fr>;
 
   public:
@@ -21,8 +21,8 @@ template <class Params> class GeminiTest : public CommitmentTest<Params> {
                                           std::vector<Fr> multilinear_evaluations,
                                           std::vector<std::span<Fr>> multilinear_polynomials,
                                           std::vector<std::span<Fr>> multilinear_polynomials_to_be_shifted,
-                                          std::vector<Commitment> multilinear_commitments,
-                                          std::vector<Commitment> multilinear_commitments_to_be_shifted)
+                                          std::vector<GroupElement> multilinear_commitments,
+                                          std::vector<GroupElement> multilinear_commitments_to_be_shifted)
     {
         auto prover_transcript = ProverTranscript<Fr>::init_empty();
 
@@ -38,8 +38,8 @@ template <class Params> class GeminiTest : public CommitmentTest<Params> {
 
         Polynomial batched_unshifted(1 << log_n);
         Polynomial batched_to_be_shifted(1 << log_n);
-        Commitment batched_commitment_unshifted = Commitment::zero();
-        Commitment batched_commitment_to_be_shifted = Commitment::zero();
+        GroupElement batched_commitment_unshifted = GroupElement::zero();
+        GroupElement batched_commitment_to_be_shifted = GroupElement::zero();
         const size_t num_unshifted = multilinear_polynomials.size();
         const size_t num_shifted = multilinear_polynomials_to_be_shifted.size();
         for (size_t i = 0; i < num_unshifted; ++i) {
@@ -105,7 +105,7 @@ TYPED_TEST_SUITE(GeminiTest, CommitmentSchemeParams);
 TYPED_TEST(GeminiTest, Single)
 {
     using Fr = typename TypeParam::Fr;
-    using Commitment = typename TypeParam::Commitment;
+    using GroupElement = typename TypeParam::GroupElement;
 
     const size_t n = 16;
     const size_t log_n = 4;
@@ -119,8 +119,8 @@ TYPED_TEST(GeminiTest, Single)
     std::vector<Fr> multilinear_evaluations = { eval };
     std::vector<std::span<Fr>> multilinear_polynomials = { poly };
     std::vector<std::span<Fr>> multilinear_polynomials_to_be_shifted = {};
-    std::vector<Commitment> multilinear_commitments = { commitment };
-    std::vector<Commitment> multilinear_commitments_to_be_shifted = {};
+    std::vector<GroupElement> multilinear_commitments = { commitment };
+    std::vector<GroupElement> multilinear_commitments_to_be_shifted = {};
 
     this->execute_gemini_and_verify_claims(log_n,
                                            u,
@@ -134,7 +134,7 @@ TYPED_TEST(GeminiTest, Single)
 TYPED_TEST(GeminiTest, SingleShift)
 {
     using Fr = typename TypeParam::Fr;
-    using Commitment = typename TypeParam::Commitment;
+    using GroupElement = typename TypeParam::GroupElement;
 
     const size_t n = 16;
     const size_t log_n = 4;
@@ -152,8 +152,8 @@ TYPED_TEST(GeminiTest, SingleShift)
     std::vector<Fr> multilinear_evaluations = { eval_shift };
     std::vector<std::span<Fr>> multilinear_polynomials = {};
     std::vector<std::span<Fr>> multilinear_polynomials_to_be_shifted = { poly };
-    std::vector<Commitment> multilinear_commitments = {};
-    std::vector<Commitment> multilinear_commitments_to_be_shifted = { commitment };
+    std::vector<GroupElement> multilinear_commitments = {};
+    std::vector<GroupElement> multilinear_commitments_to_be_shifted = { commitment };
 
     this->execute_gemini_and_verify_claims(log_n,
                                            u,
@@ -167,7 +167,7 @@ TYPED_TEST(GeminiTest, SingleShift)
 TYPED_TEST(GeminiTest, Double)
 {
     using Fr = typename TypeParam::Fr;
-    using Commitment = typename TypeParam::Commitment;
+    using GroupElement = typename TypeParam::GroupElement;
 
     const size_t n = 16;
     const size_t log_n = 4;
@@ -187,8 +187,8 @@ TYPED_TEST(GeminiTest, Double)
     std::vector<Fr> multilinear_evaluations = { eval1, eval2 };
     std::vector<std::span<Fr>> multilinear_polynomials = { poly1, poly2 };
     std::vector<std::span<Fr>> multilinear_polynomials_to_be_shifted = {};
-    std::vector<Commitment> multilinear_commitments = { commitment1, commitment2 };
-    std::vector<Commitment> multilinear_commitments_to_be_shifted = {};
+    std::vector<GroupElement> multilinear_commitments = { commitment1, commitment2 };
+    std::vector<GroupElement> multilinear_commitments_to_be_shifted = {};
 
     this->execute_gemini_and_verify_claims(log_n,
                                            u,
@@ -203,7 +203,7 @@ TYPED_TEST(GeminiTest, DoubleWithShift)
 {
     // using Gemini = MultilinearReductionScheme<TypeParam>;
     using Fr = typename TypeParam::Fr;
-    using Commitment = typename TypeParam::Commitment;
+    using GroupElement = typename TypeParam::GroupElement;
 
     const size_t n = 16;
     const size_t log_n = 4;
@@ -225,8 +225,8 @@ TYPED_TEST(GeminiTest, DoubleWithShift)
     std::vector<Fr> multilinear_evaluations = { eval1, eval2, eval2_shift };
     std::vector<std::span<Fr>> multilinear_polynomials = { poly1, poly2 };
     std::vector<std::span<Fr>> multilinear_polynomials_to_be_shifted = { poly2 };
-    std::vector<Commitment> multilinear_commitments = { commitment1, commitment2 };
-    std::vector<Commitment> multilinear_commitments_to_be_shifted = { commitment2 };
+    std::vector<GroupElement> multilinear_commitments = { commitment1, commitment2 };
+    std::vector<GroupElement> multilinear_commitments_to_be_shifted = { commitment2 };
 
     this->execute_gemini_and_verify_claims(log_n,
                                            u,

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -50,7 +50,7 @@ template <typename Params> class IPA {
                "The poly_degree should be positive and a power of two");
 
         auto a_vec = polynomial;
-        // TODO(Mara): restructure IPA so it can be integrated with the work_queue (or replacement) and
+        // TODO(#479): restructure IPA so it can be integrated with the work_queue (or replacement) and
         // see if reducing the size of G_vec_local and b_vec by taking the first iteration out of the loop
         // can also be integrated.
         auto srs_elements = ck->srs.get_monomial_points();

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -39,9 +39,9 @@ template <typename Params> class IPA {
                                       ProverTranscript<Fr>& transcript)
     {
         ASSERT(opening_pair.challenge != 0 && "The challenge point should not be zero");
-        size_t poly_degree = polynomial.size();
-        transcript.send_to_verifier("IPA:poly_degree", poly_degree);
-
+        auto poly_degree = static_cast<size_t>(polynomial.size());
+        transcript.send_to_verifier("IPA:poly_degree", static_cast<uint64_t>(poly_degree));
+        info(poly_degree);
         Fr generator_challenge = transcript.get_challenge("IPA:generator_challenge");
         auto aux_generator = Commitment::one() * generator_challenge;
 
@@ -73,7 +73,7 @@ template <typename Params> class IPA {
             b_power *= opening_pair.challenge;
         }
         // Iterate for log_2(poly_degree) rounds to compute the round commitments.
-        size_t log_poly_degree(numeric::get_msb(poly_degree));
+        auto log_poly_degree = static_cast<size_t>(numeric::get_msb(poly_degree));
         std::vector<GroupElement> L_elements(log_poly_degree);
         std::vector<GroupElement> R_elements(log_poly_degree);
         std::size_t round_size = poly_degree;
@@ -141,17 +141,17 @@ template <typename Params> class IPA {
                        VerifierTranscript<Fr>& transcript)
     {
         // so we should get an OpeningClaim as parameter with
-        auto poly_degree = transcript.template receive_from_prover<size_t>("IPA:poly_degree");
+        auto poly_degree = static_cast<size_t>(transcript.template receive_from_prover<uint64_t>("IPA:poly_degree"));
         Fr generator_challenge = transcript.get_challenge("IPA:generator_challenge");
         auto aux_generator = Commitment::one() * generator_challenge;
 
-        size_t log_poly_degree = numeric::get_msb(poly_degree);
+        auto log_poly_degree = static_cast<size_t>(numeric::get_msb(poly_degree));
 
         // Compute C_prime
         GroupElement C_prime = opening_claim.commitment + (aux_generator * opening_claim.opening_pair.evaluation);
 
         // Compute C_zero = C_prime + ∑_{j ∈ [k]} u_j^2L_j + ∑_{j ∈ [k]} u_j^{-2}R_j
-        const size_t pippenger_size = 2 * log_poly_degree;
+        auto pippenger_size = 2 * log_poly_degree;
         std::vector<Fr> round_challenges(log_poly_degree);
         std::vector<Fr> round_challenges_inv(log_poly_degree);
         std::vector<Commitment> msm_elements(pippenger_size);

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -50,9 +50,6 @@ template <typename Params> class IPA {
                "The poly_degree should be positive and a power of two");
 
         auto a_vec = polynomial;
-        // TODO(#479): restructure IPA so it can be integrated with the work_queue (or replacement) and
-        // see if reducing the size of G_vec_local and b_vec by taking the first iteration out of the loop
-        // can also be integrated.
         auto srs_elements = ck->srs.get_monomial_points();
         std::vector<Commitment> G_vec_local(poly_degree);
         // The SRS stored in the commitment key is the result after applying the pippenger point table so the
@@ -73,6 +70,10 @@ template <typename Params> class IPA {
         std::vector<GroupElement> R_elements(log_poly_degree);
         std::size_t round_size = poly_degree;
 
+        // TODO(#479): restructure IPA so it can be integrated with the pthread alternative to work queue (or even the
+        // work queue itself). Investigate whether parallelising parts of each rounds of IPA rounds brings significant
+        // improvements and see if reducing the size of G_vec_local and b_vec by taking the first iteration out of the
+        // loop can also be integrated.
         for (size_t i = 0; i < log_poly_degree; i++) {
             round_size >>= 1;
             // Compute inner_prod_L := < a_vec_lo, b_vec_hi > and inner_prod_R := < a_vec_hi, b_vec_lo >
@@ -135,7 +136,6 @@ template <typename Params> class IPA {
                        const OpeningClaim<Params>& opening_claim,
                        VerifierTranscript<Fr>& transcript)
     {
-        // so we should get an OpeningClaim as parameter with
         auto poly_degree = static_cast<size_t>(transcript.template receive_from_prover<uint64_t>("IPA:poly_degree"));
         Fr generator_challenge = transcript.get_challenge("IPA:generator_challenge");
         auto aux_generator = Commitment::one() * generator_challenge;

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -86,12 +86,12 @@ template <typename Params> class IPA {
                 inner_prod_R += a_vec[round_size + j] * b_vec[j];
             }
             // L_i = < a_vec_lo, G_vec_hi > + inner_prod_L * aux_generator
-            L_elements[i] = barretenberg::scalar_multiplication::pippenger(
+            L_elements[i] = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
                 &a_vec[0], &G_vec_local[round_size], round_size, ck->pippenger_runtime_state);
             L_elements[i] += aux_generator * inner_prod_L;
 
             // R_i = < a_vec_hi, G_vec_lo > + inner_prod_R * aux_generator
-            R_elements[i] = barretenberg::scalar_multiplication::pippenger(
+            R_elements[i] = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
                 &a_vec[round_size], &G_vec_local[0], round_size, ck->pippenger_runtime_state);
             R_elements[i] += aux_generator * inner_prod_R;
 
@@ -166,7 +166,7 @@ template <typename Params> class IPA {
             msm_scalars[2 * i] = round_challenges[i].sqr();
             msm_scalars[2 * i + 1] = round_challenges_inv[i].sqr();
         }
-        GroupElement LR_sums = barretenberg::scalar_multiplication::pippenger(
+        GroupElement LR_sums = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
             &msm_scalars[0], &msm_elements[0], pippenger_size, vk->pippenger_runtime_state);
         GroupElement C_zero = C_prime + LR_sums;
 
@@ -204,9 +204,9 @@ template <typename Params> class IPA {
         // Copy the G_vector to local memory.
         std::vector<Commitment> G_vec_local(poly_degree);
         for (size_t i = 0; i < poly_degree * 2; i += 2) {
-            G_vec_local[i >> 1] = srs_elements[i];
+            G_vec_local[i] = srs_elements[i >> 1];
         }
-        auto G_zero = barretenberg::scalar_multiplication::pippenger(
+        auto G_zero = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
             &s_vec[0], &G_vec_local[0], poly_degree, vk->pippenger_runtime_state);
 
         auto a_zero = transcript.template receive_from_prover<Fr>("IPA:a_0");

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -16,7 +16,6 @@
  */
 namespace proof_system::honk::pcs::ipa {
 
-// In the future we want this parameterised by the curve
 template <typename Params> class IPA {
     using Fr = typename Params::Fr;
     using GroupElement = typename Params::GroupElement;
@@ -57,6 +56,9 @@ template <typename Params> class IPA {
         // use SRS instead of G_vector.
         auto srs_elements = ck->srs.get_monomial_points();
         std::vector<Commitment> G_vec_local(poly_degree);
+        // The SRS stored in the commitment key is the result after applying the pippenger point table so the
+        // values at odd indices contain the point {srs[i-1].x * beta, srs[i-1].y}, where beta is the endomorphism
+        // G_vec_local should use only the original SRS thus we extract only the even indices.
         for (size_t i = 0; i < poly_degree * 2; i += 2) {
             G_vec_local[i >> 1] = srs_elements[i];
         }
@@ -203,8 +205,11 @@ template <typename Params> class IPA {
         auto srs_elements = vk->srs.get_monomial_points();
         // Copy the G_vector to local memory.
         std::vector<Commitment> G_vec_local(poly_degree);
+        // The SRS stored in the commitment key is the result after applying the pippenger point table so the
+        // values at odd indices contain the point {srs[i-1].x * beta, srs[i-1].y}, where beta is the endomorphism
+        // G_vec_local should use only the original SRS thus we extract only the even indices.
         for (size_t i = 0; i < poly_degree * 2; i += 2) {
-            G_vec_local[i] = srs_elements[i >> 1];
+            G_vec_local[i >> 1] = srs_elements[i];
         }
         auto G_zero = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
             &s_vec[0], &G_vec_local[0], poly_degree, vk->pippenger_runtime_state);

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -57,8 +57,8 @@ template <typename Params> class IPA {
         // use SRS instead of G_vector.
         auto srs_elements = ck->srs.get_monomial_points();
         std::vector<Commitment> G_vec_local(poly_degree);
-        for (size_t i = 0; i < poly_degree; i++) {
-            G_vec_local[i] = srs_elements[i];
+        for (size_t i = 0; i < poly_degree * 2; i += 2) {
+            G_vec_local[i >> 1] = srs_elements[i];
         }
         // Construct b vector
         // TODO(#220)(Arijit): For round i=0, b_vec can be derived in-place.
@@ -86,12 +86,12 @@ template <typename Params> class IPA {
                 inner_prod_R += a_vec[round_size + j] * b_vec[j];
             }
             // L_i = < a_vec_lo, G_vec_hi > + inner_prod_L * aux_generator
-            L_elements[i] = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
+            L_elements[i] = barretenberg::scalar_multiplication::pippenger(
                 &a_vec[0], &G_vec_local[round_size], round_size, ck->pippenger_runtime_state);
             L_elements[i] += aux_generator * inner_prod_L;
 
             // R_i = < a_vec_hi, G_vec_lo > + inner_prod_R * aux_generator
-            R_elements[i] = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
+            R_elements[i] = barretenberg::scalar_multiplication::pippenger(
                 &a_vec[round_size], &G_vec_local[0], round_size, ck->pippenger_runtime_state);
             R_elements[i] += aux_generator * inner_prod_R;
 
@@ -166,7 +166,7 @@ template <typename Params> class IPA {
             msm_scalars[2 * i] = round_challenges[i].sqr();
             msm_scalars[2 * i + 1] = round_challenges_inv[i].sqr();
         }
-        GroupElement LR_sums = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
+        GroupElement LR_sums = barretenberg::scalar_multiplication::pippenger(
             &msm_scalars[0], &msm_elements[0], pippenger_size, vk->pippenger_runtime_state);
         GroupElement C_zero = C_prime + LR_sums;
 
@@ -203,10 +203,10 @@ template <typename Params> class IPA {
         auto srs_elements = vk->srs.get_monomial_points();
         // Copy the G_vector to local memory.
         std::vector<Commitment> G_vec_local(poly_degree);
-        for (size_t i = 0; i < poly_degree; i++) {
-            G_vec_local[i] = srs_elements[i];
+        for (size_t i = 0; i < poly_degree * 2; i += 2) {
+            G_vec_local[i >> 1] = srs_elements[i];
         }
-        auto G_zero = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points(
+        auto G_zero = barretenberg::scalar_multiplication::pippenger(
             &s_vec[0], &G_vec_local[0], poly_degree, vk->pippenger_runtime_state);
 
         auto a_zero = transcript.template receive_from_prover<Fr>("IPA:a_0");

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
@@ -1,61 +1,88 @@
 #include "ipa.hpp"
 #include "barretenberg/common/mem.hpp"
 #include <gtest/gtest.h>
+#include "barretenberg/ecc/curves/types.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/ecc/curves/bn254/fq12.hpp"
 #include "barretenberg/honk/pcs/commitment_key.hpp"
 #include "barretenberg/honk/pcs/commitment_key.test.hpp"
 using namespace barretenberg;
-namespace proof_system::honk::pcs {
+namespace proof_system::honk::pcs::ipa {
 
-class IPATests : public CommitmentTest<ipa::Params> {
+class IPATests : public CommitmentTest<Params> {
   public:
-    using Params = ipa::Params;
     using Fr = typename Params::Fr;
-    using element = typename Params::Commitment;
-    using affine_element = typename Params::C;
-    using CK = typename Params::CK;
-    using VK = typename Params::VK;
+    using element = typename Params::GroupElement;
+    using affine_element = typename Params::Commitment;
+    using CK = typename Params::CommitmentKey;
+    using VK = typename Params::VerificationKey;
     using Polynomial = barretenberg::Polynomial<Fr>;
 };
 
 TEST_F(IPATests, Commit)
 {
-    constexpr size_t n = 128;
+    constexpr size_t n = 4;
     auto poly = this->random_polynomial(n);
     barretenberg::g1::element commitment = this->commit(poly);
     auto srs_elements = this->ck()->srs.get_monomial_points();
-    barretenberg::g1::element expected = srs_elements[0] * poly[0];
+    barretenberg::g1::element expected = g1::element(srs_elements[0]) * poly[0];
     for (size_t i = 1; i < n; i++) {
-        expected += srs_elements[i] * poly[i];
+        expected += g1::element(srs_elements[i]) * poly[i];
     }
     EXPECT_EQ(expected.normalize(), commitment.normalize());
 }
 
 TEST_F(IPATests, Open)
 {
-    using IPA = ipa::InnerProductArgument<Params>;
+    using IPA = IPA<Params>;
     // generate a random polynomial, degree needs to be a power of two
     size_t n = 128;
     auto poly = this->random_polynomial(n);
     auto [x, eval] = this->random_eval(poly);
     auto commitment = this->commit(poly);
-    const OpeningPair<Params> opening_pair{ x, eval };
+    const OpeningPair<Params> opening_pair = { x, eval };
+    const OpeningClaim<Params> opening_claim{ opening_pair, commitment };
 
     // initialize empty prover transcript
     ProverTranscript<Fr> prover_transcript;
-
-    prover_transcript.send_to_verifier("IPA:C", commitment);
-
-    IPA::reduce_prove(this->ck(), opening_pair, poly, prover_transcript);
+    IPA::compute_opening_proof(this->ck(), opening_pair, poly, prover_transcript);
 
     // initialize verifier transcript from proof data
     VerifierTranscript<Fr> verifier_transcript{ prover_transcript.proof_data };
 
-    auto result = IPA::reduce_verify(this->vk(), opening_pair, n, verifier_transcript);
+    auto result = IPA::verify(this->vk(), opening_claim, verifier_transcript);
     EXPECT_TRUE(result);
 
     EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
 }
-} // namespace proof_system::honk::pcs
+
+TEST_F(IPATests, pippenger_unsafe_short_inputs)
+{
+    constexpr size_t num_points = 128;
+
+    auto scalars = this->random_polynomial(num_points);
+
+    // g1::affine_element* points =
+    //     (g1::affine_element*)aligned_alloc(32, sizeof(g1::affine_element) * num_points * 2 + 1);
+
+    auto points = this->ck()->srs.get_monomial_points();
+    info(this->ck()->srs.get_monomial_size());
+
+    g1::element expected;
+    expected.self_set_infinity();
+    for (size_t i = 0; i < num_points; ++i) {
+        g1::element temp = points[i] * scalars[i];
+        expected += temp;
+    }
+    expected = expected.normalize();
+    scalar_multiplication::generate_pippenger_point_table(points, points, num_points);
+    scalar_multiplication::pippenger_runtime_state state(num_points);
+
+    g1::element result =
+        scalar_multiplication::pippenger_unsafe(const_cast<Fr*>(scalars.data()), points, num_points, state);
+    result = result.normalize();
+
+    EXPECT_EQ(result == expected, true);
+}
+} // namespace proof_system::honk::pcs::ipa

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
@@ -26,8 +26,11 @@ TEST_F(IPATests, Commit)
     auto poly = this->random_polynomial(n);
     barretenberg::g1::element commitment = this->commit(poly);
     auto srs_elements = this->ck()->srs.get_monomial_points();
-    barretenberg::g1::element expected = g1::element(srs_elements[0]) * poly[0];
-    for (size_t i = 1; i < 2 * n; i += 2) {
+    barretenberg::g1::element expected = srs_elements[0] * poly[0];
+    // The SRS stored in the commitment key is the result after applying the pippenger point table so the
+    // values at odd indices contain the point {srs[i-1].x * beta, srs[i-1].y}, where beta is the endomorphism
+    // G_vec_local should use only the original SRS thus we extract only the even indices.
+    for (size_t i = 2; i < 2 * n; i += 2) {
         expected += g1::element(srs_elements[i]) * poly[i >> 1];
     }
     EXPECT_EQ(expected.normalize(), commitment.normalize());
@@ -55,34 +58,5 @@ TEST_F(IPATests, Open)
     EXPECT_TRUE(result);
 
     EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
-}
-
-TEST_F(IPATests, pippenger_unsafe_short_inputs)
-{
-    constexpr size_t num_points = 128;
-
-    auto scalars = this->random_polynomial(num_points);
-
-    // g1::affine_element* points =
-    //     (g1::affine_element*)aligned_alloc(32, sizeof(g1::affine_element) * num_points * 2 + 1);
-
-    auto points = this->ck()->srs.get_monomial_points();
-    info(this->ck()->srs.get_monomial_size());
-
-    g1::element expected;
-    expected.self_set_infinity();
-    for (size_t i = 0; i < num_points; ++i) {
-        g1::element temp = points[i] * scalars[i];
-        expected += temp;
-    }
-    expected = expected.normalize();
-    scalar_multiplication::generate_pippenger_point_table(points, points, num_points);
-    scalar_multiplication::pippenger_runtime_state state(num_points);
-
-    g1::element result =
-        scalar_multiplication::pippenger_unsafe(const_cast<Fr*>(scalars.data()), points, num_points, state);
-    result = result.normalize();
-
-    EXPECT_EQ(result == expected, true);
 }
 } // namespace proof_system::honk::pcs::ipa

--- a/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
+++ b/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
@@ -27,8 +27,8 @@ TEST_F(IPATests, Commit)
     barretenberg::g1::element commitment = this->commit(poly);
     auto srs_elements = this->ck()->srs.get_monomial_points();
     barretenberg::g1::element expected = g1::element(srs_elements[0]) * poly[0];
-    for (size_t i = 1; i < n; i++) {
-        expected += g1::element(srs_elements[i]) * poly[i];
+    for (size_t i = 1; i < 2 * n; i += 2) {
+        expected += g1::element(srs_elements[i]) * poly[i >> 1];
     }
     EXPECT_EQ(expected.normalize(), commitment.normalize());
 }

--- a/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
+++ b/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
@@ -37,6 +37,8 @@ template <typename Params> class KZG {
         // Computes the coefficients for the quotient polynomial q(X) = (p(X) - v) / (X - r) through an FFT
         quotient.factor_roots(opening_pair.challenge);
         auto quotient_commitment = ck->commit(quotient);
+        // Note: for now we compute the KZG commitment directly to unify the KZG and IPA interfaces but in the future
+        // we might need to adjust this to use the incoming alternative to work queue
         prover_trancript.send_to_verifier("KZG:W", quotient_commitment);
     };
 

--- a/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
+++ b/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
@@ -38,7 +38,8 @@ template <typename Params> class KZG {
         quotient.factor_roots(opening_pair.challenge);
         auto quotient_commitment = ck->commit(quotient);
         // TODO(#479): for now we compute the KZG commitment directly to unify the KZG and IPA interfaces but in the
-        // future we might need to adjust this to use the incoming alternative to work queue
+        // future we might need to adjust this to use the incoming alternative to work queue (i.e. variation of
+        // pthreads) or even the work queue itself
         prover_trancript.send_to_verifier("KZG:W", quotient_commitment);
     };
 

--- a/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
+++ b/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
@@ -37,8 +37,8 @@ template <typename Params> class KZG {
         // Computes the coefficients for the quotient polynomial q(X) = (p(X) - v) / (X - r) through an FFT
         quotient.factor_roots(opening_pair.challenge);
         auto quotient_commitment = ck->commit(quotient);
-        // Note: for now we compute the KZG commitment directly to unify the KZG and IPA interfaces but in the future
-        // we might need to adjust this to use the incoming alternative to work queue
+        // TODO(#479): for now we compute the KZG commitment directly to unify the KZG and IPA interfaces but in the
+        // future we might need to adjust this to use the incoming alternative to work queue
         prover_trancript.send_to_verifier("KZG:W", quotient_commitment);
     };
 

--- a/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
+++ b/cpp/src/barretenberg/honk/pcs/kzg/kzg.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../claim.hpp"
+#include "barretenberg/honk/pcs/commitment_key.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
 
@@ -8,86 +9,57 @@
 #include <utility>
 
 namespace proof_system::honk::pcs::kzg {
-/**
- * @brief A transformed polynomial commitment opening claim of the form (P₀, P₁) ∈ 𝔾₁
- * which should satisfy e(P₀, [1]₂) ⋅ e(P₁, [x]₂)=1.
- *
- * @tparam Params CommitmentScheme parameters, where the verification key VK has a
- * `pairing_check` function.
- */
-template <typename Params> class BilinearAccumulator {
-    using VK = typename Params::VK;
-    using Fr = typename Params::Fr;
-    using CommitmentAffine = typename Params::C;
-    using Commitment = typename Params::Commitment;
 
-  public:
-    /**
-     * @brief Construct a new Bilinear Accumulator object given a claim (C,r,v) and proof π.
-     *      - P₀ = C − v⋅[1]₁ + r⋅[x]₁
-     *      - P₁ = −π
-     * @param claim an OpeningClaim (C,r,v)
-     * @param proof a Commitment π
-     */
-    BilinearAccumulator(const OpeningClaim<Params>& claim, const Commitment& proof)
-        : lhs(claim.commitment - (Commitment::one() * claim.opening_pair.evaluation) +
-              (proof * claim.opening_pair.challenge))
-        , rhs(-proof)
-    {}
-
-    /**
-     * @brief verifies the accumulator with a pairing check
-     *
-     * @param vk VerificationKey
-     * @return e(P₀,[1]₁)e(P₁,[x]₂)≡ [1]ₜ
-     */
-    bool verify(std::shared_ptr<VK> vk) const { return vk->pairing_check(lhs, rhs); };
-
-    bool operator==(const BilinearAccumulator& other) const = default;
-
-    CommitmentAffine lhs, rhs;
-};
-
-template <typename Params> class UnivariateOpeningScheme {
-    using CK = typename Params::CK;
-
+template <typename Params> class KZG {
+    using CK = typename Params::CommitmentKey;
+    using VK = typename Params::VerificationKey;
     using Fr = typename Params::Fr;
     using Commitment = typename Params::Commitment;
-    using CommitmentAffine = typename Params::C;
+    using GroupElement = typename Params::GroupElement;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-  public:
-    using Accumulator = BilinearAccumulator<Params>;
-
     /**
-     * @brief Compute KZG opening proof polynomial
+     * @brief Computes the KZG commitment to an opening proof polynomial at a single evaluation point
      *
-     * @param opening_pair OpeningPair = {r, v = polynomial(r)}
-     * @param polynomial the witness polynomial being opened
-     * @return KZG quotient polynomial of the form (p(X) - v) / (X - r)
+     * @param ck The commitment key which has a commit function, the srs and pippenger_runtime_state
+     * @param opening_pair OpeningPair = {r, v = p(r)}
+     * @param polynomial The witness whose opening proof needs to be computed
+     * @param prover_transcript Prover transcript
      */
-    static Polynomial compute_opening_proof_polynomial(const OpeningPair<Params>& opening_pair,
-                                                       const Polynomial& polynomial)
+  public:
+    static void compute_opening_proof(std::shared_ptr<CK> ck,
+                                      const OpeningPair<Params>& opening_pair,
+                                      const Polynomial& polynomial,
+                                      ProverTranscript<Fr>& prover_trancript)
     {
         Polynomial quotient(polynomial);
         quotient[0] -= opening_pair.evaluation;
+        // Computes the coefficients for the quotient polynomial q(X) = (p(X) - v) / (X - r) through an FFT
         quotient.factor_roots(opening_pair.challenge);
-
-        return quotient;
+        auto quotient_commitment = ck->commit(quotient);
+        prover_trancript.send_to_verifier("KZG:W", quotient_commitment);
     };
 
     /**
-     * @brief Computes the accumulator for a single polynomial commitment opening claim
+     * @brief Computes the KZG verification for an opening claim of a single polynomial commitment
      * This reduction is non-interactive and always succeeds.
      *
+     * @param vk is the verification key which has a pairing check function
      * @param claim OpeningClaim ({r, v}, C)
-     * @param proof π, a commitment to Q(X) = ( P(X) - v )/( X - r)
-     * @return Accumulator {C − v⋅[1]₁ + r⋅π, −π}
+     * @return  e(P₀,[1]₁)e(P₁,[x]₂)≡ [1]ₜ where
+     *      - P₀ = C − v⋅[1]₁ + r⋅[x]₁
+     *      - P₁ = [Q(x)]₁
      */
-    static Accumulator reduce_verify(const OpeningClaim<Params>& claim, VerifierTranscript<Fr>& verifier_transcript)
+    static bool verify(std::shared_ptr<VK> vk,
+                       const OpeningClaim<Params>& claim,
+                       VerifierTranscript<Fr>& verifier_transcript)
     {
-        auto quotient_commitment = verifier_transcript.template receive_from_prover<CommitmentAffine>("KZG:W");
-        return Accumulator(claim, quotient_commitment);
+        auto quotient_commitment = verifier_transcript.template receive_from_prover<Commitment>("KZG:W");
+        auto lhs = claim.commitment - (GroupElement::one() * claim.opening_pair.evaluation) +
+                   (quotient_commitment * claim.opening_pair.challenge);
+        auto rhs = -quotient_commitment;
+
+        return vk->pairing_check(lhs, rhs);
     };
 };
 } // namespace proof_system::honk::pcs::kzg

--- a/cpp/src/barretenberg/honk/pcs/shplonk/shplonk_single.hpp
+++ b/cpp/src/barretenberg/honk/pcs/shplonk/shplonk_single.hpp
@@ -8,16 +8,17 @@ namespace proof_system::honk::pcs::shplonk {
 
 /**
  * @brief Protocol for opening several polynomials, each in a single different point.
- * It is a simplification of the MultiBatchOpeningScheme.
+ * It is a simplification of the MultiBatchOpeningScheme (several polynomials on several
+ * different points, protocol not implemented).
  *
  * @tparam Params for the given commitment scheme
  */
 template <typename Params> class SingleBatchOpeningScheme {
-    using CK = typename Params::CK;
+    using CK = typename Params::CommitmentKey;
 
     using Fr = typename Params::Fr;
+    using GroupElement = typename Params::GroupElement;
     using Commitment = typename Params::Commitment;
-    using CommitmentAffine = typename Params::C;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
   public:
@@ -129,7 +130,7 @@ template <typename Params> class SingleBatchOpeningScheme {
 
         const Fr nu = transcript.get_challenge("Shplonk:nu");
 
-        auto Q_commitment = transcript.template receive_from_prover<CommitmentAffine>("Shplonk:Q");
+        auto Q_commitment = transcript.template receive_from_prover<Commitment>("Shplonk:Q");
 
         const Fr z_challenge = transcript.get_challenge("Shplonk:z");
 
@@ -143,7 +144,7 @@ template <typename Params> class SingleBatchOpeningScheme {
 
         // [G] = [Q] - ∑ⱼ ρʲ / ( r − xⱼ )⋅[fⱼ] + G₀⋅[1]
         //     = [Q] - [∑ⱼ ρʲ ⋅ ( fⱼ(X) − vⱼ) / ( r − xⱼ )]
-        Commitment G_commitment = Q_commitment;
+        GroupElement G_commitment = Q_commitment;
 
         // {ẑⱼ(r)}ⱼ , where ẑⱼ(r) = 1/zⱼ(r) = 1/(r - xⱼ)
         std::vector<Fr> inverse_vanishing_evals;
@@ -168,7 +169,7 @@ template <typename Params> class SingleBatchOpeningScheme {
             current_nu *= nu;
         }
         // [G] += G₀⋅[1] = [G] + (∑ⱼ ρʲ ⋅ vⱼ / ( r − xⱼ ))⋅[1]
-        G_commitment += Commitment::one() * G_commitment_constant;
+        G_commitment += GroupElement::one() * G_commitment_constant;
 
         // Return opening pair (z, 0) and commitment [G]
         return { { z_challenge, Fr::zero() }, G_commitment };

--- a/cpp/src/barretenberg/honk/proof_system/composer_helper.lib.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/composer_helper.lib.hpp
@@ -23,7 +23,7 @@ std::shared_ptr<typename Flavor::VerificationKey> compute_verification_key_commo
     auto verification_key = std::make_shared<typename Flavor::VerificationKey>(
         proving_key->circuit_size, proving_key->num_public_inputs, vrs, proving_key->composer_type);
 
-    auto commitment_key = typename Flavor::PCSParams::CK(proving_key->circuit_size, "../srs_db/ignition");
+    auto commitment_key = typename Flavor::PCSParams::CommitmentKey(proving_key->circuit_size, "../srs_db/ignition");
 
     size_t poly_idx = 0; // TODO(#391) zip
     for (auto& polynomial : proving_key) {

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -217,13 +217,16 @@ template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_shplonk_p
 }
 
 /**
- * - Compute KZG quotient commitment [W]_1.
+ * - Compute final PCS opening proof:
+ * - for KZG this is the quotient commitment [W]_1.
+ * - for IPA
  *
  * */
-template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_kzg_round()
+template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_final_pcs_round()
 {
-    quotient_W = KZG::compute_opening_proof_polynomial(shplonk_output.opening_pair, shplonk_output.witness);
-    queue.add_commitment(quotient_W, "KZG:W");
+    PCS::compute_opening_proof(pcs_commitment_key, shplonk_output.opening_pair, shplonk_output.witness, transcript);
+    // TODO(Mara):
+    // queue.add_commitment(quotient_W, "KZG:W");
 }
 
 template <StandardFlavor Flavor> plonk::proof& StandardProver_<Flavor>::export_proof()
@@ -275,9 +278,9 @@ template <StandardFlavor Flavor> plonk::proof& StandardProver_<Flavor>::construc
     execute_shplonk_partial_evaluation_round();
 
     // Fiat-Shamir: z
-    // Compute KZG quotient commitment
-    execute_kzg_round();
-    queue.process_queue();
+    // Compute final PCS opening proof (KZG quotien commitment or IPA opening proof)
+    execute_final_pcs_round();
+    // queue.process_queue();
 
     return export_proof();
 }

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -224,6 +224,7 @@ template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_shplonk_p
 template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_final_pcs_round()
 {
     PCS::compute_opening_proof(pcs_commitment_key, shplonk_output.opening_pair, shplonk_output.witness, transcript);
+    info("done");
 }
 
 template <StandardFlavor Flavor> plonk::proof& StandardProver_<Flavor>::export_proof()

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -224,7 +224,6 @@ template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_shplonk_p
 template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_final_pcs_round()
 {
     PCS::compute_opening_proof(pcs_commitment_key, shplonk_output.opening_pair, shplonk_output.witness, transcript);
-    info("done");
 }
 
 template <StandardFlavor Flavor> plonk::proof& StandardProver_<Flavor>::export_proof()
@@ -278,6 +277,7 @@ template <StandardFlavor Flavor> plonk::proof& StandardProver_<Flavor>::construc
     // Fiat-Shamir: z
     // Compute final PCS opening proof (this is KZG quotient commitment or IPA opening proof)
     execute_final_pcs_round();
+    // TODO(#479): queue.process_queue after the work_queue has been (re)added to KZG/IPA
 
     return export_proof();
 }

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -218,15 +218,12 @@ template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_shplonk_p
 
 /**
  * - Compute final PCS opening proof:
- * - for KZG this is the quotient commitment [W]_1.
- * - for IPA
- *
+ * - For KZG, this is the quotient commitment [W]_1
+ * - For IPA, the vectors L and R
  * */
 template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_final_pcs_round()
 {
     PCS::compute_opening_proof(pcs_commitment_key, shplonk_output.opening_pair, shplonk_output.witness, transcript);
-    // TODO(Mara):
-    // queue.add_commitment(quotient_W, "KZG:W");
 }
 
 template <StandardFlavor Flavor> plonk::proof& StandardProver_<Flavor>::export_proof()
@@ -278,9 +275,8 @@ template <StandardFlavor Flavor> plonk::proof& StandardProver_<Flavor>::construc
     execute_shplonk_partial_evaluation_round();
 
     // Fiat-Shamir: z
-    // Compute final PCS opening proof (KZG quotien commitment or IPA opening proof)
+    // Compute final PCS opening proof (this is KZG quotient commitment or IPA opening proof)
     execute_final_pcs_round();
-    // queue.process_queue();
 
     return export_proof();
 }

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -3,7 +3,6 @@
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/honk/pcs/gemini/gemini.hpp"
 #include "barretenberg/honk/pcs/shplonk/shplonk_single.hpp"
-#include "barretenberg/honk/pcs/kzg/kzg.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
 #include "barretenberg/honk/sumcheck/sumcheck.hpp"
 #include "barretenberg/honk/sumcheck/sumcheck_output.hpp"
@@ -20,11 +19,13 @@ template <typename T> concept StandardFlavor = IsAnyOf<T, honk::flavor::Standard
 template <StandardFlavor Flavor> class StandardProver_ {
 
     using FF = typename Flavor::FF;
-    using PCSParams = typename Flavor::PCSParams;
     using ProvingKey = typename Flavor::ProvingKey;
     using Polynomial = typename Flavor::Polynomial;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
+    using PCSParams = typename Flavor::PCSParams;
+    using PCSCommitmentKey = typename Flavor::PCSParams::CommitmentKey;
+    using PCS = typename Flavor::PCS;
 
   public:
     explicit StandardProver_(std::shared_ptr<ProvingKey> input_key = nullptr);
@@ -38,7 +39,8 @@ template <StandardFlavor Flavor> class StandardProver_ {
     void execute_pcs_evaluation_round();
     void execute_shplonk_batched_quotient_round();
     void execute_shplonk_partial_evaluation_round();
-    void execute_kzg_round();
+
+    void execute_final_pcs_round();
 
     void compute_wire_commitments();
 
@@ -73,10 +75,10 @@ template <StandardFlavor Flavor> class StandardProver_ {
     sumcheck::SumcheckOutput<Flavor> sumcheck_output;
     pcs::gemini::ProverOutput<PCSParams> gemini_output;
     pcs::shplonk::ProverOutput<PCSParams> shplonk_output;
+    std::shared_ptr<PCSCommitmentKey> pcs_commitment_key;
 
     using Gemini = pcs::gemini::MultilinearReductionScheme<PCSParams>;
     using Shplonk = pcs::shplonk::SingleBatchOpeningScheme<PCSParams>;
-    using KZG = pcs::kzg::UnivariateOpeningScheme<PCSParams>;
 
   private:
     plonk::proof proof;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
@@ -276,10 +276,10 @@ template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_shplonk_partial
  * - Compute KZG quotient commitment [W]_1.
  *
  * */
-template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_kzg_round()
+template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_final_pcs_round()
 {
-    quotient_W = KZG::compute_opening_proof_polynomial(shplonk_output.opening_pair, shplonk_output.witness);
-    queue.add_commitment(quotient_W, "KZG:W");
+    PCS::compute_opening_proof(pcs_commitment_key, shplonk_output.opening_pair, shplonk_output.witness, transcript);
+    // queue.add_commitment(quotient_W, "KZG:W");
 }
 
 template <UltraFlavor Flavor> plonk::proof& UltraProver_<Flavor>::export_proof()
@@ -330,8 +330,8 @@ template <UltraFlavor Flavor> plonk::proof& UltraProver_<Flavor>::construct_proo
 
     // Fiat-Shamir: z
     // Compute KZG quotient commitment
-    execute_kzg_round();
-    queue.process_queue();
+    execute_final_pcs_round();
+    // queue.process_queue();
 
     return export_proof();
 }

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
@@ -271,10 +271,10 @@ template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_shplonk_partial
     shplonk_output = Shplonk::compute_partially_evaluated_batched_quotient(
         gemini_output.opening_pairs, gemini_output.witnesses, std::move(batched_quotient_Q), nu_challenge, z_challenge);
 }
-
 /**
- * - Compute KZG quotient commitment [W]_1.
- *
+ * - Compute final PCS opening proof:
+ * - For KZG, this is the quotient commitment [W]_1
+ * - For IPA, the vectors L and R
  * */
 template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_final_pcs_round()
 {
@@ -329,9 +329,8 @@ template <UltraFlavor Flavor> plonk::proof& UltraProver_<Flavor>::construct_proo
     execute_shplonk_partial_evaluation_round();
 
     // Fiat-Shamir: z
-    // Compute KZG quotient commitment
+    // Compute PCS opening proof (either KZG quotient commitment or IPA opening proof)
     execute_final_pcs_round();
-    // queue.process_queue();
 
     return export_proof();
 }

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
@@ -3,7 +3,6 @@
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/honk/pcs/gemini/gemini.hpp"
 #include "barretenberg/honk/pcs/shplonk/shplonk_single.hpp"
-#include "barretenberg/honk/pcs/kzg/kzg.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
 #include "barretenberg/honk/flavor/ultra.hpp"
 #include "barretenberg/honk/sumcheck/relations/relation_parameters.hpp"
@@ -18,6 +17,8 @@ template <UltraFlavor Flavor> class UltraProver_ {
 
     using FF = typename Flavor::FF;
     using PCSParams = typename Flavor::PCSParams;
+    using PCS = typename Flavor::PCS;
+    using PCSCommitmentKey = typename Flavor::PCSParams::CommitmentKey;
     using ProvingKey = typename Flavor::ProvingKey;
     using Polynomial = typename Flavor::Polynomial;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
@@ -35,7 +36,7 @@ template <UltraFlavor Flavor> class UltraProver_ {
     void execute_pcs_evaluation_round();
     void execute_shplonk_batched_quotient_round();
     void execute_shplonk_partial_evaluation_round();
-    void execute_kzg_round();
+    void execute_final_pcs_round();
 
     void compute_wire_commitments();
 
@@ -63,15 +64,15 @@ template <UltraFlavor Flavor> class UltraProver_ {
 
     Polynomial quotient_W;
 
-    work_queue<pcs::kzg::Params> queue;
+    work_queue<PCSParams> queue;
 
     sumcheck::SumcheckOutput<Flavor> sumcheck_output;
     pcs::gemini::ProverOutput<PCSParams> gemini_output;
     pcs::shplonk::ProverOutput<PCSParams> shplonk_output;
+    std::shared_ptr<PCSCommitmentKey> pcs_commitment_key;
 
     using Gemini = pcs::gemini::MultilinearReductionScheme<PCSParams>;
     using Shplonk = pcs::shplonk::SingleBatchOpeningScheme<PCSParams>;
-    using KZG = pcs::kzg::UnivariateOpeningScheme<PCSParams>;
 
   private:
     plonk::proof proof;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -19,15 +19,15 @@ UltraVerifier_<Flavor>::UltraVerifier_(std::shared_ptr<typename Flavor::Verifica
 template <typename Flavor>
 UltraVerifier_<Flavor>::UltraVerifier_(UltraVerifier_&& other)
     : key(std::move(other.key))
-    , kate_verification_key(std::move(other.kate_verification_key))
+    , pcs_verification_key(std::move(other.pcs_verification_key))
 {}
 
 template <typename Flavor> UltraVerifier_<Flavor>& UltraVerifier_<Flavor>::operator=(UltraVerifier_&& other)
 {
     key = other.key;
-    kate_verification_key = (std::move(other.kate_verification_key));
-    kate_g1_elements.clear();
-    kate_fr_elements.clear();
+    pcs_verification_key = (std::move(other.pcs_verification_key));
+    pcs_g1_elements.clear();
+    pcs_fr_elements.clear();
     return *this;
 }
 
@@ -40,9 +40,10 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     using FF = typename Flavor::FF;
     using GroupElement = typename Flavor::GroupElement;
     using Commitment = typename Flavor::Commitment;
-    using Gemini = pcs::gemini::MultilinearReductionScheme<pcs::kzg::Params>;
-    using Shplonk = pcs::shplonk::SingleBatchOpeningScheme<pcs::kzg::Params>;
-    using KZG = pcs::kzg::UnivariateOpeningScheme<pcs::kzg::Params>;
+    using PCSParams = typename Flavor::PCSParams;
+    using PCS = typename Flavor::PCS;
+    using Gemini = pcs::gemini::MultilinearReductionScheme<PCSParams>;
+    using Shplonk = pcs::shplonk::SingleBatchOpeningScheme<PCSParams>;
     using VerifierCommitments = typename Flavor::VerifierCommitments;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
 
@@ -156,10 +157,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     auto shplonk_claim = Shplonk::reduce_verify(gemini_claim, transcript);
 
     // Aggregate inputs [Q] - [Q_z] and [W] into an 'accumulator' (can perform pairing check on result)
-    auto kzg_claim = KZG::reduce_verify(shplonk_claim, transcript);
-
-    // Return result of final pairing check
-    return kzg_claim.verify(kate_verification_key);
+    return PCS::verify(pcs_verification_key, shplonk_claim, transcript);
 }
 
 template class UltraVerifier_<honk::flavor::Ultra>;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -26,7 +26,7 @@ template <typename Flavor> UltraVerifier_<Flavor>& UltraVerifier_<Flavor>::opera
 {
     key = other.key;
     pcs_verification_key = (std::move(other.pcs_verification_key));
-    pcs_g1_elements.clear();
+    commitments.clear();
     pcs_fr_elements.clear();
     return *this;
 }

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -156,7 +156,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     // Produce a Shplonk claim: commitment [Q] - [Q_z], evaluation zero (at random challenge z)
     auto shplonk_claim = Shplonk::reduce_verify(gemini_claim, transcript);
 
-    // Aggregate inputs [Q] - [Q_z] and [W] into an 'accumulator' (can perform pairing check on result)
+    // // Verify the Shplonk claim with KZG or IPA
     return PCS::verify(pcs_verification_key, shplonk_claim, transcript);
 }
 

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.hpp
@@ -21,7 +21,7 @@ template <typename Flavor> class UltraVerifier_ {
     bool verify_proof(const plonk::proof& proof);
 
     std::shared_ptr<VerificationKey> key;
-    std::map<std::string, Commitment> pcs_g1_elements;
+    std::map<std::string, Commitment> commitments;
     std::map<std::string, FF> pcs_fr_elements;
     std::shared_ptr<PCSVerificationKey> pcs_verification_key;
     VerifierTranscript<FF> transcript;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.hpp
@@ -9,7 +9,7 @@ template <typename Flavor> class UltraVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using VerificationKey = typename Flavor::VerificationKey;
-    using PCSVerificationKey = typename Flavor::PCSParams::VK;
+    using PCSVerificationKey = typename Flavor::PCSParams::VerificationKey;
 
   public:
     explicit UltraVerifier_(std::shared_ptr<VerificationKey> verifier_key = nullptr);
@@ -21,9 +21,9 @@ template <typename Flavor> class UltraVerifier_ {
     bool verify_proof(const plonk::proof& proof);
 
     std::shared_ptr<VerificationKey> key;
-    std::map<std::string, Commitment> kate_g1_elements;
-    std::map<std::string, FF> kate_fr_elements;
-    std::shared_ptr<PCSVerificationKey> kate_verification_key;
+    std::map<std::string, Commitment> pcs_g1_elements;
+    std::map<std::string, FF> pcs_fr_elements;
+    std::shared_ptr<PCSVerificationKey> pcs_verification_key;
     VerifierTranscript<FF> transcript;
 };
 

--- a/cpp/src/barretenberg/honk/proof_system/verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.cpp
@@ -24,7 +24,7 @@ template <typename Flavor> StandardVerifier_<Flavor>& StandardVerifier_<Flavor>:
 {
     key = other.key;
     pcs_verification_key = (std::move(other.pcs_verification_key));
-    pcs_g1_elements.clear();
+    commitments.clear();
     pcs_fr_elements.clear();
     return *this;
 }

--- a/cpp/src/barretenberg/honk/proof_system/verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.cpp
@@ -17,15 +17,15 @@ StandardVerifier_<Flavor>::StandardVerifier_(std::shared_ptr<typename Flavor::Ve
 template <typename Flavor>
 StandardVerifier_<Flavor>::StandardVerifier_(StandardVerifier_&& other)
     : key(other.key)
-    , kate_verification_key(std::move(other.kate_verification_key))
+    , pcs_verification_key(std::move(other.pcs_verification_key))
 {}
 
 template <typename Flavor> StandardVerifier_<Flavor>& StandardVerifier_<Flavor>::operator=(StandardVerifier_&& other)
 {
     key = other.key;
-    kate_verification_key = (std::move(other.kate_verification_key));
-    kate_g1_elements.clear();
-    kate_fr_elements.clear();
+    pcs_verification_key = (std::move(other.pcs_verification_key));
+    pcs_g1_elements.clear();
+    pcs_fr_elements.clear();
     return *this;
 }
 
@@ -60,9 +60,10 @@ template <typename Flavor> bool StandardVerifier_<Flavor>::verify_proof(const pl
     using FF = typename Flavor::FF;
     using GroupElement = typename Flavor::GroupElement;
     using Commitment = typename Flavor::Commitment;
-    using Gemini = pcs::gemini::MultilinearReductionScheme<pcs::kzg::Params>;
-    using Shplonk = pcs::shplonk::SingleBatchOpeningScheme<pcs::kzg::Params>;
-    using KZG = pcs::kzg::UnivariateOpeningScheme<pcs::kzg::Params>;
+    using PCSParams = typename Flavor::PCSParams;
+    using Gemini = pcs::gemini::MultilinearReductionScheme<PCSParams>;
+    using Shplonk = pcs::shplonk::SingleBatchOpeningScheme<PCSParams>;
+    using PCS = typename Flavor::PCS;
     using VerifierCommitments = typename Flavor::VerifierCommitments;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
 
@@ -163,11 +164,13 @@ template <typename Flavor> bool StandardVerifier_<Flavor>::verify_proof(const pl
     // Produce a Shplonk claim: commitment [Q] - [Q_z], evaluation zero (at random challenge z)
     auto shplonk_claim = Shplonk::reduce_verify(gemini_claim, transcript);
 
+    // final verify
+
     // Aggregate inputs [Q] - [Q_z] and [W] into an 'accumulator' (can perform pairing check on result)
-    auto kzg_claim = KZG::reduce_verify(shplonk_claim, transcript);
+    return PCS::verify(pcs_verification_key, shplonk_claim, transcript);
 
     // Return result of final pairing check
-    return kzg_claim.verify(kate_verification_key);
+    // return kzg_claim.verify(pcs_verification_key);
 }
 
 template class StandardVerifier_<honk::flavor::Standard>;

--- a/cpp/src/barretenberg/honk/proof_system/verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.cpp
@@ -164,13 +164,8 @@ template <typename Flavor> bool StandardVerifier_<Flavor>::verify_proof(const pl
     // Produce a Shplonk claim: commitment [Q] - [Q_z], evaluation zero (at random challenge z)
     auto shplonk_claim = Shplonk::reduce_verify(gemini_claim, transcript);
 
-    // final verify
-
-    // Aggregate inputs [Q] - [Q_z] and [W] into an 'accumulator' (can perform pairing check on result)
+    // Verify the Shplonk claim with KZG or IPA
     return PCS::verify(pcs_verification_key, shplonk_claim, transcript);
-
-    // Return result of final pairing check
-    // return kzg_claim.verify(pcs_verification_key);
 }
 
 template class StandardVerifier_<honk::flavor::Standard>;

--- a/cpp/src/barretenberg/honk/proof_system/verifier.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.hpp
@@ -20,7 +20,7 @@ template <typename Flavor> class StandardVerifier_ {
     bool verify_proof(const plonk::proof& proof);
 
     std::shared_ptr<VerificationKey> key;
-    std::map<std::string, Commitment> pcs_g1_elements;
+    std::map<std::string, Commitment> commitments;
     std::map<std::string, FF> pcs_fr_elements;
     std::shared_ptr<PCSVerificationKey> pcs_verification_key;
     VerifierTranscript<FF> transcript;

--- a/cpp/src/barretenberg/honk/proof_system/verifier.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.hpp
@@ -8,7 +8,7 @@ template <typename Flavor> class StandardVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using VerificationKey = typename Flavor::VerificationKey;
-    using PCSVerificationKey = typename Flavor::PCSParams::VK;
+    using PCSVerificationKey = typename Flavor::PCSParams::VerificationKey;
 
   public:
     StandardVerifier_(std::shared_ptr<VerificationKey> verifier_key = nullptr);
@@ -20,9 +20,9 @@ template <typename Flavor> class StandardVerifier_ {
     bool verify_proof(const plonk::proof& proof);
 
     std::shared_ptr<VerificationKey> key;
-    std::map<std::string, Commitment> kate_g1_elements;
-    std::map<std::string, FF> kate_fr_elements;
-    std::shared_ptr<PCSVerificationKey> kate_verification_key;
+    std::map<std::string, Commitment> pcs_g1_elements;
+    std::map<std::string, FF> pcs_fr_elements;
+    std::shared_ptr<PCSVerificationKey> pcs_verification_key;
     VerifierTranscript<FF> transcript;
 };
 

--- a/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
@@ -14,9 +14,9 @@ enum WorkType { SCALAR_MULTIPLICATION };
 // at the same time as the similar patterns in Gemini etc.
 template <typename Params> class work_queue {
 
-    using CommitmentKey = typename Params::CK;
+    using CommitmentKey = typename Params::CommitmentKey;
     using FF = typename Params::Fr;
-    using Commitment = typename Params::C;
+    using Commitment = typename Params::Commitment;
 
     struct work_item_info {
         uint32_t num_scalar_multiplications;

--- a/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
+++ b/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
@@ -79,24 +79,24 @@ template <typename FF> class TranscriptTest : public testing::Test {
         manifest_expected.add_challenge(round, "Shplonk:z");
 
         round++;
-        // For KZG
         // TODO(Mara): Make testing more flavor agnostic so we can test this with all flavors
-        // manifest_expected.add_entry(round, "KZG:W", size_G);
-        info(circuit_size);
-        manifest_expected.add_entry(round, "IPA:poly_degree", circuit_size);
-        manifest_expected.add_challenge(round, "IPA:generator_challenge");
+        manifest_expected.add_entry(round, "KZG:W", size_G);
 
-        for (size_t i = 0; i < log_n; i++) {
-            round++;
-            std::string idx = std::to_string(i);
-            manifest_expected.add_entry(round, "IPA:L_" + idx, size_G);
-            manifest_expected.add_entry(round, "IPA:R_" + idx, size_G);
-            std::string label = "IPA:round_challenge_" + idx;
-            manifest_expected.add_challenge(round, label);
-        }
+        // For IPA
+        // manifest_expected.add_entry(round, "IPA:poly_degree", circuit_size);
+        // manifest_expected.add_challenge(round, "IPA:generator_challenge");
 
-        round++;
-        manifest_expected.add_entry(round, "IPA:a_0", size_FF);
+        // for (size_t i = 0; i < log_n; i++) {
+        //     round++;
+        //     std::string idx = std::to_string(i);
+        //     manifest_expected.add_entry(round, "IPA:L_" + idx, size_G);
+        //     manifest_expected.add_entry(round, "IPA:R_" + idx, size_G);
+        //     std::string label = "IPA:round_challenge_" + idx;
+        //     manifest_expected.add_challenge(round, label);
+        // }
+
+        // round++;
+        // manifest_expected.add_entry(round, "IPA:a_0", size_FF);
 
         manifest_expected.add_challenge(round); // no challenge
 

--- a/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
+++ b/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
@@ -79,7 +79,24 @@ template <typename FF> class TranscriptTest : public testing::Test {
         manifest_expected.add_challenge(round, "Shplonk:z");
 
         round++;
-        manifest_expected.add_entry(round, "KZG:W", size_G);
+        // manifest_expected.add_entry(round, "KZG:W", size_G);
+
+        // For IPA
+        manifest_expected.add_entry(round, "IPA:poly_degree", circuit_size);
+        manifest_expected.add_challenge(round, "IPA:generator_challenge");
+
+        for (size_t i = 0; i < log_n; i++) {
+            round++;
+            std::string idx = std::to_string(i);
+            manifest_expected.add_entry(round, "IPA:L_" + idx, size_G);
+            manifest_expected.add_entry(round, "IPA:R_" + idx, size_G);
+            std::string label = "IPA:round_challenge_" + idx;
+            manifest_expected.add_challenge(round, label);
+        }
+
+        round++;
+        manifest_expected.add_entry(round, "IPA:a_0", size_FF);
+
         manifest_expected.add_challenge(round); // no challenge
 
         return manifest_expected;
@@ -108,7 +125,6 @@ TYPED_TEST(TranscriptTest, ProverManifestConsistency)
     // Check that the prover generated manifest agrees with the manifest hard coded in this suite
     auto manifest_expected = TestFixture::construct_standard_honk_manifest(prover.key->circuit_size);
     auto prover_manifest = prover.transcript.get_manifest();
-
     // Note: a manifest can be printed using manifest.print()
     for (size_t round = 0; round < manifest_expected.size(); ++round) {
         ASSERT_EQ(prover_manifest[round], manifest_expected[round]) << "Prover manifest discrepency in round " << round;

--- a/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
+++ b/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
@@ -27,7 +27,7 @@ template <typename FF> class TranscriptTest : public testing::Test {
     {
         TranscriptManifest manifest_expected;
 
-        size_t log_n(numeric::get_msb(circuit_size));
+        auto log_n = numeric::get_msb(circuit_size);
 
         size_t max_relation_length = 5;
         size_t size_FF = sizeof(FF);
@@ -79,9 +79,10 @@ template <typename FF> class TranscriptTest : public testing::Test {
         manifest_expected.add_challenge(round, "Shplonk:z");
 
         round++;
+        // For KZG
+        // TODO(Mara): Make testing more flavor agnostic so we can test this with all flavors
         // manifest_expected.add_entry(round, "KZG:W", size_G);
-
-        // For IPA
+        info(circuit_size);
         manifest_expected.add_entry(round, "IPA:poly_degree", circuit_size);
         manifest_expected.add_challenge(round, "IPA:generator_challenge");
 

--- a/cpp/src/barretenberg/plonk/composer/composer_helper/composer_helper_lib.cpp
+++ b/cpp/src/barretenberg/plonk/composer/composer_helper/composer_helper_lib.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<plonk::verification_key> compute_verification_key_common(
     auto circuit_verification_key = std::make_shared<plonk::verification_key>(
         proving_key->circuit_size, proving_key->num_public_inputs, vrs, proving_key->composer_type);
     // TODO(kesha): Dirty hack for now. Need to actually make commitment-agnositc
-    auto commitment_key = proof_system::honk::pcs::kzg::CommitmentKey(proving_key->circuit_size, srs_path);
+    auto commitment_key = proof_system::honk::pcs::kzg::Params::CommitmentKey(proving_key->circuit_size, srs_path);
 
     for (size_t i = 0; i < proving_key->polynomial_manifest.size(); ++i) {
         const auto& poly_info = proving_key->polynomial_manifest[i];

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -176,18 +176,18 @@ class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
  */
 template <typename PrecomputedCommitments> class VerificationKey_ : public PrecomputedCommitments {
   public:
-    std::shared_ptr<VerifierReferenceString> vrs;
+    // std::shared_ptr<VerifierReferenceString> vrs;
 
     VerificationKey_() = default;
     VerificationKey_(const size_t circuit_size,
                      const size_t num_public_inputs,
-                     std::shared_ptr<VerifierReferenceString> const& vrs,
+                     //  std::shared_ptr<VerifierReferenceString> const& vrs,
                      ComposerType composer_type)
     {
         this->circuit_size = circuit_size;
         this->log_circuit_size = numeric::get_msb(circuit_size);
         this->num_public_inputs = num_public_inputs;
-        this->vrs = vrs;
+        // this->vrs = vrs;
         this->composer_type = composer_type;
     };
 };

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -176,18 +176,12 @@ class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
  */
 template <typename PrecomputedCommitments> class VerificationKey_ : public PrecomputedCommitments {
   public:
-    // std::shared_ptr<VerifierReferenceString> vrs;
-
     VerificationKey_() = default;
-    VerificationKey_(const size_t circuit_size,
-                     const size_t num_public_inputs,
-                     //  std::shared_ptr<VerifierReferenceString> const& vrs,
-                     ComposerType composer_type)
+    VerificationKey_(const size_t circuit_size, const size_t num_public_inputs, ComposerType composer_type)
     {
         this->circuit_size = circuit_size;
         this->log_circuit_size = numeric::get_msb(circuit_size);
         this->num_public_inputs = num_public_inputs;
-        // this->vrs = vrs;
         this->composer_type = composer_type;
     };
 };


### PR DESCRIPTION
This PR closes #220, #236, #166 and:
* refactors the polynomial commitment schemes (pcs) interfaces in Honk to have unified interfaces and ensures usages of the pcs inside Honk are commitment agnostic
* improves documentations in the pcs folder
* resolves an issue in the IPA commentiment that was causing the proving system to fail when using IPA (in short: because the srs was being transform with the pippenger point table twice) and resolves some tech debt in the IPA component

Moreover, it advances work on issue #400 but, in order for this issue to be resolved, we further need to decide on structure and level of abstraction for Honk that enables us to run the same tests on IPA and KZG automatically (right now, to test IPA one would need to change the PCS-related parameters in the flavor manually). 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
