### PR TITLE
chore: disable circuits tests in master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,6 +315,12 @@ bb_test: &bb_test
     - x86_64-linux-clang-assert
   <<: *defaults
 
+notmaster: &notmaster
+  filters:
+    branches:
+      ignore:
+        - master
+
 workflows:
   system:
     jobs:
@@ -342,12 +348,16 @@ workflows:
                 - master
           <<: *defaults
       - circuits-wasm-linux-clang-builder-runner: *defaults
+          <<: *notmaster
       - circuits-x86_64-linux-clang-builder-runner: *defaults
+          <<: *notmaster
       - circuits-wasm-tests:
           requires:
             - circuits-wasm-linux-clang-builder-runner
           <<: *defaults
+          <<: *notmaster
       - circuits-x86_64-tests:
           requires:
             - circuits-x86_64-linux-clang-builder-runner
           <<: *defaults
+          <<: *notmaster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ notmaster: &notmaster
   filters:
     branches:
       ignore:
-        - db/disable-circuits-tests-master
+        - master
   <<: *defaults
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,8 @@ notmaster: &notmaster
   filters:
     branches:
       ignore:
-        - master
+        - db/disable-circuits-tests-master
+  <<: *defaults
 
 workflows:
   system:
@@ -347,17 +348,13 @@ workflows:
               only:
                 - master
           <<: *defaults
-      - circuits-wasm-linux-clang-builder-runner: *defaults
-          <<: *notmaster
-      - circuits-x86_64-linux-clang-builder-runner: *defaults
-          <<: *notmaster
+      - circuits-wasm-linux-clang-builder-runner: *notmaster
+      - circuits-x86_64-linux-clang-builder-runner:  *notmaster
       - circuits-wasm-tests:
           requires:
             - circuits-wasm-linux-clang-builder-runner
-          <<: *defaults
           <<: *notmaster
       - circuits-x86_64-tests:
           requires:
             - circuits-x86_64-linux-clang-builder-runner
-          <<: *defaults
           <<: *notmaster


### PR DESCRIPTION
# Description

Circuits tests are skipped in master.

Here is an example (but with branch hardcoded to this pr branch instead of master just for demonstration): https://app.circleci.com/pipelines/github/AztecProtocol/barretenberg/3323/workflows/6bc869af-6c91-46df-b384-3c4f05dad88a

Changed skip-branch back to master and now this PR fails because the circuits-test job fails (since circuits tests are broken in master rn), but CI should pass in master after this is merged since circuits-tests will be skipped.



# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
