### PR TITLE
Sumcheck improvements

### DIFF
--- a/cpp/src/barretenberg/honk/flavor/flavor.test.cpp
+++ b/cpp/src/barretenberg/honk/flavor/flavor.test.cpp
@@ -38,7 +38,7 @@ TEST(Flavor, StandardGetters)
     Flavor::VerificationKey verification_key;
     Flavor::ProverPolynomials prover_polynomials;
     Flavor::ExtendedEdges<Flavor::NUM_ALL_ENTITIES> edges;
-    Flavor::PurportedEvaluations evals;
+    Flavor::ClaimedEvaluations evals;
     Flavor::CommitmentLabels commitment_labels;
 
     // Globals are also available through STL container sizes

--- a/cpp/src/barretenberg/honk/flavor/flavor.test.cpp
+++ b/cpp/src/barretenberg/honk/flavor/flavor.test.cpp
@@ -120,11 +120,11 @@ TEST(Flavor, AllEntitiesSpecialMemberFunctions)
 {
     using Flavor = proof_system::honk::flavor::Standard;
     using FF = Flavor::FF;
-    using FoldedPolynomials = Flavor::FoldedPolynomials;
+    using PartiallyEvaluatedMultivariates = Flavor::PartiallyEvaluatedMultivariates;
     using Polynomial = Polynomial<FF>;
 
-    FoldedPolynomials polynomials_A;
-    std::vector<FF> random_poly{ 10 };
+    PartiallyEvaluatedMultivariates polynomials_A;
+    auto random_poly = Polynomial(10);
     for (auto& coeff : random_poly) {
         coeff = FF::random_element();
     }
@@ -135,10 +135,10 @@ TEST(Flavor, AllEntitiesSpecialMemberFunctions)
 
     ASSERT_EQ(random_poly, polynomials_A.w_l);
 
-    FoldedPolynomials polynomials_B(polynomials_A);
+    PartiallyEvaluatedMultivariates polynomials_B(polynomials_A);
     ASSERT_EQ(random_poly, polynomials_B.w_l);
 
-    FoldedPolynomials polynomials_C(std::move(polynomials_B));
+    PartiallyEvaluatedMultivariates polynomials_C(std::move(polynomials_B));
     ASSERT_EQ(random_poly, polynomials_C.w_l);
 }
 

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -191,9 +191,19 @@ class Standard {
 
     /**
      * @brief A container for polynomials produced after the first round of sumcheck.
-     * @todo TODO(#394) Use polynomial classes for guaranteed memory alignment.
      */
-    using FoldedPolynomials = AllEntities<std::vector<FF>, PolynomialHandle>;
+    class PartiallyEvaluatedMultivariates : public AllEntities<Polynomial, PolynomialHandle> {
+
+      public:
+        PartiallyEvaluatedMultivariates() = default;
+        PartiallyEvaluatedMultivariates(const size_t circuit_size)
+        {
+            // Storage is only needed after the first partial evaluation, hence polynomials of size (n / 2)
+            for (auto& poly : this->_data) {
+                poly = Polynomial(circuit_size / 2);
+            }
+        }
+    };
 
     /**
      * @brief A container for univariates produced during the hot loop in sumcheck.

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -52,6 +52,7 @@ class Standard {
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 4;
 
+    // define the tuple of Relations that comprise the Sumcheck relation
     using Relations = std::tuple<sumcheck::ArithmeticRelation<FF>,
                                  sumcheck::GrandProductComputationRelation<FF>,
                                  sumcheck::GrandProductInitializationRelation<FF>>;
@@ -59,7 +60,9 @@ class Standard {
     static constexpr size_t MAX_RELATION_LENGTH = get_max_relation_length<Relations>();
     static constexpr size_t NUM_RELATIONS = std::tuple_size<Relations>::value;
 
+    // define the container for storing the univariate contribution from each relation in Sumcheck
     using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations, 0>());
+    // define utilities to extend univarates from RELATION_LENGTH to MAX_RELATION_LENGTH for each Relation
     using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH, 0>());
 
   private:
@@ -204,7 +207,7 @@ class Standard {
     using ProverPolynomials = AllEntities<PolynomialHandle, PolynomialHandle>;
 
     /**
-     * @brief A container for polynomials produced after the first round of sumcheck.
+     * @brief A container for storing the partially evaluated multivariates produced by sumcheck.
      */
     class PartiallyEvaluatedMultivariates : public AllEntities<Polynomial, PolynomialHandle> {
 

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -217,11 +217,11 @@ class Standard {
      * @brief A container for the polynomials evaluations produced during sumcheck, which are purported to be the
      * evaluations of polynomials committed in earlier rounds.
      */
-    class PurportedEvaluations : public AllEntities<FF, FF> {
+    class ClaimedEvaluations : public AllEntities<FF, FF> {
       public:
         using Base = AllEntities<FF, FF>;
         using Base::Base;
-        PurportedEvaluations(std::array<FF, NUM_ALL_ENTITIES> _data_in) { this->_data = _data_in; }
+        ClaimedEvaluations(std::array<FF, NUM_ALL_ENTITIES> _data_in) { this->_data = _data_in; }
     };
 
     /**

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -61,9 +61,9 @@ class Standard {
     static constexpr size_t NUM_RELATIONS = std::tuple_size<Relations>::value;
 
     // define the container for storing the univariate contribution from each relation in Sumcheck
-    using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations, 0>());
+    using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations>());
     // define utilities to extend univarates from RELATION_LENGTH to MAX_RELATION_LENGTH for each Relation
-    using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH, 0>());
+    using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH>());
 
   private:
     /**

--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -6,8 +6,12 @@
 #include <type_traits>
 #include <vector>
 #include "barretenberg/honk/pcs/commitment_key.hpp"
+#include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
+#include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
 #include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
 #include "barretenberg/polynomials/evaluation_domain.hpp"
@@ -47,6 +51,16 @@ class Standard {
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 13;
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 4;
+
+    using Relations = std::tuple<sumcheck::ArithmeticRelation<FF>,
+                                 sumcheck::GrandProductComputationRelation<FF>,
+                                 sumcheck::GrandProductInitializationRelation<FF>>;
+
+    static constexpr size_t MAX_RELATION_LENGTH = get_max_relation_length<Relations>();
+    static constexpr size_t NUM_RELATIONS = std::tuple_size<Relations>::value;
+
+    using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations, 0>());
+    using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH, 0>());
 
   private:
     /**

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -50,6 +50,7 @@ class Ultra {
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 11;
 
+    // define the tuple of Relations that comprise the Sumcheck relation
     using Relations = std::tuple<sumcheck::UltraArithmeticRelation<FF>,
                                  sumcheck::UltraArithmeticRelationSecondary<FF>,
                                  sumcheck::UltraGrandProductComputationRelation<FF>,
@@ -63,7 +64,9 @@ class Ultra {
     static constexpr size_t MAX_RELATION_LENGTH = get_max_relation_length<Relations>();
     static constexpr size_t NUM_RELATIONS = std::tuple_size<Relations>::value;
 
+    // define the container for storing the univariate contribution from each relation in Sumcheck
     using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations, 0>());
+    // define utilities to extend univarates from RELATION_LENGTH to MAX_RELATION_LENGTH for each Relation
     using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH, 0>());
 
   private:
@@ -274,7 +277,7 @@ class Ultra {
     using ProverPolynomials = AllEntities<PolynomialHandle, PolynomialHandle>;
 
     /**
-     * @brief A container for polynomials produced after the first round of sumcheck.
+     * @brief A container for storing the partially evaluated multivariates produced by sumcheck.
      */
     class PartiallyEvaluatedMultivariates : public AllEntities<Polynomial, PolynomialHandle> {
 

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <vector>
 #include "barretenberg/honk/pcs/commitment_key.hpp"
+#include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
@@ -15,6 +16,14 @@
 #include "barretenberg/proof_system/circuit_constructors/ultra_circuit_constructor.hpp"
 #include "barretenberg/srs/reference_string/reference_string.hpp"
 #include "barretenberg/proof_system/flavor/flavor.hpp"
+#include "barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation_secondary.hpp"
+#include "barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/lookup_grand_product_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/elliptic_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp"
 
 namespace proof_system::honk::flavor {
 
@@ -40,6 +49,22 @@ class Ultra {
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 25;
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 11;
+
+    using Relations = std::tuple<sumcheck::UltraArithmeticRelation<FF>,
+                                 sumcheck::UltraArithmeticRelationSecondary<FF>,
+                                 sumcheck::UltraGrandProductComputationRelation<FF>,
+                                 sumcheck::UltraGrandProductInitializationRelation<FF>,
+                                 sumcheck::LookupGrandProductComputationRelation<FF>,
+                                 sumcheck::LookupGrandProductInitializationRelation<FF>,
+                                 sumcheck::GenPermSortRelation<FF>,
+                                 sumcheck::EllipticRelation<FF>,
+                                 sumcheck::AuxiliaryRelation<FF>>;
+
+    static constexpr size_t MAX_RELATION_LENGTH = get_max_relation_length<Relations>();
+    static constexpr size_t NUM_RELATIONS = std::tuple_size<Relations>::value;
+
+    using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations, 0>());
+    using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH, 0>());
 
   private:
     template <typename DataType, typename HandleType>

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -65,9 +65,9 @@ class Ultra {
     static constexpr size_t NUM_RELATIONS = std::tuple_size<Relations>::value;
 
     // define the container for storing the univariate contribution from each relation in Sumcheck
-    using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations, 0>());
+    using UnivariateTuple = decltype(create_univariate_tuple<FF, Relations>());
     // define utilities to extend univarates from RELATION_LENGTH to MAX_RELATION_LENGTH for each Relation
-    using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH, 0>());
+    using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH>());
 
   private:
     template <typename DataType, typename HandleType>

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -276,11 +276,11 @@ class Ultra {
      * @brief A container for the polynomials evaluations produced during sumcheck, which are purported to be the
      * evaluations of polynomials committed in earlier rounds.
      */
-    class PurportedEvaluations : public AllEntities<FF, FF> {
+    class ClaimedEvaluations : public AllEntities<FF, FF> {
       public:
         using Base = AllEntities<FF, FF>;
         using Base::Base;
-        PurportedEvaluations(std::array<FF, NUM_ALL_ENTITIES> _data_in) { this->_data = _data_in; }
+        ClaimedEvaluations(std::array<FF, NUM_ALL_ENTITIES> _data_in) { this->_data = _data_in; }
     };
 
     /**

--- a/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -250,9 +250,19 @@ class Ultra {
 
     /**
      * @brief A container for polynomials produced after the first round of sumcheck.
-     * @todo TODO(#394) Use polynomial classes for guaranteed memory alignment.
      */
-    using FoldedPolynomials = AllEntities<std::vector<FF>, PolynomialHandle>;
+    class PartiallyEvaluatedMultivariates : public AllEntities<Polynomial, PolynomialHandle> {
+
+      public:
+        PartiallyEvaluatedMultivariates() = default;
+        PartiallyEvaluatedMultivariates(const size_t circuit_size)
+        {
+            // Storage is only needed after the first partial evaluation, hence polynomials of size (n / 2)
+            for (auto& poly : this->_data) {
+                poly = Polynomial(circuit_size / 2);
+            }
+        }
+    };
 
     /**
      * @brief A container for univariates produced during the hot loop in sumcheck.

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -3,9 +3,6 @@
 #include "barretenberg/honk/sumcheck/sumcheck.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
 #include "barretenberg/honk/utils/power_polynomial.hpp"
-#include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp"
 #include "barretenberg/honk/flavor/standard.hpp"
 
 namespace proof_system::honk {
@@ -130,11 +127,7 @@ template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_grand_pro
  * */
 template <StandardFlavor Flavor> void StandardProver_<Flavor>::execute_relation_check_rounds()
 {
-    using Sumcheck = sumcheck::Sumcheck<Flavor,
-                                        ProverTranscript<FF>,
-                                        sumcheck::ArithmeticRelation,
-                                        sumcheck::GrandProductComputationRelation,
-                                        sumcheck::GrandProductInitializationRelation>;
+    using Sumcheck = sumcheck::Sumcheck<Flavor, ProverTranscript<FF>>;
 
     auto sumcheck = Sumcheck(key->circuit_size, transcript);
 

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
@@ -2,8 +2,6 @@
 #include <algorithm>
 #include <cstddef>
 #include "barretenberg/honk/proof_system/prover_library.hpp"
-#include "barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation_secondary.hpp"
 #include "barretenberg/honk/sumcheck/sumcheck.hpp"
 #include <array>
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp" // will go away
@@ -15,13 +13,6 @@
 #include <vector>
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
-#include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/lookup_grand_product_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/elliptic_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/transcript/transcript_wrappers.hpp"
 #include <string>
@@ -191,17 +182,7 @@ template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_grand_product_c
  */
 template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_relation_check_rounds()
 {
-    using Sumcheck = sumcheck::Sumcheck<Flavor,
-                                        ProverTranscript<FF>,
-                                        sumcheck::UltraArithmeticRelation,
-                                        sumcheck::UltraArithmeticRelationSecondary,
-                                        sumcheck::UltraGrandProductComputationRelation,
-                                        sumcheck::UltraGrandProductInitializationRelation,
-                                        sumcheck::LookupGrandProductComputationRelation,
-                                        sumcheck::LookupGrandProductInitializationRelation,
-                                        sumcheck::GenPermSortRelation,
-                                        sumcheck::EllipticRelation,
-                                        sumcheck::AuxiliaryRelation>;
+    using Sumcheck = sumcheck::Sumcheck<Flavor, ProverTranscript<FF>>;
 
     auto sumcheck = Sumcheck(key->circuit_size, transcript);
 

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -4,14 +4,6 @@
 #include "barretenberg/honk/flavor/standard.hpp"
 #include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/honk/utils/power_polynomial.hpp"
-#include "barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation_secondary.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/lookup_grand_product_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/elliptic_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp"
 
 #pragma GCC diagnostic ignored "-Wunused-variable"
 
@@ -107,17 +99,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     commitments.z_lookup = transcript.template receive_from_prover<Commitment>(commitment_labels.z_lookup);
 
     // Execute Sumcheck Verifier
-    auto sumcheck = Sumcheck<Flavor,
-                             VerifierTranscript<FF>,
-                             honk::sumcheck::UltraArithmeticRelation,
-                             honk::sumcheck::UltraArithmeticRelationSecondary,
-                             honk::sumcheck::UltraGrandProductComputationRelation,
-                             honk::sumcheck::UltraGrandProductInitializationRelation,
-                             honk::sumcheck::LookupGrandProductComputationRelation,
-                             honk::sumcheck::LookupGrandProductInitializationRelation,
-                             honk::sumcheck::GenPermSortRelation,
-                             honk::sumcheck::EllipticRelation,
-                             honk::sumcheck::AuxiliaryRelation>(circuit_size, transcript);
+    auto sumcheck = Sumcheck<Flavor, VerifierTranscript<FF>>(circuit_size, transcript);
 
     std::optional sumcheck_output = sumcheck.execute_verifier(relation_parameters);
 

--- a/cpp/src/barretenberg/honk/proof_system/verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/verifier.cpp
@@ -4,9 +4,6 @@
 #include "barretenberg/honk/flavor/standard.hpp"
 #include "barretenberg/ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/honk/utils/power_polynomial.hpp"
-#include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_initialization_relation.hpp"
-#include "barretenberg/honk/sumcheck/relations/grand_product_computation_relation.hpp"
 
 using namespace barretenberg;
 using namespace proof_system::honk::sumcheck;
@@ -111,11 +108,7 @@ template <typename Flavor> bool StandardVerifier_<Flavor>::verify_proof(const pl
     commitments.z_perm = transcript.template receive_from_prover<Commitment>(commitment_labels.z_perm);
 
     // Execute Sumcheck Verifier
-    auto sumcheck = Sumcheck<Flavor,
-                             VerifierTranscript<FF>,
-                             honk::sumcheck::ArithmeticRelation,
-                             honk::sumcheck::GrandProductComputationRelation,
-                             honk::sumcheck::GrandProductInitializationRelation>(circuit_size, transcript);
+    auto sumcheck = Sumcheck<Flavor, VerifierTranscript<FF>>(circuit_size, transcript);
     std::optional sumcheck_output = sumcheck.execute_verifier(relation_parameters);
 
     // If Sumcheck does not return an output, sumcheck verification has failed

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
@@ -165,19 +165,4 @@ template <class Fr, size_t domain_size, size_t num_evals> class BarycentricData 
         return result;
     };
 };
-
-// Explicit instantiation of the templates needed for Standard and Ultra
-// TODO(#390)(luke): The hard coded 5/6 here is based on max relation length. Ideally this would be handled
-// programtically via some integration with the Flavor.
-template class BarycentricData<barretenberg::fr, 2, 5>;
-template class BarycentricData<barretenberg::fr, 3, 5>;
-template class BarycentricData<barretenberg::fr, 4, 5>;
-template class BarycentricData<barretenberg::fr, 5, 5>;
-
-template class BarycentricData<barretenberg::fr, 2, 6>;
-template class BarycentricData<barretenberg::fr, 3, 6>;
-template class BarycentricData<barretenberg::fr, 4, 6>;
-template class BarycentricData<barretenberg::fr, 5, 6>;
-template class BarycentricData<barretenberg::fr, 6, 6>;
-
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <array>
 #include <algorithm>
-// #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "univariate.hpp"
 
 /* IMPROVEMENT(Cody): This could or should be improved in various ways. In no particular order:

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
@@ -1,17 +1,16 @@
 #pragma once
 #include <array>
 #include <algorithm>
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "univariate.hpp"
 
 /* IMPROVEMENT(Cody): This could or should be improved in various ways. In no particular order:
    1) Edge cases are not considered. One non-use case situation (I forget which) leads to a segfault.
 
-   2) This could all be constexpr.
-
-   3) Precomputing for all possible size pairs is probably feasible and might be a better solution than instantiating
+   2) Precomputing for all possible size pairs is probably feasible and might be a better solution than instantiating
    many instances separately. Then perhaps we could infer input type to `extend`.
 
-   4) There should be more thorough testing of this class in isolation.
+   3) There should be more thorough testing of this class in isolation.
  */
 namespace proof_system::honk::sumcheck {
 
@@ -166,4 +165,19 @@ template <class Fr, size_t domain_size, size_t num_evals> class BarycentricData 
         return result;
     };
 };
+
+// Explicit instantiation of the templates needed for Standard and Ultra
+// TODO(#390)(luke): The hard coded 5/6 here is based on max relation length. Ideally this would be handled
+// programtically via some integration with the Flavor.
+template class BarycentricData<barretenberg::fr, 2, 5>;
+template class BarycentricData<barretenberg::fr, 3, 5>;
+template class BarycentricData<barretenberg::fr, 4, 5>;
+template class BarycentricData<barretenberg::fr, 5, 5>;
+
+template class BarycentricData<barretenberg::fr, 2, 6>;
+template class BarycentricData<barretenberg::fr, 3, 6>;
+template class BarycentricData<barretenberg::fr, 4, 6>;
+template class BarycentricData<barretenberg::fr, 5, 6>;
+template class BarycentricData<barretenberg::fr, 6, 6>;
+
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <array>
 #include <algorithm>
-#include "barretenberg/ecc/curves/bn254/fr.hpp"
+// #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "univariate.hpp"
 
 /* IMPROVEMENT(Cody): This could or should be improved in various ways. In no particular order:
@@ -22,6 +22,10 @@ namespace proof_system::honk::sumcheck {
 template <class Fr, size_t domain_size, size_t num_evals> class BarycentricData {
   public:
     static constexpr size_t big_domain_size = std::max(domain_size, num_evals);
+
+    /**
+     * Static constexpr methods for computing arrays of precomputable data used for barycentric extension and evaluation
+     */
 
     // build big_domain, currently the set of x_i in {0, 1, ..., t-1}
     static constexpr std::array<Fr, big_domain_size> construct_big_domain()

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/multivariates.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/multivariates.test.cpp
@@ -61,7 +61,7 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsSpecial)
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript::init_empty();
-    auto sumcheck = Sumcheck<Flavor, Transcript, ArithmeticRelation>(multivariate_n, transcript);
+    auto sumcheck = Sumcheck<Flavor, Transcript>(multivariate_n, transcript);
 
     FF round_challenge_0 = { 0x6c7301b49d85a46c, 0x44311531e39c64f6, 0xb13d66d8d6c1a24c, 0x04410c360230a295 };
     round_challenge_0.self_to_montgomery_form();
@@ -98,7 +98,7 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsGeneric)
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript::init_empty();
-    auto sumcheck = Sumcheck<Flavor, Transcript, ArithmeticRelation>(multivariate_n, transcript);
+    auto sumcheck = Sumcheck<Flavor, Transcript>(multivariate_n, transcript);
 
     FF round_challenge_0 = FF::random_element();
     FF expected_lo = v00 * (FF(1) - round_challenge_0) + v10 * round_challenge_0;
@@ -159,7 +159,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsSpecial)
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript::init_empty();
-    auto sumcheck = Sumcheck<Flavor, Transcript, ArithmeticRelation>(multivariate_n, transcript);
+    auto sumcheck = Sumcheck<Flavor, Transcript>(multivariate_n, transcript);
 
     FF round_challenge_0 = 1;
     FF expected_q1 = v000 * (FF(1) - round_challenge_0) + v100 * round_challenge_0; // 2
@@ -210,7 +210,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGeneric)
 
     auto full_polynomials = std::array<std::span<FF>, 1>({ f0 });
     auto transcript = Transcript::init_empty();
-    auto sumcheck = Sumcheck<Flavor, Transcript, ArithmeticRelation>(multivariate_n, transcript);
+    auto sumcheck = Sumcheck<Flavor, Transcript>(multivariate_n, transcript);
 
     FF round_challenge_0 = FF::random_element();
     FF expected_q1 = v000 * (FF(1) - round_challenge_0) + v100 * round_challenge_0;
@@ -272,7 +272,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
 
     auto full_polynomials = std::array<std::span<FF>, 3>{ f0, f1, f2 };
     auto transcript = Transcript::init_empty();
-    auto sumcheck = Sumcheck<Flavor, Transcript, ArithmeticRelation>(multivariate_n, transcript);
+    auto sumcheck = Sumcheck<Flavor, Transcript>(multivariate_n, transcript);
 
     std::array<FF, 3> expected_q1;
     std::array<FF, 3> expected_q2;

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/multivariates.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/multivariates.test.cpp
@@ -68,7 +68,7 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsSpecial)
     FF expected_lo = v00 * (FF(1) - round_challenge_0) + v10 * round_challenge_0;
     FF expected_hi = v01 * (FF(1) - round_challenge_0) + v11 * round_challenge_0;
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
 
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], round_challenge_0);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], FF(0));
@@ -76,7 +76,7 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsSpecial)
     FF round_challenge_1 = 2;
     FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
 
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
@@ -104,14 +104,14 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsGeneric)
     FF expected_lo = v00 * (FF(1) - round_challenge_0) + v10 * round_challenge_0;
     FF expected_hi = v01 * (FF(1) - round_challenge_0) + v11 * round_challenge_0;
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
 
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_lo);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_hi);
 
     FF round_challenge_1 = FF::random_element();
     FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
@@ -167,7 +167,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsSpecial)
     FF expected_q3 = v001 * (FF(1) - round_challenge_0) + v101 * round_challenge_0; // 6
     FF expected_q4 = v011 * (FF(1) - round_challenge_0) + v111 * round_challenge_0; // 8
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
 
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_q1);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_q2);
@@ -178,13 +178,13 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsSpecial)
     FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1; // 6
     FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1; // 10
 
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_lo);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_hi);
 
     FF round_challenge_2 = 3;
     FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2; // 18
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
@@ -218,7 +218,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGeneric)
     FF expected_q3 = v001 * (FF(1) - round_challenge_0) + v101 * round_challenge_0;
     FF expected_q4 = v011 * (FF(1) - round_challenge_0) + v111 * round_challenge_0;
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
 
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_q1);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_q2);
@@ -229,13 +229,13 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGeneric)
     FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1;
     FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1;
 
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_lo);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_hi);
 
     FF round_challenge_2 = FF::random_element();
     FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2;
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
     EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
@@ -286,7 +286,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
         expected_q4[i] = v011[i] * (FF(1) - round_challenge_0) + v111[i] * round_challenge_0;
     }
 
-    sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][0], expected_q1[i]);
         EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][1], expected_q2[i]);
@@ -301,7 +301,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
         expected_lo[i] = expected_q1[i] * (FF(1) - round_challenge_1) + expected_q2[i] * round_challenge_1;
         expected_hi[i] = expected_q3[i] * (FF(1) - round_challenge_1) + expected_q4[i] * round_challenge_1;
     }
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][0], expected_lo[i]);
         EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][1], expected_hi[i]);
@@ -311,7 +311,7 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
     for (size_t i = 0; i < 3; i++) {
         expected_val[i] = expected_lo[i] * (FF(1) - round_challenge_2) + expected_hi[i] * round_challenge_2;
     }
-    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][0], expected_val[i]);
     }

--- a/cpp/src/barretenberg/honk/sumcheck/polynomials/multivariates.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/polynomials/multivariates.test.cpp
@@ -70,14 +70,14 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsSpecial)
 
     sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], round_challenge_0);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][1], FF(0));
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], round_challenge_0);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], FF(0));
 
     FF round_challenge_1 = 2;
     FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
 
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_val);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
 TYPED_TEST(MultivariatesTests, FoldTwoRoundsGeneric)
@@ -106,13 +106,13 @@ TYPED_TEST(MultivariatesTests, FoldTwoRoundsGeneric)
 
     sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_lo);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_hi);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_lo);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_hi);
 
     FF round_challenge_1 = FF::random_element();
     FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_val);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
 /*
@@ -169,23 +169,23 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsSpecial)
 
     sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_q1);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_q2);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][2], expected_q3);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][3], expected_q4);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_q1);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_q2);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][2], expected_q3);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][3], expected_q4);
 
     FF round_challenge_1 = 2;
     FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1; // 6
     FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1; // 10
 
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_lo);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_hi);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_lo);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_hi);
 
     FF round_challenge_2 = 3;
     FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2; // 18
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_2);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_val);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
 TYPED_TEST(MultivariatesTests, FoldThreeRoundsGeneric)
@@ -220,23 +220,23 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGeneric)
 
     sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
 
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_q1);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_q2);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][2], expected_q3);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][3], expected_q4);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_q1);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_q2);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][2], expected_q3);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][3], expected_q4);
 
     FF round_challenge_1 = FF::random_element();
     FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1;
     FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1;
 
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_lo);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][1], expected_hi);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_lo);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][1], expected_hi);
 
     FF round_challenge_2 = FF::random_element();
     FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2;
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_2);
-    EXPECT_EQ(sumcheck.folded_polynomials[0][0], expected_val);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    EXPECT_EQ(sumcheck.partially_evaluated_polynomials[0][0], expected_val);
 }
 
 TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
@@ -288,10 +288,10 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
 
     sumcheck.fold(full_polynomials, multivariate_n, round_challenge_0);
     for (size_t i = 0; i < 3; i++) {
-        EXPECT_EQ(sumcheck.folded_polynomials[i][0], expected_q1[i]);
-        EXPECT_EQ(sumcheck.folded_polynomials[i][1], expected_q2[i]);
-        EXPECT_EQ(sumcheck.folded_polynomials[i][2], expected_q3[i]);
-        EXPECT_EQ(sumcheck.folded_polynomials[i][3], expected_q4[i]);
+        EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][0], expected_q1[i]);
+        EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][1], expected_q2[i]);
+        EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][2], expected_q3[i]);
+        EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][3], expected_q4[i]);
     }
 
     FF round_challenge_1 = FF::random_element();
@@ -301,19 +301,19 @@ TYPED_TEST(MultivariatesTests, FoldThreeRoundsGenericMultiplePolys)
         expected_lo[i] = expected_q1[i] * (FF(1) - round_challenge_1) + expected_q2[i] * round_challenge_1;
         expected_hi[i] = expected_q3[i] * (FF(1) - round_challenge_1) + expected_q4[i] * round_challenge_1;
     }
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
     for (size_t i = 0; i < 3; i++) {
-        EXPECT_EQ(sumcheck.folded_polynomials[i][0], expected_lo[i]);
-        EXPECT_EQ(sumcheck.folded_polynomials[i][1], expected_hi[i]);
+        EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][0], expected_lo[i]);
+        EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][1], expected_hi[i]);
     }
     FF round_challenge_2 = FF::random_element();
     std::array<FF, 3> expected_val;
     for (size_t i = 0; i < 3; i++) {
         expected_val[i] = expected_lo[i] * (FF(1) - round_challenge_2) + expected_hi[i] * round_challenge_2;
     }
-    sumcheck.fold(sumcheck.folded_polynomials, multivariate_n >> 2, round_challenge_2);
+    sumcheck.fold(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
     for (size_t i = 0; i < 3; i++) {
-        EXPECT_EQ(sumcheck.folded_polynomials[i][0], expected_val[i]);
+        EXPECT_EQ(sumcheck.partially_evaluated_polynomials[i][0], expected_val[i]);
     }
 }
 

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_consistency.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_consistency.test.cpp
@@ -33,7 +33,7 @@ class StandardRelationConsistency : public testing::Test {
   public:
     using Flavor = honk::flavor::Standard;
     using FF = typename Flavor::FF;
-    using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+    using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
     // TODO(#390): Move MAX_RELATION_LENGTH into Flavor and simplify this.
 
     template <size_t t> using ExtendedEdges = typename Flavor::template ExtendedEdges<t>;
@@ -82,7 +82,7 @@ class StandardRelationConsistency : public testing::Test {
      * @return std::array<FF, NUM_UNIVARIATES> such that result[j] = univariates[j].value_at(i)
      */
     template <size_t univariate_length>
-    static PurportedEvaluations transposed_univariate_array_at(ExtendedEdges<univariate_length> univariates, size_t i)
+    static ClaimedEvaluations transposed_univariate_array_at(ExtendedEdges<univariate_length> univariates, size_t i)
     {
         ASSERT(i < univariate_length);
         std::array<FF, Flavor::NUM_ALL_ENTITIES> result;
@@ -117,7 +117,7 @@ class StandardRelationConsistency : public testing::Test {
         Univariate<FF, FULL_RELATION_LENGTH> expected_evals_index{ 0 };
         for (size_t i = 0; i < FULL_RELATION_LENGTH; ++i) {
             // Get an array of the same size as `extended_edges` with only the i-th element of each extended edge.
-            PurportedEvaluations evals_i = transposed_univariate_array_at(extended_edges, i);
+            ClaimedEvaluations evals_i = transposed_univariate_array_at(extended_edges, i);
             // Evaluate the relation
             relation.add_full_relation_value_contribution(
                 expected_evals_index.value_at(i), evals_i, relation_parameters);

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
@@ -42,7 +42,7 @@ TEST(RelationCorrectness, StandardRelationCorrectness)
     using Flavor = honk::flavor::Standard;
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
-    using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+    using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     // Create a composer and a dummy circuit with a few gates
     auto composer = StandardHonkComposer();
@@ -115,7 +115,7 @@ TEST(RelationCorrectness, StandardRelationCorrectness)
     for (size_t i = 0; i < prover.key->circuit_size; i++) {
         // Compute an array containing all the evaluations at a given row i
 
-        PurportedEvaluations evaluations_at_index_i;
+        ClaimedEvaluations evaluations_at_index_i;
         size_t poly_idx = 0;
         for (auto& polynomial : prover_polynomials) {
             evaluations_at_index_i[poly_idx] = polynomial[i];
@@ -154,7 +154,7 @@ TEST(RelationCorrectness, UltraRelationCorrectness)
     using Flavor = honk::flavor::Ultra;
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
-    using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+    using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     // Create a composer and then add an assortment of gates designed to ensure that the constraint(s) represented
     // by each relation are non-trivially exercised.
@@ -379,7 +379,7 @@ TEST(RelationCorrectness, UltraRelationCorrectness)
     fr result = 0;
     for (size_t i = 0; i < prover.key->circuit_size; i++) {
         // Compute an array containing all the evaluations at a given row i
-        PurportedEvaluations evaluations_at_index_i;
+        ClaimedEvaluations evaluations_at_index_i;
         size_t poly_idx = 0;
         for (auto& polynomial : prover_polynomials) {
             evaluations_at_index_i[poly_idx] = polynomial[i];

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ultra_relation_consistency.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ultra_relation_consistency.test.cpp
@@ -36,7 +36,7 @@ class UltraRelationConsistency : public testing::Test {
   public:
     using Flavor = honk::flavor::Ultra;
     using FF = typename Flavor::FF;
-    using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+    using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     // TODO(#390): Move MAX_RELATION_LENGTH into Flavor and simplify this.
     template <size_t t> using ExtendedEdges = typename Flavor::template ExtendedEdges<t>;
@@ -83,7 +83,7 @@ class UltraRelationConsistency : public testing::Test {
      * @return std::array<FF, NUM_UNIVARIATES> such that result[j] = univariates[j].value_at(i)
      */
     template <size_t univariate_length>
-    static PurportedEvaluations transposed_univariate_array_at(ExtendedEdges<univariate_length> univariates, size_t i)
+    static ClaimedEvaluations transposed_univariate_array_at(ExtendedEdges<univariate_length> univariates, size_t i)
     {
         ASSERT(i < univariate_length);
         std::array<FF, Flavor::NUM_ALL_ENTITIES> result;
@@ -118,7 +118,7 @@ class UltraRelationConsistency : public testing::Test {
         Univariate<FF, FULL_RELATION_LENGTH> expected_evals_index{ 0 };
         for (size_t i = 0; i < FULL_RELATION_LENGTH; ++i) {
             // Get an array of the same size as `extended_edges` with only the i-th element of each extended edge.
-            PurportedEvaluations evals_i = transposed_univariate_array_at(extended_edges, i);
+            ClaimedEvaluations evals_i = transposed_univariate_array_at(extended_edges, i);
             // Evaluate the relation
             relation.add_full_relation_value_contribution(
                 expected_evals_index.value_at(i), evals_i, relation_parameters);

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
@@ -18,20 +18,20 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename Flavor, class Transcript, template <class> class... Relations> class Sumcheck {
+template <typename Flavor, class Transcript> class Sumcheck {
 
   public:
     using FF = typename Flavor::FF;
     using PartiallyEvaluatedMultivariates = typename Flavor::PartiallyEvaluatedMultivariates;
     using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
-    static constexpr size_t MAX_RELATION_LENGTH = std::max({ Relations<FF>::RELATION_LENGTH... });
+    static constexpr size_t MAX_RELATION_LENGTH = Flavor::MAX_RELATION_LENGTH;
     static constexpr size_t NUM_POLYNOMIALS = Flavor::NUM_ALL_ENTITIES;
 
     Transcript& transcript;
     const size_t multivariate_n;
     const size_t multivariate_d;
-    SumcheckRound<Flavor, Relations...> round;
+    SumcheckRound<Flavor> round;
 
     /**
     *
@@ -71,7 +71,7 @@ template <typename Flavor, class Transcript, template <class> class... Relations
         : transcript(transcript)
         , multivariate_n(multivariate_n)
         , multivariate_d(numeric::get_msb(multivariate_n))
-        , round(multivariate_n, std::tuple(Relations<FF>()...))
+        , round(multivariate_n)
         , partially_evaluated_polynomials(multivariate_n){};
 
     // verifier instantiates sumcheck with circuit size and a verifier transcript
@@ -79,7 +79,7 @@ template <typename Flavor, class Transcript, template <class> class... Relations
         : transcript(transcript)
         , multivariate_n(multivariate_n)
         , multivariate_d(numeric::get_msb(multivariate_n))
-        , round(std::tuple(Relations<FF>()...)){};
+        , round(){};
 
     /**
      * @brief Compute univariate restriction place in transcript, generate challenge, partially evaluate,... repeat

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck.hpp
@@ -23,7 +23,7 @@ template <typename Flavor, class Transcript, template <class> class... Relations
   public:
     using FF = typename Flavor::FF;
     using PartiallyEvaluatedMultivariates = typename Flavor::PartiallyEvaluatedMultivariates;
-    using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+    using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     static constexpr size_t MAX_RELATION_LENGTH = std::max({ Relations<FF>::RELATION_LENGTH... });
     static constexpr size_t NUM_POLYNOMIALS = Flavor::NUM_ALL_ENTITIES;
@@ -123,7 +123,7 @@ template <typename Flavor, class Transcript, template <class> class... Relations
         }
 
         // Final round: Extract multivariate evaluations from partially_evaluated_polynomials and add to transcript
-        PurportedEvaluations multivariate_evaluations;
+        ClaimedEvaluations multivariate_evaluations;
         size_t evaluation_idx = 0;
         for (auto& polynomial : partially_evaluated_polynomials) { // TODO(#391) zip
             multivariate_evaluations[evaluation_idx] = polynomial[0];
@@ -178,7 +178,7 @@ template <typename Flavor, class Transcript, template <class> class... Relations
         }
 
         // Final round
-        PurportedEvaluations purported_evaluations =
+        ClaimedEvaluations purported_evaluations =
             transcript.template receive_from_prover<std::array<FF, NUM_POLYNOMIALS>>("Sumcheck:evaluations");
 
         FF full_honk_relation_purported_value = round.compute_full_honk_relation_purported_value(

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
@@ -178,7 +178,7 @@ TEST(Sumcheck, PolynomialNormalization)
                               l_2 * full_polynomials[i][2] + l_3 * full_polynomials[i][3] +
                               l_4 * full_polynomials[i][4] + l_5 * full_polynomials[i][5] +
                               l_6 * full_polynomials[i][6] + l_7 * full_polynomials[i][7];
-        EXPECT_EQ(hand_computed_value, sumcheck.folded_polynomials[i][0]);
+        EXPECT_EQ(hand_computed_value, sumcheck.partially_evaluated_polynomials[i][0]);
     }
 }
 

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
@@ -138,11 +138,7 @@ TEST(Sumcheck, PolynomialNormalization)
 
     auto transcript = ProverTranscript<FF>::init_empty();
 
-    auto sumcheck = Sumcheck<Flavor,
-                             ProverTranscript<FF>,
-                             ArithmeticRelation,
-                             GrandProductComputationRelation,
-                             GrandProductInitializationRelation>(multivariate_n, transcript);
+    auto sumcheck = Sumcheck<Flavor, ProverTranscript<FF>>(multivariate_n, transcript);
 
     auto [multivariate_challenge, evaluations] = sumcheck.execute_prover(full_polynomials, {});
 
@@ -238,11 +234,7 @@ TEST(Sumcheck, Prover)
 
         auto transcript = ProverTranscript<FF>::init_empty();
 
-        auto sumcheck = Sumcheck<Flavor,
-                                 ProverTranscript<FF>,
-                                 ArithmeticRelation,
-                                 GrandProductComputationRelation,
-                                 GrandProductInitializationRelation>(multivariate_n, transcript);
+        auto sumcheck = Sumcheck<Flavor, ProverTranscript<FF>>(multivariate_n, transcript);
 
         auto [multivariate_challenge, evaluations] = sumcheck.execute_prover(full_polynomials, {});
         FF u_0 = multivariate_challenge[0];
@@ -319,21 +311,13 @@ TEST(Sumcheck, ProverAndVerifier)
 
     auto prover_transcript = ProverTranscript<FF>::init_empty();
 
-    auto sumcheck_prover = Sumcheck<Flavor,
-                                    ProverTranscript<FF>,
-                                    ArithmeticRelation,
-                                    GrandProductComputationRelation,
-                                    GrandProductInitializationRelation>(multivariate_n, prover_transcript);
+    auto sumcheck_prover = Sumcheck<Flavor, ProverTranscript<FF>>(multivariate_n, prover_transcript);
 
     auto prover_output = sumcheck_prover.execute_prover(full_polynomials, relation_parameters);
 
     auto verifier_transcript = VerifierTranscript<FF>::init_empty(prover_transcript);
 
-    auto sumcheck_verifier = Sumcheck<Flavor,
-                                      VerifierTranscript<FF>,
-                                      ArithmeticRelation,
-                                      GrandProductComputationRelation,
-                                      GrandProductInitializationRelation>(multivariate_n, verifier_transcript);
+    auto sumcheck_verifier = Sumcheck<Flavor, VerifierTranscript<FF>>(multivariate_n, verifier_transcript);
 
     std::optional verifier_output = sumcheck_verifier.execute_verifier(relation_parameters);
 
@@ -401,21 +385,13 @@ TEST(Sumcheck, ProverAndVerifierLonger)
 
         auto prover_transcript = ProverTranscript<FF>::init_empty();
 
-        auto sumcheck_prover = Sumcheck<Flavor,
-                                        ProverTranscript<FF>,
-                                        ArithmeticRelation,
-                                        GrandProductComputationRelation,
-                                        GrandProductInitializationRelation>(multivariate_n, prover_transcript);
+        auto sumcheck_prover = Sumcheck<Flavor, ProverTranscript<FF>>(multivariate_n, prover_transcript);
 
         auto prover_output = sumcheck_prover.execute_prover(full_polynomials, relation_parameters);
 
         auto verifier_transcript = VerifierTranscript<FF>::init_empty(prover_transcript);
 
-        auto sumcheck_verifier = Sumcheck<Flavor,
-                                          VerifierTranscript<FF>,
-                                          ArithmeticRelation,
-                                          GrandProductComputationRelation,
-                                          GrandProductInitializationRelation>(multivariate_n, verifier_transcript);
+        auto sumcheck_verifier = Sumcheck<Flavor, VerifierTranscript<FF>>(multivariate_n, verifier_transcript);
 
         std::optional verifier_output = sumcheck_verifier.execute_verifier(relation_parameters);
 

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck_output.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck_output.hpp
@@ -10,16 +10,16 @@ namespace proof_system::honk::sumcheck {
  */
 template <typename Flavor> struct SumcheckOutput {
     using FF = typename Flavor::FF;
-    using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+    using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
     // u = (u_0, ..., u_{d-1})
     std::vector<FF> challenge_point;
     // Evaluations in `u` of the polynomials used in Sumcheck
-    PurportedEvaluations purported_evaluations;
+    ClaimedEvaluations purported_evaluations;
 
     SumcheckOutput()
         : purported_evaluations(std::array<FF, Flavor::NUM_ALL_ENTITIES>()){};
 
-    SumcheckOutput(const std::vector<FF>& _challenge_point, const PurportedEvaluations& _purported_evaluations)
+    SumcheckOutput(const std::vector<FF>& _challenge_point, const ClaimedEvaluations& _purported_evaluations)
         : challenge_point(_challenge_point)
         , purported_evaluations(_purported_evaluations){};
 

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.hpp
@@ -59,7 +59,7 @@ template <typename Flavor, template <class> class... Relations> class SumcheckRo
     using FF = typename Flavor::FF;
     template <size_t univariate_length>
     using ExtendedEdges = typename Flavor::template ExtendedEdges<univariate_length>;
-    using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+    using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     bool round_failed = false;
     size_t round_size; // a power of 2
@@ -218,7 +218,7 @@ template <typename Flavor, template <class> class... Relations> class SumcheckRo
      * together, with appropriate scaling factors, produces the expected value of the full Honk relation. This value is
      * checked against the final value of the target total sum, defined as sigma_d.
      */
-    FF compute_full_honk_relation_purported_value(PurportedEvaluations purported_evaluations,
+    FF compute_full_honk_relation_purported_value(ClaimedEvaluations purported_evaluations,
                                                   const RelationParameters<FF>& relation_parameters,
                                                   const PowUnivariate<FF>& pow_univariate,
                                                   const FF alpha)
@@ -316,7 +316,7 @@ template <typename Flavor, template <class> class... Relations> class SumcheckRo
      */
     template <size_t relation_idx = 0>
     // TODO(#224)(Cody): Input should be an array?
-    void accumulate_relation_evaluations(PurportedEvaluations purported_evaluations,
+    void accumulate_relation_evaluations(ClaimedEvaluations purported_evaluations,
                                          const RelationParameters<FF>& relation_parameters)
     {
         std::get<relation_idx>(relations).add_full_relation_value_contribution(

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
@@ -1,7 +1,4 @@
 #include "sumcheck_round.hpp"
-#include "relations/arithmetic_relation.hpp"
-#include "relations/grand_product_computation_relation.hpp"
-#include "relations/grand_product_initialization_relation.hpp"
 #include "polynomials/univariate.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
@@ -80,12 +77,9 @@ static Univariate<FF, max_relation_length> compute_round_univariate(
     const FF alpha)
 {
     size_t round_size = 1;
-    auto relations = std::tuple(
-        ArithmeticRelation<FF>(), GrandProductComputationRelation<FF>(), GrandProductInitializationRelation<FF>());
+
     // Improvement(Cody): This is ugly? Maye supply some/all of this data through "flavor" class?
-    auto round =
-        SumcheckRound<Flavor, ArithmeticRelation, GrandProductComputationRelation, GrandProductInitializationRelation>(
-            round_size, relations);
+    auto round = SumcheckRound<Flavor>(round_size);
     auto w_l = input_polynomials[0];
     auto w_r = input_polynomials[1];
     auto w_o = input_polynomials[2];
@@ -206,11 +200,8 @@ static FF compute_full_purported_value(std::array<FF, NUM_POLYNOMIALS>& input_va
     purported_evaluations.id_3 = input_values[15];
     purported_evaluations.lagrange_first = input_values[16];
     purported_evaluations.lagrange_last = input_values[17];
-    auto relations = std::tuple(
-        ArithmeticRelation<FF>(), GrandProductComputationRelation<FF>(), GrandProductInitializationRelation<FF>());
-    auto round =
-        SumcheckRound<Flavor, ArithmeticRelation, GrandProductComputationRelation, GrandProductInitializationRelation>(
-            relations);
+
+    auto round = SumcheckRound<Flavor>();
     PowUnivariate<FF> pow_univariate(1);
     FF full_purported_value = round.compute_full_honk_relation_purported_value(
         purported_evaluations, relation_parameters, pow_univariate, alpha);

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
@@ -25,7 +25,7 @@ using namespace proof_system::honk::sumcheck;
 using Flavor = flavor::Standard;
 using FF = typename Flavor::FF;
 using ProverPolynomials = typename Flavor::ProverPolynomials;
-using PurportedEvaluations = typename Flavor::PurportedEvaluations;
+using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
 const size_t NUM_POLYNOMIALS = Flavor::NUM_ALL_ENTITIES;
 const size_t max_relation_length = 5;
@@ -187,7 +187,7 @@ static FF compute_full_purported_value(std::array<FF, NUM_POLYNOMIALS>& input_va
                                        const RelationParameters<FF>& relation_parameters,
                                        const FF alpha)
 {
-    PurportedEvaluations purported_evaluations;
+    ClaimedEvaluations purported_evaluations;
     purported_evaluations.w_l = input_values[0];
     purported_evaluations.w_r = input_values[1];
     purported_evaluations.w_o = input_values[2];

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -224,14 +224,14 @@ template <typename Tuple, std::size_t Index = 0> static constexpr size_t get_max
     if constexpr (Index >= std::tuple_size<Tuple>::value) {
         return 0; // Return 0 when reach end of the tuple
     } else {
-        constexpr size_t currentLength = std::tuple_element<Index, Tuple>::type::RELATION_LENGTH;
-        constexpr size_t nextLength = get_max_relation_length<Tuple, Index + 1>();
-        return (currentLength > nextLength) ? currentLength : nextLength;
+        constexpr size_t current_length = std::tuple_element<Index, Tuple>::type::RELATION_LENGTH;
+        constexpr size_t next_length = get_max_relation_length<Tuple, Index + 1>();
+        return (current_length > next_length) ? current_length : next_length;
     }
 }
 
 /**
- * @brief Recursive utility function to construct tuple of Univariates of length RELATION_LENGTH...
+ * @brief Recursive utility function to construct tuple of Univariates of length RELATION_LENGTH
  *
  */
 template <class FF, typename Tuple, std::size_t Index = 0> static constexpr auto create_univariate_tuple()
@@ -254,8 +254,8 @@ static constexpr auto create_barycentric_utils()
     if constexpr (Index >= std::tuple_size<Tuple>::value) {
         return std::tuple<>{}; // Return empty when reach end of the tuple
     } else {
-        constexpr size_t relationLength = std::tuple_element_t<Index, Tuple>::RELATION_LENGTH;
-        using BarycentricType = sumcheck::BarycentricData<FF, relationLength, ExtendedLength>;
+        constexpr size_t relation_length = std::tuple_element_t<Index, Tuple>::RELATION_LENGTH;
+        using BarycentricType = sumcheck::BarycentricData<FF, relation_length, ExtendedLength>;
         return std::tuple_cat(std::tuple<BarycentricType>{},
                               create_barycentric_utils<FF, Tuple, ExtendedLength, Index + 1>());
     }

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -67,9 +67,11 @@
 #include <array>
 #include <concepts>
 #include <vector>
+#include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
 #include "barretenberg/srs/reference_string/reference_string.hpp"
 #include "barretenberg/polynomials/evaluation_domain.hpp"
 #include "barretenberg/proof_system/types/composer_type.hpp"
+#include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 
 namespace proof_system::honk::flavor {
 
@@ -212,6 +214,52 @@ class AllEntities_ : public Entities_<DataType, DataType, NUM_ALL_ENTITIES> {
         return result;
     };
 };
+
+/**
+ * @brief Recursive utility function to find max RELATION_LENGTH over tuple of Relations
+ *
+ */
+template <typename Tuple, std::size_t Index = 0> static constexpr size_t get_max_relation_length()
+{
+    if constexpr (Index >= std::tuple_size<Tuple>::value) {
+        return 0; // Return 0 when reach end of the tuple
+    } else {
+        constexpr size_t currentLength = std::tuple_element<Index, Tuple>::type::RELATION_LENGTH;
+        constexpr size_t nextLength = get_max_relation_length<Tuple, Index + 1>();
+        return (currentLength > nextLength) ? currentLength : nextLength;
+    }
+}
+
+/**
+ * @brief Recursive utility function to construct tuple of Univariates of length RELATION_LENGTH...
+ *
+ */
+template <class FF, typename Tuple, std::size_t Index = 0> static constexpr auto create_univariate_tuple()
+{
+    if constexpr (Index >= std::tuple_size<Tuple>::value) {
+        return std::tuple<>{}; // Return empty when reach end of the tuple
+    } else {
+        using UnivariateType = sumcheck::Univariate<FF, std::tuple_element_t<Index, Tuple>::RELATION_LENGTH>;
+        return std::tuple_cat(std::tuple<UnivariateType>{}, create_univariate_tuple<FF, Tuple, Index + 1>());
+    }
+}
+
+/**
+ * @brief Recursive helper function to construct BarycentricData to extend each Relation in a tuple
+ *
+ */
+template <class FF, typename Tuple, size_t ExtendedLength, std::size_t Index = 0>
+static constexpr auto create_barycentric_utils()
+{
+    if constexpr (Index >= std::tuple_size<Tuple>::value) {
+        return std::tuple<>{}; // Return empty when reach end of the tuple
+    } else {
+        constexpr size_t relationLength = std::tuple_element_t<Index, Tuple>::RELATION_LENGTH;
+        using BarycentricType = sumcheck::BarycentricData<FF, relationLength, ExtendedLength>;
+        return std::tuple_cat(std::tuple<BarycentricType>{},
+                              create_barycentric_utils<FF, Tuple, ExtendedLength, Index + 1>());
+    }
+}
 
 } // namespace proof_system::honk::flavor
 

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -57,7 +57,6 @@
  * empty slots. This is a conscious choice to limit complexity. Note that there is very little memory cost here since
  * the DataType size in that case is small.
  *
- * @todo TODO(#394): Folded polynomials should use polynomial class.
  * @todo TODO(#395): Getters should return arrays?
  * @todo TODO(#396): Access specifiers?
  * @todo TODO(#397): Use more handle types?


### PR DESCRIPTION
This PR addresses a few TODOs/issues related to Sumcheck
- #390 Move specification of Relations into Flavor
- #224 Make `BarycentricData` member arrays `static constexpr` (Issue is broader so is not closed with this PR)
- #394 Change the underlying storage of `partially_evaluated_polynomials` from vector to Polynomial to take advantage of built in memory alignment
- #458: Rename Sumcheck `fold` to `partially_evaluate` and `folded_polynomials` to `partially_evaluated_polynomials`

# Description

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
