### PR TITLE
fix: msgpack header mistake

### DIFF
--- a/cpp/src/msgpack-c/include/msgpack/assert.hpp
+++ b/cpp/src/msgpack-c/include/msgpack/assert.hpp
@@ -16,7 +16,7 @@
 #include <cassert>
 #define MSGPACK_ASSERT assert
 
-#else  // defined(MSGPACK_NO_BOOST)
+#else // defined(MSGPACK_NO_BOOST)
 
 #include <boost/assert.hpp>
 #define MSGPACK_ASSERT BOOST_ASSERT
@@ -25,15 +25,16 @@
 
 #ifdef __wasm__
 struct AbortStream {
-    void operator<< [[noreturn]] (const auto& error) {
-        info(error.what());
+    void operator<< [[noreturn]] (const auto& error)
+    {
+        (void)error; // TODO how to print this?
         std::abort();
     }
 };
 #define THROW AbortStream() <<
 #define try if (true)
 #define catch(...) if (false)
-#define RETHROW 
+#define RETHROW
 #else
 #define THROW throw
 #define RETHROW THROW


### PR DESCRIPTION
# Description
Fixes breakage in ecc test
# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
