### PR TITLE
Add missing `hash_index` while compressing vk.

### DIFF
--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -339,7 +339,8 @@ template <typename Curve> struct verification_key {
         return compressed_key;
     }
 
-    static barretenberg::fr compress_native(const std::shared_ptr<plonk::verification_key>& key, const size_t = 0)
+    static barretenberg::fr compress_native(const std::shared_ptr<plonk::verification_key>& key,
+                                            const size_t hash_index = 0)
     {
         std::vector<uint8_t> preimage_data;
 
@@ -365,10 +366,10 @@ template <typename Curve> struct verification_key {
 
         barretenberg::fr compressed_key;
         if constexpr (Composer::type == ComposerType::PLOOKUP) {
-            compressed_key =
-                from_buffer<barretenberg::fr>(crypto::pedersen_commitment::lookup::compress_native(preimage_data));
+            compressed_key = from_buffer<barretenberg::fr>(
+                crypto::pedersen_commitment::lookup::compress_native(preimage_data, hash_index));
         } else {
-            compressed_key = crypto::pedersen_commitment::compress_native(preimage_data);
+            compressed_key = crypto::pedersen_commitment::compress_native(preimage_data, hash_index);
         }
         return compressed_key;
     }

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
@@ -63,10 +63,10 @@ TYPED_TEST(VerificationKeyFixture, vk_data_vs_recursion_compress_native)
     auto recurs_vk = RecursVk::from_witness(&composer, native_vk);
 
     EXPECT_EQ(vk_data.compress_native(0), RecursVk::compress_native(native_vk, 0));
-    EXPECT_EQ(vk_data.compress_native(15), RecursVk::compress_native(native_vk, 15));
-    // ne hash indeces still lead to ne compressions
-    EXPECT_NE(vk_data.compress_native(0), RecursVk::compress_native(native_vk, 15));
-    EXPECT_NE(vk_data.compress_native(14), RecursVk::compress_native(native_vk, 15));
+    // EXPECT_EQ(vk_data.compress_native(15), RecursVk::compress_native(native_vk, 15));
+    // // ne hash indeces still lead to ne compressions
+    // EXPECT_NE(vk_data.compress_native(0), RecursVk::compress_native(native_vk, 15));
+    // EXPECT_NE(vk_data.compress_native(14), RecursVk::compress_native(native_vk, 15));
 }
 
 TYPED_TEST(VerificationKeyFixture, compress_vs_compress_native)
@@ -83,8 +83,8 @@ TYPED_TEST(VerificationKeyFixture, compress_vs_compress_native)
     auto recurs_vk = RecursVk::from_witness(&composer, native_vk);
 
     EXPECT_EQ(recurs_vk->compress(0).get_value(), RecursVk::compress_native(native_vk, 0));
-    EXPECT_EQ(recurs_vk->compress(15).get_value(), RecursVk::compress_native(native_vk, 15));
-    // ne hash indeces still lead to ne compressions
-    EXPECT_NE(recurs_vk->compress(0).get_value(), RecursVk::compress_native(native_vk, 15));
-    EXPECT_NE(recurs_vk->compress(14).get_value(), RecursVk::compress_native(native_vk, 15));
+    // EXPECT_EQ(recurs_vk->compress(15).get_value(), RecursVk::compress_native(native_vk, 15));
+    // // ne hash indeces still lead to ne compressions
+    // EXPECT_NE(recurs_vk->compress(0).get_value(), RecursVk::compress_native(native_vk, 15));
+    // EXPECT_NE(recurs_vk->compress(14).get_value(), RecursVk::compress_native(native_vk, 15));
 }

--- a/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
+++ b/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
@@ -63,10 +63,10 @@ TYPED_TEST(VerificationKeyFixture, vk_data_vs_recursion_compress_native)
     auto recurs_vk = RecursVk::from_witness(&composer, native_vk);
 
     EXPECT_EQ(vk_data.compress_native(0), RecursVk::compress_native(native_vk, 0));
-    // EXPECT_EQ(vk_data.compress_native(15), RecursVk::compress_native(native_vk, 15));
+    EXPECT_EQ(vk_data.compress_native(15), RecursVk::compress_native(native_vk, 15));
     // ne hash indeces still lead to ne compressions
-    // EXPECT_NE(vk_data.compress_native(0), RecursVk::compress_native(native_vk, 15));
-    // EXPECT_NE(vk_data.compress_native(14), RecursVk::compress_native(native_vk, 15));
+    EXPECT_NE(vk_data.compress_native(0), RecursVk::compress_native(native_vk, 15));
+    EXPECT_NE(vk_data.compress_native(14), RecursVk::compress_native(native_vk, 15));
 }
 
 TYPED_TEST(VerificationKeyFixture, compress_vs_compress_native)
@@ -83,8 +83,8 @@ TYPED_TEST(VerificationKeyFixture, compress_vs_compress_native)
     auto recurs_vk = RecursVk::from_witness(&composer, native_vk);
 
     EXPECT_EQ(recurs_vk->compress(0).get_value(), RecursVk::compress_native(native_vk, 0));
-    // EXPECT_EQ(recurs_vk->compress(15).get_value(), RecursVk::compress_native(native_vk, 15));
+    EXPECT_EQ(recurs_vk->compress(15).get_value(), RecursVk::compress_native(native_vk, 15));
     // ne hash indeces still lead to ne compressions
-    // EXPECT_NE(recurs_vk->compress(0).get_value(), RecursVk::compress_native(native_vk, 15));
-    // EXPECT_NE(recurs_vk->compress(14).get_value(), RecursVk::compress_native(native_vk, 15));
+    EXPECT_NE(recurs_vk->compress(0).get_value(), RecursVk::compress_native(native_vk, 15));
+    EXPECT_NE(recurs_vk->compress(14).get_value(), RecursVk::compress_native(native_vk, 15));
 }


### PR DESCRIPTION
# Description

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
