### PR TITLE
fix: bbmalloc linker error

### DIFF
--- a/cpp/src/barretenberg/env/crs.cpp
+++ b/cpp/src/barretenberg/env/crs.cpp
@@ -7,13 +7,13 @@
 
 const int NUM_POINTS_IN_TRANSCRIPT = 5040001;
 
-
 extern "C" {
 /**
  * @brief In WASM, loads the verifier reference string.
  * Used in native code to quickly create an in-memory reference string.
  */
-uint8_t* env_load_verifier_crs() {
+uint8_t* env_load_verifier_crs()
+{
     std::ifstream transcript;
     transcript.open("../srs_db/ignition/monomial/transcript00.dat", std::ifstream::binary);
     // We need two g2 points, each 64 bytes.
@@ -22,7 +22,7 @@ uint8_t* env_load_verifier_crs() {
     transcript.seekg(28 + NUM_POINTS_IN_TRANSCRIPT * 64);
     transcript.read((char*)g2_points.data(), (std::streamsize)g2_points_size);
     transcript.close();
-    auto* g2_points_copy = (uint8_t*)bbmalloc(g2_points_size);
+    auto* g2_points_copy = (uint8_t*)aligned_alloc(64, g2_points_size);
     memcpy(g2_points_copy, g2_points.data(), g2_points_size);
     return g2_points_copy;
 }
@@ -33,20 +33,20 @@ uint8_t* env_load_verifier_crs() {
  * In native code, not intended to be used.
  * @param num_points The number of points to load.
  */
-uint8_t* env_load_prover_crs(size_t num_points) {
+uint8_t* env_load_prover_crs(size_t num_points)
+{
     // Note: This implementation is only meant to be instructive.
     // This should only be used in c-binds to implement the C++ abstractions.
     std::ifstream transcript;
     transcript.open("../srs_db/ignition/monomial/transcript00.dat", std::ifstream::binary);
     // Each g1 point is 64 bytes.
-    size_t g1_points_size = (num_points) * 64;
+    size_t g1_points_size = (num_points)*64;
     std::vector<uint8_t> g1_points(g1_points_size);
     transcript.seekg(28);
     transcript.read((char*)g1_points.data(), (std::streamsize)g1_points_size);
     transcript.close();
-    auto* g1_points_copy = (uint8_t*)bbmalloc(g1_points_size);
+    auto* g1_points_copy = (uint8_t*)aligned_alloc(64, g1_points_size);
     memcpy(g1_points_copy, g1_points.data(), g1_points_size);
     return g1_points_copy;
 }
-
 }


### PR DESCRIPTION
# Description

When building locally, a bbmalloc linker error comes up from load_verifier_crs. This removes the dependency as a workaround

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
