### PR TITLE
Adam/fix allow explicit field init

### DIFF
--- a/cpp/src/barretenberg/ecc/fields/field.hpp
+++ b/cpp/src/barretenberg/ecc/fields/field.hpp
@@ -24,12 +24,16 @@
 namespace barretenberg {
 template <class Params> struct alignas(32) field {
   public:
-    // We don't initialize data by default since we'd lose a lot of time on pointless initializations.
+    // We don't initialize data in the default constructor since we'd lose a lot of time on huge array initializations.
     // Other alternatives have been noted, such as casting to get around constructors where they matter,
     // however it is felt that sanitizer tools (e.g. MSAN) can detect garbage well, whereas doing
     // hacky casts where needed would require rework to critical algos like MSM, FFT, Sumcheck.
-    // Instead, the recommended solution is use an explicit = 0 where initialization is important.
-    field() noexcept {}
+    // Instead, the recommended solution is use an explicit {} where initialization is important:
+    //  field f; // not initialized
+    //  field f{}; // zero-initialized
+    //  std::array<field, N> arr; // not initialized, good for huge N
+    //  std::array<field, N> arr {}; // zero-initialized, preferable for moderate N
+    field() = default;
 
     constexpr field(const uint256_t& input) noexcept
         : data{ input.data[0], input.data[1], input.data[2], input.data[3] }

--- a/cpp/src/msgpack-c/include/msgpack/assert.hpp
+++ b/cpp/src/msgpack-c/include/msgpack/assert.hpp
@@ -16,7 +16,7 @@
 #include <cassert>
 #define MSGPACK_ASSERT assert
 
-#else  // defined(MSGPACK_NO_BOOST)
+#else // defined(MSGPACK_NO_BOOST)
 
 #include <boost/assert.hpp>
 #define MSGPACK_ASSERT BOOST_ASSERT
@@ -25,15 +25,16 @@
 
 #ifdef __wasm__
 struct AbortStream {
-    void operator<< [[noreturn]] (const auto& error) {
-        info(error.what());
+    void operator<< [[noreturn]] (const auto& error)
+    {
+        (void)error; // TODO how to print this?
         std::abort();
     }
 };
 #define THROW AbortStream() <<
 #define try if (true)
 #define catch(...) if (false)
-#define RETHROW 
+#define RETHROW
 #else
 #define THROW throw
 #define RETHROW THROW


### PR DESCRIPTION
# Description

Allow explicit field initialization with {} syntax. Before, the empty body actively broke this syntax. The =default semantics match, as the name implies, the default for a C struct. We should not break defaults as C++11 ascribes them special meaning, see the comment for what this enables

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
