### PR TITLE
fix: msgpack variant_impl.hpp

### DIFF
--- a/cpp/src/barretenberg/serialize/msgpack_impl/variant_impl.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/variant_impl.hpp
@@ -9,7 +9,7 @@ namespace msgpack::adaptor {
 template<typename... T>
 struct pack<std::variant< T...>> {
     auto &operator()(auto& o, std::variant<T...> const &variant) const {
-        std::visit([&o](auto &&arg) { msgpack::pack(o, arg); }, variant);
+        std::visit([&o](const auto& arg) { o.pack(arg); }, variant);
         return o;
     }
 };


### PR DESCRIPTION
Previous version accidentally created a packer<packer< Stream >>>

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
