### PR TITLE
chore: Format msgpack serialization in bberg 

### DIFF
--- a/cpp/src/barretenberg/common/fuzzer.hpp
+++ b/cpp/src/barretenberg/common/fuzzer.hpp
@@ -84,80 +84,83 @@ class FastRandom {
  *
  * @tparam T
  */
-template <typename T>
-concept SimpleRng = requires(T a) {
-                        {
-                            a.next()
-                            } -> std::convertible_to<uint32_t>;
-                    };
+template <typename T> concept SimpleRng = requires(T a)
+{
+    {
+        a.next()
+    }
+    ->std::convertible_to<uint32_t>;
+};
 /**
  * @brief Concept for forcing ArgumentSizes to be size_t
  *
  * @tparam T
  */
-template <typename T>
-concept InstructionArgumentSizes = requires {
-                                       {
-                                           std::make_tuple(T::CONSTANT,
-                                                           T::WITNESS,
-                                                           T::CONSTANT_WITNESS,
-                                                           T::ADD,
-                                                           T::SUBTRACT,
-                                                           T::MULTIPLY,
-                                                           T::DIVIDE,
-                                                           T::ADD_TWO,
-                                                           T::MADD,
-                                                           T::MULT_MADD,
-                                                           T::MSUB_DIV,
-                                                           T::SQR,
-                                                           T::SQR_ADD,
-                                                           T::SUBTRACT_WITH_CONSTRAINT,
-                                                           T::DIVIDE_WITH_CONSTRAINTS,
-                                                           T::SLICE,
-                                                           T::ASSERT_ZERO,
-                                                           T::ASSERT_NOT_ZERO)
-                                           } -> std::same_as<std::tuple<size_t>>;
-                                   };
+template <typename T> concept InstructionArgumentSizes = requires
+{
+    {
+        std::make_tuple(T::CONSTANT,
+                        T::WITNESS,
+                        T::CONSTANT_WITNESS,
+                        T::ADD,
+                        T::SUBTRACT,
+                        T::MULTIPLY,
+                        T::DIVIDE,
+                        T::ADD_TWO,
+                        T::MADD,
+                        T::MULT_MADD,
+                        T::MSUB_DIV,
+                        T::SQR,
+                        T::SQR_ADD,
+                        T::SUBTRACT_WITH_CONSTRAINT,
+                        T::DIVIDE_WITH_CONSTRAINTS,
+                        T::SLICE,
+                        T::ASSERT_ZERO,
+                        T::ASSERT_NOT_ZERO)
+    }
+    ->std::same_as<std::tuple<size_t>>;
+};
 
 /**
  * @brief Concept for Havoc Configurations
  *
  * @tparam T
  */
-template <typename T>
-concept HavocConfigConstraint =
-    requires {
-        {
-            std::make_tuple(T::GEN_MUTATION_COUNT_LOG, T::GEN_STRUCTURAL_MUTATION_PROBABILITY)
-            } -> std::same_as<std::tuple<size_t>>;
-        T::GEN_MUTATION_COUNT_LOG <= 7;
-    };
+template <typename T> concept HavocConfigConstraint = requires
+{
+    {
+        std::make_tuple(T::GEN_MUTATION_COUNT_LOG, T::GEN_STRUCTURAL_MUTATION_PROBABILITY)
+    }
+    ->std::same_as<std::tuple<size_t>>;
+    T::GEN_MUTATION_COUNT_LOG <= 7;
+};
 /**
  * @brief Concept specifying the class used by the fuzzer
  *
  * @tparam T
  */
-template <typename T>
-concept ArithmeticFuzzHelperConstraint = requires {
-                                             typename T::ArgSizes;
-                                             typename T::Instruction;
-                                             typename T::ExecutionState;
-                                             typename T::ExecutionHandler;
-                                             InstructionArgumentSizes<typename T::ArgSizes>;
-                                             // HavocConfigConstraint<typename T::HavocConfig>;
-                                         };
+template <typename T> concept ArithmeticFuzzHelperConstraint = requires
+{
+    typename T::ArgSizes;
+    typename T::Instruction;
+    typename T::ExecutionState;
+    typename T::ExecutionHandler;
+    InstructionArgumentSizes<typename T::ArgSizes>;
+    // HavocConfigConstraint<typename T::HavocConfig>;
+};
 
 /**
  * @brief Fuzzer uses only composers with check_circuit function
  *
  * @tparam T
  */
-template <typename T>
-concept CheckableComposer = requires(T a) {
-                                {
-                                    a.check_circuit()
-                                    } -> std::same_as<bool>;
-                            };
+template <typename T> concept CheckableComposer = requires(T a)
+{
+    {
+        a.check_circuit()
+    }
+    ->std::same_as<bool>;
+};
 
 /**
  * @brief The fuzzer can use a postprocessing function that is specific to the type being fuzzed
@@ -167,11 +170,13 @@ concept CheckableComposer = requires(T a) {
  * @tparam Context The class containing the full context
  */
 template <typename T, typename Composer, typename Context>
-concept PostProcessingEnabled = requires(Composer composer, Context context) {
-                                    {
-                                        T::postProcess(&composer, context)
-                                        } -> std::same_as<bool>;
-                                };
+concept PostProcessingEnabled = requires(Composer composer, Context context)
+{
+    {
+        T::postProcess(&composer, context)
+    }
+    ->std::same_as<bool>;
+};
 
 /**
  * @brief This concept is used when we want to limit the number of executions of certain instructions (for example,
@@ -179,19 +184,17 @@ concept PostProcessingEnabled = requires(Composer composer, Context context) {
  *
  * @tparam T
  */
-template <typename T>
-concept InstructionWeightsEnabled = requires {
-                                        typename T::InstructionWeights;
-                                        T::InstructionWeights::_LIMIT;
-                                    };
+template <typename T> concept InstructionWeightsEnabled = requires
+{
+    typename T::InstructionWeights;
+    T::InstructionWeights::_LIMIT;
+};
 /**
  * @brief A templated class containing most of the fuzzing logic for a generic Arithmetic class
  *
  * @tparam T
  */
-template <typename T>
-    requires ArithmeticFuzzHelperConstraint<T>
-class ArithmeticFuzzHelper {
+template <typename T> requires ArithmeticFuzzHelperConstraint<T> class ArithmeticFuzzHelper {
   private:
     /**
      * @brief Mutator swapping two instructions together
@@ -494,8 +497,8 @@ class ArithmeticFuzzHelper {
      * @param instructions
      */
     template <typename Composer>
-    inline static void executeInstructions(std::vector<typename T::Instruction>& instructions)
-        requires CheckableComposer<Composer>
+    inline static void executeInstructions(
+        std::vector<typename T::Instruction>& instructions) requires CheckableComposer<Composer>
     {
         typename T::ExecutionState state;
         Composer composer = Composer();

--- a/cpp/src/barretenberg/common/log.hpp
+++ b/cpp/src/barretenberg/common/log.hpp
@@ -10,11 +10,13 @@
 #define BENCHMARK_INFO_SUFFIX "##BENCHMARK_INFO_SUFFIX##"
 
 #define GET_COMPOSER_NAME_STRING(composer)                                                                             \
-    (typeid(composer) == typeid(plonk::StandardComposer)      ? "StandardPlonk"                                        \
-     : typeid(composer) == typeid(plonk::TurboComposer)       ? "TurboPlonk"                                           \
-     : typeid(composer) == typeid(plonk::UltraComposer)       ? "UltraPlonk"                                           \
-     : typeid(composer) == typeid(honk::StandardHonkComposer) ? "StandardHonk"                                         \
-                                                              : "NULLPlonk")
+    (typeid(composer) == typeid(plonk::StandardComposer)                                                               \
+         ? "StandardPlonk"                                                                                             \
+         : typeid(composer) == typeid(plonk::TurboComposer)                                                            \
+               ? "TurboPlonk"                                                                                          \
+               : typeid(composer) == typeid(plonk::UltraComposer)                                                      \
+                     ? "UltraPlonk"                                                                                    \
+                     : typeid(composer) == typeid(honk::StandardHonkComposer) ? "StandardHonk" : "NULLPlonk")
 
 namespace {
 

--- a/cpp/src/barretenberg/crypto/hmac/hmac.hpp
+++ b/cpp/src/barretenberg/crypto/hmac/hmac.hpp
@@ -93,8 +93,8 @@ std::array<uint8_t, Hash::OUTPUT_SIZE> hmac(const MessageContainer& message, con
  * @return Fr output field element as uint512_t( H(10...0 || HMAC(k,m)) || H(00...0 || HMAC(k,m)) ) % r
  */
 template <typename Hash, typename Fr, typename MessageContainer, typename KeyContainer>
-Fr get_unbiased_field_from_hmac(const MessageContainer& message, const KeyContainer& key)
-    requires(Hash::OUTPUT_SIZE == 32)
+Fr get_unbiased_field_from_hmac(const MessageContainer& message,
+                                const KeyContainer& key) requires(Hash::OUTPUT_SIZE == 32)
 {
     // Strong assumption that works for now with our suite of Hashers
     static_assert(Hash::BLOCK_SIZE > Hash::OUTPUT_SIZE);

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -7,7 +7,7 @@
 #include "ecdsa_secp256k1.hpp"
 TEST(acir_format, msgpack_logic_constraint)
 {
-    auto [actual, expected] = msgpack_roundtrip(acir_format::LogicConstraint {});
+    auto [actual, expected] = msgpack_roundtrip(acir_format::LogicConstraint{});
     EXPECT_EQ(actual, expected);
 }
 TEST(acir_format, test_logic_gate_from_noir_circuit)

--- a/cpp/src/barretenberg/ecc/curves/bn254/fq.test.cpp
+++ b/cpp/src/barretenberg/ecc/curves/bn254/fq.test.cpp
@@ -7,7 +7,7 @@ using namespace barretenberg;
 
 TEST(fq, msgpack)
 {
-    auto [actual, expected] = msgpack_roundtrip(barretenberg::fq{1ull, 2ull, 3ull, 4ull});
+    auto [actual, expected] = msgpack_roundtrip(barretenberg::fq{ 1ull, 2ull, 3ull, 4ull });
     EXPECT_EQ(actual, expected);
 }
 

--- a/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
+++ b/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
@@ -6,7 +6,7 @@ using namespace barretenberg;
 
 TEST(fr, msgpack)
 {
-    auto [actual, expected] = msgpack_roundtrip(barretenberg::fr{1ull, 2ull, 3ull, 4ull});
+    auto [actual, expected] = msgpack_roundtrip(barretenberg::fr{ 1ull, 2ull, 3ull, 4ull });
     EXPECT_EQ(actual, expected);
 }
 

--- a/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -606,16 +606,16 @@ template <class T> constexpr field<T> field<T>::multiplicative_generator() noexc
     return target;
 }
 
-// This function is used to serialize a field. It matches the old serialization format by first 
-// converting the field from Montgomery form, which is a special representation used for efficient 
+// This function is used to serialize a field. It matches the old serialization format by first
+// converting the field from Montgomery form, which is a special representation used for efficient
 // modular arithmetic.
 template <class Params> void field<Params>::msgpack_pack(auto& packer) const
 {
     // The field is first converted from Montgomery form, similar to how the old format did it.
     auto adjusted = from_montgomery_form();
 
-    // The data is then converted to big endian format using htonll, which stands for "host to network long long". 
-    // This is necessary because the data will be written to a raw msgpack buffer, which requires big endian format. 
+    // The data is then converted to big endian format using htonll, which stands for "host to network long long".
+    // This is necessary because the data will be written to a raw msgpack buffer, which requires big endian format.
     uint64_t bin_data[4] = {
         htonll(adjusted.data[3]), htonll(adjusted.data[2]), htonll(adjusted.data[1]), htonll(adjusted.data[0])
     };
@@ -625,22 +625,22 @@ template <class Params> void field<Params>::msgpack_pack(auto& packer) const
     packer.pack_bin_body((const char*)bin_data, sizeof(bin_data));
 }
 
-// This function is used to deserialize a field. It also matches the old deserialization format by 
-// reading the binary data as big endian uint64_t's, correcting them to the host endianness, and 
-// then converting the field back to Montgomery form. 
+// This function is used to deserialize a field. It also matches the old deserialization format by
+// reading the binary data as big endian uint64_t's, correcting them to the host endianness, and
+// then converting the field back to Montgomery form.
 template <class Params> void field<Params>::msgpack_unpack(auto o)
 {
     // The binary data is first extracted from the msgpack object.
     std::array<uint8_t, sizeof(data)> raw_data = o;
 
-    // The binary data is then read as big endian uint64_t's. This is done by casting the raw data to uint64_t* and then 
+    // The binary data is then read as big endian uint64_t's. This is done by casting the raw data to uint64_t* and then
     // using ntohll ("network to host long long") to correct the endianness to the host's endianness.
     uint64_t* cast_data = (uint64_t*)&raw_data[0];
-    uint64_t reversed[] = {ntohll(cast_data[3]), ntohll(cast_data[2]), ntohll(cast_data[1]), ntohll(cast_data[0])};
+    uint64_t reversed[] = { ntohll(cast_data[3]), ntohll(cast_data[2]), ntohll(cast_data[1]), ntohll(cast_data[0]) };
 
     // The corrected data is then copied back into the field's data array.
     for (int i = 0; i < 4; i++) {
-        data[i] = reversed[i];  
+        data[i] = reversed[i];
     }
 
     // Finally, the field is converted back to Montgomery form, just like in the old format.

--- a/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
+++ b/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
@@ -87,12 +87,12 @@ template <class T> field<T> field<T>::asm_mul_with_coarse_reduction(const field&
             : "%r"(&a),
               "%r"(&b),
               "r"(&r),
-              [modulus_0] "m"(modulus_0),
-              [modulus_1] "m"(modulus_1),
-              [modulus_2] "m"(modulus_2),
-              [modulus_3] "m"(modulus_3),
-              [r_inv] "m"(r_inv),
-              [zero_reference] "m"(zero_ref)
+              [ modulus_0 ] "m"(modulus_0),
+              [ modulus_1 ] "m"(modulus_1),
+              [ modulus_2 ] "m"(modulus_2),
+              [ modulus_3 ] "m"(modulus_3),
+              [ r_inv ] "m"(r_inv),
+              [ zero_reference ] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -119,12 +119,12 @@ template <class T> void field<T>::asm_self_mul_with_coarse_reduction(const field
             :
             : "r"(&a),
               "r"(&b),
-              [modulus_0] "m"(modulus_0),
-              [modulus_1] "m"(modulus_1),
-              [modulus_2] "m"(modulus_2),
-              [modulus_3] "m"(modulus_3),
-              [r_inv] "m"(r_inv),
-              [zero_reference] "m"(zero_ref)
+              [ modulus_0 ] "m"(modulus_0),
+              [ modulus_1 ] "m"(modulus_1),
+              [ modulus_2 ] "m"(modulus_2),
+              [ modulus_3 ] "m"(modulus_3),
+              [ r_inv ] "m"(r_inv),
+              [ zero_reference ] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -157,12 +157,12 @@ template <class T> field<T> field<T>::asm_sqr_with_coarse_reduction(const field&
             : "%r"(&a),
               "%r"(&a),
               "r"(&r),
-              [modulus_0] "m"(modulus_0),
-              [modulus_1] "m"(modulus_1),
-              [modulus_2] "m"(modulus_2),
-              [modulus_3] "m"(modulus_3),
-              [r_inv] "m"(r_inv),
-              [zero_reference] "m"(zero_ref)
+              [ modulus_0 ] "m"(modulus_0),
+              [ modulus_1 ] "m"(modulus_1),
+              [ modulus_2 ] "m"(modulus_2),
+              [ modulus_3 ] "m"(modulus_3),
+              [ r_inv ] "m"(r_inv),
+              [ zero_reference ] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 
 #else
@@ -181,12 +181,12 @@ template <class T> field<T> field<T>::asm_sqr_with_coarse_reduction(const field&
             :
             : "r"(&a),
               "r"(&r),
-              [zero_reference] "m"(zero_ref),
-              [modulus_0] "m"(modulus_0),
-              [modulus_1] "m"(modulus_1),
-              [modulus_2] "m"(modulus_2),
-              [modulus_3] "m"(modulus_3),
-              [r_inv] "m"(r_inv)
+              [ zero_reference ] "m"(zero_ref),
+              [ modulus_0 ] "m"(modulus_0),
+              [ modulus_1 ] "m"(modulus_1),
+              [ modulus_2 ] "m"(modulus_2),
+              [ modulus_3 ] "m"(modulus_3),
+              [ r_inv ] "m"(r_inv)
             : "%rcx", "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 #endif
     return r;
@@ -219,12 +219,12 @@ template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(const field
             :
             : "r"(&a),
               "r"(&a),
-              [modulus_0] "m"(modulus_0),
-              [modulus_1] "m"(modulus_1),
-              [modulus_2] "m"(modulus_2),
-              [modulus_3] "m"(modulus_3),
-              [r_inv] "m"(r_inv),
-              [zero_reference] "m"(zero_ref)
+              [ modulus_0 ] "m"(modulus_0),
+              [ modulus_1 ] "m"(modulus_1),
+              [ modulus_2 ] "m"(modulus_2),
+              [ modulus_3 ] "m"(modulus_3),
+              [ r_inv ] "m"(r_inv),
+              [ zero_reference ] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 
 #else
@@ -241,12 +241,12 @@ template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(const field
             STORE_FIELD_ELEMENT("%0", "%%r12", "%%r13", "%%r14", "%%r15")
             :
             : "r"(&a),
-              [zero_reference] "m"(zero_ref),
-              [modulus_0] "m"(modulus_0),
-              [modulus_1] "m"(modulus_1),
-              [modulus_2] "m"(modulus_2),
-              [modulus_3] "m"(modulus_3),
-              [r_inv] "m"(r_inv)
+              [ zero_reference ] "m"(zero_ref),
+              [ modulus_0 ] "m"(modulus_0),
+              [ modulus_1 ] "m"(modulus_1),
+              [ modulus_2 ] "m"(modulus_2),
+              [ modulus_3 ] "m"(modulus_3),
+              [ r_inv ] "m"(r_inv)
             : "%rcx", "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 #endif
 }
@@ -270,10 +270,10 @@ template <class T> field<T> field<T>::asm_add_with_coarse_reduction(const field&
             : "%r"(&a),
               "%r"(&b),
               "r"(&r),
-              [twice_not_modulus_0] "m"(twice_not_modulus_0),
-              [twice_not_modulus_1] "m"(twice_not_modulus_1),
-              [twice_not_modulus_2] "m"(twice_not_modulus_2),
-              [twice_not_modulus_3] "m"(twice_not_modulus_3)
+              [ twice_not_modulus_0 ] "m"(twice_not_modulus_0),
+              [ twice_not_modulus_1 ] "m"(twice_not_modulus_1),
+              [ twice_not_modulus_2 ] "m"(twice_not_modulus_2),
+              [ twice_not_modulus_3 ] "m"(twice_not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -294,10 +294,10 @@ template <class T> void field<T>::asm_self_add_with_coarse_reduction(const field
             :
             : "r"(&a),
               "r"(&b),
-              [twice_not_modulus_0] "m"(twice_not_modulus_0),
-              [twice_not_modulus_1] "m"(twice_not_modulus_1),
-              [twice_not_modulus_2] "m"(twice_not_modulus_2),
-              [twice_not_modulus_3] "m"(twice_not_modulus_3)
+              [ twice_not_modulus_0 ] "m"(twice_not_modulus_0),
+              [ twice_not_modulus_1 ] "m"(twice_not_modulus_1),
+              [ twice_not_modulus_2 ] "m"(twice_not_modulus_2),
+              [ twice_not_modulus_3 ] "m"(twice_not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -318,10 +318,10 @@ template <class T> field<T> field<T>::asm_sub_with_coarse_reduction(const field&
         : "r"(&a),
           "r"(&b),
           "r"(&r),
-          [twice_modulus_0] "m"(twice_modulus_0),
-          [twice_modulus_1] "m"(twice_modulus_1),
-          [twice_modulus_2] "m"(twice_modulus_2),
-          [twice_modulus_3] "m"(twice_modulus_3)
+          [ twice_modulus_0 ] "m"(twice_modulus_0),
+          [ twice_modulus_1 ] "m"(twice_modulus_1),
+          [ twice_modulus_2 ] "m"(twice_modulus_2),
+          [ twice_modulus_3 ] "m"(twice_modulus_3)
         : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -340,10 +340,10 @@ template <class T> void field<T>::asm_self_sub_with_coarse_reduction(const field
         :
         : "r"(&a),
           "r"(&b),
-          [twice_modulus_0] "m"(twice_modulus_0),
-          [twice_modulus_1] "m"(twice_modulus_1),
-          [twice_modulus_2] "m"(twice_modulus_2),
-          [twice_modulus_3] "m"(twice_modulus_3)
+          [ twice_modulus_0 ] "m"(twice_modulus_0),
+          [ twice_modulus_1 ] "m"(twice_modulus_1),
+          [ twice_modulus_2 ] "m"(twice_modulus_2),
+          [ twice_modulus_3 ] "m"(twice_modulus_3)
         : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -372,10 +372,10 @@ template <class T> void field<T>::asm_conditional_negate(field& r, const uint64_
             :
             : "r"(predicate),
               "r"(&r),
-              [twice_modulus_0] "i"(twice_modulus_0),
-              [twice_modulus_1] "i"(twice_modulus_1),
-              [twice_modulus_2] "i"(twice_modulus_2),
-              [twice_modulus_3] "i"(twice_modulus_3)
+              [ twice_modulus_0 ] "i"(twice_modulus_0),
+              [ twice_modulus_1 ] "i"(twice_modulus_1),
+              [ twice_modulus_2 ] "i"(twice_modulus_2),
+              [ twice_modulus_3 ] "i"(twice_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -394,10 +394,10 @@ template <class T> field<T> field<T>::asm_reduce_once(const field& a) noexcept
             :
             : "r"(&a),
               "r"(&r),
-              [not_modulus_0] "m"(not_modulus_0),
-              [not_modulus_1] "m"(not_modulus_1),
-              [not_modulus_2] "m"(not_modulus_2),
-              [not_modulus_3] "m"(not_modulus_3)
+              [ not_modulus_0 ] "m"(not_modulus_0),
+              [ not_modulus_1 ] "m"(not_modulus_1),
+              [ not_modulus_2 ] "m"(not_modulus_2),
+              [ not_modulus_3 ] "m"(not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -414,10 +414,10 @@ template <class T> void field<T>::asm_self_reduce_once(const field& a) noexcept
                     STORE_FIELD_ELEMENT("%0", "%%r12", "%%r13", "%%r14", "%%r15")
             :
             : "r"(&a),
-              [not_modulus_0] "m"(not_modulus_0),
-              [not_modulus_1] "m"(not_modulus_1),
-              [not_modulus_2] "m"(not_modulus_2),
-              [not_modulus_3] "m"(not_modulus_3)
+              [ not_modulus_0 ] "m"(not_modulus_0),
+              [ not_modulus_1 ] "m"(not_modulus_1),
+              [ not_modulus_2 ] "m"(not_modulus_2),
+              [ not_modulus_3 ] "m"(not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 } // namespace barretenberg

--- a/cpp/src/barretenberg/ecc/groups/group_impl_asm.tcc
+++ b/cpp/src/barretenberg/ecc/groups/group_impl_asm.tcc
@@ -98,10 +98,10 @@ inline void group<coordinate_field, subgroup_field, GroupParams>::conditional_ne
                              : "r"(src),
                                "r"(dest),
                                "r"(predicate),
-                               [modulus_0] "i"(twice_modulus_0),
-                               [modulus_1] "i"(twice_modulus_1),
-                               [modulus_2] "i"(twice_modulus_2),
-                               [modulus_3] "i"(twice_modulus_3)
+                               [ modulus_0 ] "i"(twice_modulus_0),
+                               [ modulus_1 ] "i"(twice_modulus_1),
+                               [ modulus_2 ] "i"(twice_modulus_2),
+                               [ modulus_3 ] "i"(twice_modulus_3)
                              : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "%ymm0", "memory", "cc");
 #else
         __asm__ __volatile__("xorq %%r8, %%r8                              \n\t"
@@ -138,10 +138,10 @@ inline void group<coordinate_field, subgroup_field, GroupParams>::conditional_ne
                              : "r"(src),
                                "r"(dest),
                                "r"(predicate),
-                               [modulus_0] "i"(twice_modulus_0),
-                               [modulus_1] "i"(twice_modulus_1),
-                               [modulus_2] "i"(twice_modulus_2),
-                               [modulus_3] "i"(twice_modulus_3)
+                               [ modulus_0 ] "i"(twice_modulus_0),
+                               [ modulus_1 ] "i"(twice_modulus_1),
+                               [ modulus_2 ] "i"(twice_modulus_2),
+                               [ modulus_3 ] "i"(twice_modulus_3)
                              : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "memory", "cc");
 #endif
     } else {

--- a/cpp/src/barretenberg/ecc/serialize.test.cpp
+++ b/cpp/src/barretenberg/ecc/serialize.test.cpp
@@ -4,6 +4,6 @@
 
 TEST(msgpack_tests, msgpack_field)
 {
-    auto [actual, expected] = msgpack_roundtrip(barretenberg::fr{1ull, 2ull, 3ull, 4ull});
+    auto [actual, expected] = msgpack_roundtrip(barretenberg::fr{ 1ull, 2ull, 3ull, 4ull });
     EXPECT_EQ(actual, expected);
 }

--- a/cpp/src/barretenberg/env/crs.hpp
+++ b/cpp/src/barretenberg/env/crs.hpp
@@ -2,9 +2,9 @@
 #include <stdint.h>
 
 // To be provided by the environment.
-// Outputs from a trusted setup "Common reference string" model: https://en.wikipedia.org/wiki/Common_reference_string_model
-// For a WASM build, this is provided by the JavaScript environment.
-// For a native build, this is provided in this module.
+// Outputs from a trusted setup "Common reference string" model:
+// https://en.wikipedia.org/wiki/Common_reference_string_model For a WASM build, this is provided by the JavaScript
+// environment. For a native build, this is provided in this module.
 
 /**
  * @brief In WASM, loads the verifier reference string.

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -15,8 +15,7 @@ namespace proof_system::honk {
 
 // We won't compile this class with honk::flavor::Ultra, but we will like want to compile it (at least for testing)
 // with a flavor that uses the curve Grumpkin, or a flavor that does/does not have zk, etc.
-template <typename T>
-concept StandardFlavor = IsAnyOf<T, honk::flavor::Standard>;
+template <typename T> concept StandardFlavor = IsAnyOf<T, honk::flavor::Standard>;
 
 template <StandardFlavor Flavor> class StandardProver_ {
 

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
@@ -13,8 +13,7 @@ namespace proof_system::honk {
 
 // We won't compile this class with honk::flavor::Standard, but we will like want to compile it (at least for testing)
 // with a flavor that uses the curve Grumpkin, or a flavor that does/does not have zk, etc.
-template <typename T>
-concept UltraFlavor = IsAnyOf<T, honk::flavor::Ultra>;
+template <typename T> concept UltraFlavor = IsAnyOf<T, honk::flavor::Ultra>;
 template <UltraFlavor Flavor> class UltraProver_ {
 
     using FF = typename Flavor::FF;

--- a/cpp/src/barretenberg/serialize/cbind.hpp
+++ b/cpp/src/barretenberg/serialize/cbind.hpp
@@ -47,12 +47,11 @@ template <typename T> constexpr auto param_tuple()
 
 // This function is intended to bind a function to a MessagePack-formatted input data,
 // perform the function with the unpacked data, then pack the result back into MessagePack format.
-inline void msgpack_cbind_impl(
-    auto func,                  // The function to be applied
-    const uint8_t* input_in,    // The input data in MessagePack format
-    size_t input_len_in,        // The length of the input data
-    uint8_t** output_out,       // The output data in MessagePack format
-    size_t* output_len_out)     // The length of the output data
+inline void msgpack_cbind_impl(auto func,               // The function to be applied
+                               const uint8_t* input_in, // The input data in MessagePack format
+                               size_t input_len_in,     // The length of the input data
+                               uint8_t** output_out,    // The output data in MessagePack format
+                               size_t* output_len_out)  // The length of the output data
 {
     // Get the parameter types of the function as a tuple.
     auto params = param_tuple<decltype(func)>();

--- a/cpp/src/barretenberg/serialize/msgpack.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack.hpp
@@ -1,6 +1,6 @@
 #pragma once
-/* Minimal header for declaring msgpack fields. 
-This should be included as "barretenberg/serialize/msgpack.hpp" unless a translation wants 
+/* Minimal header for declaring msgpack fields.
+This should be included as "barretenberg/serialize/msgpack.hpp" unless a translation wants
 to use msgpack for bindings, then "barretenberg/serialize/cbind.hpp" should be included.
 
 ## Overview
@@ -99,7 +99,4 @@ e.g. unpacking
 // Define a macro that takes any amount of parameters and expands to a msgpack method definition
 // __VA__ARGS__ expands to the parmeters, comma separated.
 #define MSGPACK_FIELDS(...)                                                                                            \
-    void msgpack(auto pack_fn)                                                                                         \
-    {                                                                                                                  \
-        pack_fn(NVP(__VA_ARGS__));                                                                                     \
-    }
+    void msgpack(auto pack_fn) { pack_fn(NVP(__VA_ARGS__)); }

--- a/cpp/src/barretenberg/serialize/msgpack_impl/concepts.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/concepts.hpp
@@ -4,8 +4,12 @@ struct DoNothing {
     void operator()(auto...) {}
 };
 namespace msgpack_concepts {
-template <typename T>
-concept HasMsgPack = requires(T t, DoNothing nop) { t.msgpack(nop); };
-template <typename T>
-concept HasMsgPackPack = requires(T t, DoNothing nop) { t.msgpack_pack(nop); };
+template <typename T> concept HasMsgPack = requires(T t, DoNothing nop)
+{
+    t.msgpack(nop);
+};
+template <typename T> concept HasMsgPackPack = requires(T t, DoNothing nop)
+{
+    t.msgpack_pack(nop);
+};
 } // namespace msgpack_concepts

--- a/cpp/src/barretenberg/serialize/msgpack_impl/func_traits.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/func_traits.hpp
@@ -3,31 +3,27 @@
 #include "../msgpack.hpp"
 
 // Define a template struct to deduce function traits for different function types
-template <typename Func> 
-struct func_traits;
+template <typename Func> struct func_traits;
 
 // Specialization for function pointers
-template <typename R, typename... Vs> 
-struct func_traits<R (*)(Vs...)> {
+template <typename R, typename... Vs> struct func_traits<R (*)(Vs...)> {
     typedef std::tuple<Vs...> Args; // Define a tuple type that holds all argument types
-    Args args; // Args instance
-    R ret;     // Holds return type
-    MSGPACK_FIELDS(args, ret); // Macro from msgpack library to serialize/deserialize fields
+    Args args;                      // Args instance
+    R ret;                          // Holds return type
+    MSGPACK_FIELDS(args, ret);      // Macro from msgpack library to serialize/deserialize fields
 };
 
 // Specialization for function references
-template <typename R, typename... Vs> 
-struct func_traits<R (&)(Vs...)> {
+template <typename R, typename... Vs> struct func_traits<R (&)(Vs...)> {
     typedef std::tuple<Vs...> Args;
     Args args;
     R ret;
     MSGPACK_FIELDS(args, ret);
 };
 
-// Specialization for member function pointers. This also includes lambda types, 
+// Specialization for member function pointers. This also includes lambda types,
 // as they are functors (objects with operator()) and hence have a member function pointer
-template <typename R, typename T, typename... Vs> 
-struct func_traits<R (T::*)(Vs...) const> {
+template <typename R, typename T, typename... Vs> struct func_traits<R (T::*)(Vs...) const> {
     typedef std::tuple<Vs...> Args;
     Args args;
     R ret;
@@ -36,22 +32,20 @@ struct func_traits<R (T::*)(Vs...) const> {
 
 // Define a concept that checks if the type is a lambda (or functor) type
 // This is done by checking if T::operator() exists
-template <typename T>
-concept LambdaType = requires() { 
-    typename std::enable_if_t<std::is_member_function_pointer_v<decltype(&T::operator())>, void>; 
+template <typename T> concept LambdaType = requires()
+{
+    typename std::enable_if_t<std::is_member_function_pointer_v<decltype(&T::operator())>, void>;
 };
 
 // Overload for lambda (or functor) types
-template <LambdaType T> 
-constexpr auto get_func_traits()
+template <LambdaType T> constexpr auto get_func_traits()
 {
     // If T is a lambda type (i.e. it has operator()), deduce its traits using func_traits
     return func_traits<decltype(&T::operator())>();
 }
 
 // Overload for non-lambda types
-template <typename T> 
-constexpr auto get_func_traits()
+template <typename T> constexpr auto get_func_traits()
 {
     // If T is not a lambda, just deduce its traits using func_traits
     return func_traits<T>();

--- a/cpp/src/barretenberg/serialize/msgpack_impl/name_value_pair_macro.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/name_value_pair_macro.hpp
@@ -5,7 +5,9 @@
  * used in msgpack serialization. */
 
 // hacky counting of variadic macro params:
-#define VA_NARGS_IMPL(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...) N
+#define VA_NARGS_IMPL(                                                                                                 \
+    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...)                 \
+    N
 // AD: support for 20 fields!? one may ask. Well, after 15 not being enough...
 #define VA_NARGS(...) VA_NARGS_IMPL(__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
 
@@ -34,7 +36,7 @@
 #define _NVP19(x, ...) _NVP1(x), _NVP18(__VA_ARGS__)
 #define _NVP20(x, ...) _NVP1(x), _NVP19(__VA_ARGS__)
 
-#define CONCAT(a, b) a ## b
+#define CONCAT(a, b) a##b
 #define _NVP_N(n) CONCAT(_NVP, n)
 #define NVP(...) _NVP_N(VA_NARGS(__VA_ARGS__))(__VA_ARGS__)
 // end of #define NVP

--- a/cpp/src/barretenberg/serialize/msgpack_impl/schema_impl.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/schema_impl.hpp
@@ -58,9 +58,11 @@ inline void _schema_pack_map_content(MsgpackSchemaPacker&)
 }
 
 namespace msgpack_concepts {
-template <typename T>
-concept SchemaPackable = requires(T value, MsgpackSchemaPacker packer) { msgpack_schema_pack(packer, value); };
-}
+template <typename T> concept SchemaPackable = requires(T value, MsgpackSchemaPacker packer)
+{
+    msgpack_schema_pack(packer, value);
+};
+} // namespace msgpack_concepts
 
 // Helper for packing (key, value, key, value, ...) arguments
 template <typename Value, typename... Rest>
@@ -80,8 +82,8 @@ inline void _schema_pack_map_content(MsgpackSchemaPacker& packer, std::string ke
  * @param packer the schema packer.
  */
 template <typename T>
-    requires(!msgpack_concepts::HasMsgPack<T> && !msgpack_concepts::HasMsgPackPack<T>)
-inline void msgpack_schema_pack(MsgpackSchemaPacker& packer, T const&)
+requires(!msgpack_concepts::HasMsgPack<T> &&
+         !msgpack_concepts::HasMsgPackPack<T>) inline void msgpack_schema_pack(MsgpackSchemaPacker& packer, T const&)
 {
     packer.pack(msgpack_schema_name(T{}));
 }

--- a/cpp/src/barretenberg/serialize/msgpack_impl/struct_map_impl.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/struct_map_impl.hpp
@@ -27,9 +27,11 @@ template <typename... Args> auto drop_keys(std::tuple<Args...>&& tuple)
 } // namespace msgpack
 
 namespace msgpack {
-template <typename T, typename... Args>
-concept MsgpackConstructible = requires(T object, Args... args) { T{ args... }; };
-}
+template <typename T, typename... Args> concept MsgpackConstructible = requires(T object, Args... args)
+{
+    T{ args... };
+};
+} // namespace msgpack
 
 namespace msgpack::adaptor {
 // reads structs with msgpack() method from a JSON-like dictionary

--- a/cpp/src/barretenberg/serialize/msgpack_impl/variant_impl.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/variant_impl.hpp
@@ -6,11 +6,11 @@
 
 namespace msgpack::adaptor {
 // writes std::variant to msgpack format (TODO should we read std::variant?)
-template<typename... T>
-struct pack<std::variant< T...>> {
-    auto &operator()(auto& o, std::variant<T...> const &variant) const {
+template <typename... T> struct pack<std::variant<T...>> {
+    auto& operator()(auto& o, std::variant<T...> const& variant) const
+    {
         std::visit([&o](const auto& arg) { o.pack(arg); }, variant);
         return o;
     }
 };
-}
+} // namespace msgpack::adaptor

--- a/cpp/src/barretenberg/serialize/raw_pointer.hpp
+++ b/cpp/src/barretenberg/serialize/raw_pointer.hpp
@@ -3,31 +3,24 @@
 #include "msgpack_impl/schema_name.hpp"
 
 // Holds a raw pointer to an object of type T.
-// It provides methods for packing and unpacking the pointer using MessagePack, 
+// It provides methods for packing and unpacking the pointer using MessagePack,
 // a binary serialization format.
-template <typename T>
-struct RawPointer {
+template <typename T> struct RawPointer {
     // Raw pointer to an object of type T
     T* ptr = nullptr;
 
     // Pack the raw pointer into a MessagePack packer.
     // The pointer is first cast to an integer type (uintptr_t) which can hold a pointer,
     // and then packed into the packer.
-    void msgpack_pack(auto& packer) const { 
-        packer.pack(reinterpret_cast<uintptr_t>(ptr)); 
-    }
+    void msgpack_pack(auto& packer) const { packer.pack(reinterpret_cast<uintptr_t>(ptr)); }
 
     // Unpack the raw pointer from a MessagePack object.
     // The object is first cast to an integer type (uintptr_t), and then to a pointer of type T.
-    void msgpack_unpack(auto object) { 
-        ptr = reinterpret_cast<T*>((uintptr_t)object); 
-    }
+    void msgpack_unpack(auto object) { ptr = reinterpret_cast<T*>((uintptr_t)object); }
 
     // Overload the arrow operator to return the raw pointer.
     // This allows users to directly access the object pointed to by the raw pointer.
-    T* operator->() { 
-        return ptr; 
-    }
+    T* operator->() { return ptr; }
 };
 
 // help our msgpack schema compiler with this struct

--- a/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -193,7 +193,6 @@ TEST(stdlib_keccak, test_format_input_lanes)
         }
     }
 
-
     auto prover = composer.create_prover();
     auto verifier = composer.create_verifier();
 
@@ -277,7 +276,6 @@ TEST(stdlib_keccak, test_double_block_variable_length)
     std::vector<uint8_t> expected = stdlib::keccak<Composer>::hash_native(input_v);
 
     EXPECT_EQ(output.get_value(), expected);
-
 
     auto prover = composer.create_prover();
     auto verifier = composer.create_verifier();

--- a/cpp/src/msgpack-c/.clang-format
+++ b/cpp/src/msgpack-c/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
# Description

When msgpack was added it was missing the formatting pre-commit hook. Thus, any work interacting with msgpack was also not formatted. I also added a new `.clang-format` file into the `msgpack-c` folder. Msgpack is a third party package which we bundled into barretenberg so we want to exclude it from our clang format rules, however, any code in barretenberg that uses msgpack should still be formatted. 

# Checklist:

- [X] I have reviewed my diff in github, line by line.
- [X] Every change is related to the PR description.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [X] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [X] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- X ] The branch has been rebased against the head of its merge target.
- [X] I'm happy for the PR to be merged at the reviewer's next convenience.
- [] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
