### PR TITLE
Fixed a bug in biggroup tests

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -472,7 +472,7 @@ template <class Composer, class Fq, class Fr, class NativeGroup> class element {
         {
             num_points = points.size();
             num_fives = num_points / 5;
-
+            num_sixes = 0;
             // size-6 table is expensive and only benefits us if creating them reduces the number of total tables
             if (num_fives * 5 == (num_points - 1)) {
                 num_fives -= 1;


### PR DESCRIPTION
# Description
stdlib primitives test were failing due to a timeout (https://app.circleci.com/pipelines/github/AztecProtocol/barretenberg/3416/workflows/51c52ba4-0e94-4c46-8122-3d89fa0e62e1/jobs/26173). Turns out, it's an uninitialized memory issue. num_sixes is not initialized if the number of points is low. It still accesses memory and is used in a loop as a top margin, which leads to an almost eternal loop
# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
