### PR TITLE
fix: block constraints with no witness assignment

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -94,7 +94,7 @@ void create_circuit(Composer& composer, const acir_format& constraint_system)
 
     // Add block constraints
     for (const auto& constraint : constraint_system.block_constraints) {
-        create_block_constraints(composer, constraint);
+        create_block_constraints(composer, constraint, false);
     }
 }
 
@@ -185,7 +185,7 @@ Composer create_circuit(const acir_format& constraint_system,
 
     // Add block constraints
     for (const auto& constraint : constraint_system.block_constraints) {
-        create_block_constraints(composer, constraint);
+        create_block_constraints(composer, constraint, false);
     }
 
     return composer;

--- a/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -24,7 +24,9 @@ struct BlockConstraint {
     BlockType type;
 };
 
-void create_block_constraints(Composer& composer, const BlockConstraint constraint);
+void create_block_constraints(Composer& composer,
+                              const BlockConstraint constraint,
+                              bool has_valid_witness_assignments = true);
 
 template <typename B> inline void read(B& buf, MemOp& mem_op)
 {


### PR DESCRIPTION
# Description

Block constraint was not taking into account circuits created with no witness assignment, and this was causing invalid index when reading/writing from rom/ram table.
We now check for this case and use a 0 index. For rom table, we use instead a witness whose value is 0 because constant index is not supported.

# Checklist:

- [X] I have reviewed my diff in github, line by line.
- [X] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [X] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [X] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [X] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [X] I'm happy for the PR to be merged at the reviewer's next convenience.
- [X] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [X] If existing code has been modified, such documentation has been added or updated.
