### PR TITLE
chore(dsl)!: Patch noir master acir format w/ recursion constraints

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
@@ -10,6 +10,7 @@
 #include "block_constraint.hpp"
 #include "pedersen.hpp"
 #include "hash_to_field.hpp"
+#include "recursion_constraint.hpp"
 #include "barretenberg/dsl/types.hpp"
 
 namespace acir_format {
@@ -32,6 +33,7 @@ struct acir_format {
     std::vector<HashToFieldConstraint> hash_to_field_constraints;
     std::vector<PedersenConstraint> pedersen_constraints;
     std::vector<BlockConstraint> block_constraints;
+    std::vector<RecursionConstraint> recursion_constraints;
     // A standard plonk arithmetic constraint, as defined in the poly_triple struct, consists of selector values
     // for q_M,q_L,q_R,q_O,q_C and indices of three variables taking the role of left, right and output wire
     std::vector<poly_triple> constraints;
@@ -71,6 +73,7 @@ template <typename B> inline void read(B& buf, acir_format& data)
     read(buf, data.pedersen_constraints);
     read(buf, data.hash_to_field_constraints);
     read(buf, data.fixed_base_scalar_mul_constraints);
+    read(buf, data.recursion_constraints);
     read(buf, data.constraints);
     read(buf, data.block_constraints);
 }
@@ -91,6 +94,7 @@ template <typename B> inline void write(B& buf, acir_format const& data)
     write(buf, data.pedersen_constraints);
     write(buf, data.hash_to_field_constraints);
     write(buf, data.fixed_base_scalar_mul_constraints);
+    write(buf, data.recursion_constraints);
     write(buf, data.constraints);
     write(buf, data.block_constraints);
 }

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -97,6 +97,7 @@ TEST(acir_format, test_logic_gate_from_noir_circuit)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .block_constraints = {},
+        .recursion_constraints = {},
         .constraints = { expr_a, expr_b, expr_c, expr_d },
     };
 
@@ -163,6 +164,7 @@ TEST(acir_format, test_schnorr_verify_pass)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .block_constraints = {},
+        .recursion_constraints = {},
         .constraints = { poly_triple{
             .a = schnorr_constraint.result,
             .b = schnorr_constraint.result,
@@ -234,6 +236,7 @@ TEST(acir_format, test_schnorr_verify_small_range)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .block_constraints = {},
+        .recursion_constraints = {},
         .constraints = { poly_triple{
             .a = schnorr_constraint.result,
             .b = schnorr_constraint.result,

--- a/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -117,6 +117,7 @@ TEST(up_ram, TestBlockConstraint)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .block_constraints = { block },
+        .recursion_constraints = {},
         .constraints = {},
     };
 

--- a/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
@@ -98,6 +98,7 @@ TEST(ECDSASecp256k1, TestECDSAConstraintSucceed)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .block_constraints = {},
+        .recursion_constraints = {},
         .constraints = {},
     };
 
@@ -134,6 +135,7 @@ TEST(ECDSASecp256k1, TestECDSACompilesForVerifier)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .block_constraints = {},
+        .recursion_constraints = {},
         .constraints = {},
     };
     auto crs_factory = std::make_unique<proof_system::ReferenceStringFactory>();
@@ -167,6 +169,7 @@ TEST(ECDSASecp256k1, TestECDSAConstraintFail)
         .hash_to_field_constraints = {},
         .pedersen_constraints = {},
         .block_constraints = {},
+        .recursion_constraints = {},
         .constraints = {},
     };
 

--- a/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include <vector>
+#include "barretenberg/dsl/types.hpp"
+#include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
+
+namespace acir_format {
+
+using namespace proof_system::plonk;
+
+/**
+ * @brief RecursionConstraint struct contains information required to recursively verify a proof!
+ *
+ * Implementation of this constraint can be found on barretenberg master. This branch (`acvm-backend-barretenberg`)
+ * is temporary until Noir fully moves to bb.js (and other dynamic backends) as its prover. This struct is defined in
+ * order to match up the acir format used by `master` and `acvm-backend-barretenberg` while the temporary branch still
+ * exists.
+ */
+struct RecursionConstraint {
+    // An aggregation state is represented by two G1 affine elements. Each G1 point has
+    // two field element coordinates (x, y). Thus, four field elements
+    static constexpr size_t NUM_AGGREGATION_ELEMENTS = 4;
+    // Four limbs are used when simulating a non-native field using the bigfield class
+    static constexpr size_t AGGREGATION_OBJECT_SIZE =
+        NUM_AGGREGATION_ELEMENTS * NUM_QUOTIENT_PARTS; // 16 field elements
+    std::vector<uint32_t> key;
+    std::vector<uint32_t> proof;
+    std::vector<uint32_t> public_inputs;
+    uint32_t key_hash;
+    std::array<uint32_t, AGGREGATION_OBJECT_SIZE> input_aggregation_object;
+    std::array<uint32_t, AGGREGATION_OBJECT_SIZE> output_aggregation_object;
+    std::array<uint32_t, AGGREGATION_OBJECT_SIZE> nested_aggregation_object;
+
+    friend bool operator==(RecursionConstraint const& lhs, RecursionConstraint const& rhs) = default;
+};
+
+template <typename B> inline void read(B& buf, RecursionConstraint& constraint)
+{
+    using serialize::read;
+    read(buf, constraint.key);
+    read(buf, constraint.proof);
+    read(buf, constraint.public_inputs);
+    read(buf, constraint.key_hash);
+    read(buf, constraint.input_aggregation_object);
+    read(buf, constraint.output_aggregation_object);
+    read(buf, constraint.nested_aggregation_object);
+}
+
+template <typename B> inline void write(B& buf, RecursionConstraint const& constraint)
+{
+    using serialize::write;
+    write(buf, constraint.key);
+    write(buf, constraint.proof);
+    write(buf, constraint.public_inputs);
+    write(buf, constraint.key_hash);
+    write(buf, constraint.input_aggregation_object);
+    write(buf, constraint.output_aggregation_object);
+    write(buf, constraint.nested_aggregation_object);
+}

--- a/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <vector>
 #include "barretenberg/dsl/types.hpp"
-#include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
 
 namespace acir_format {
 

--- a/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
+++ b/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
@@ -55,3 +55,5 @@ template <typename B> inline void write(B& buf, RecursionConstraint const& const
     write(buf, constraint.output_aggregation_object);
     write(buf, constraint.nested_aggregation_object);
 }
+
+} // namespace acir_format


### PR DESCRIPTION
# Description

This is a patch to have the `acvm-backend-barretenberg` branch stay in line with barretenberg master once bb.js is the prover 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
