### PR TITLE
feat(honk): Shared relation arithmetic

### DIFF
--- a/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -66,9 +66,6 @@ class Standard {
     using RelationUnivariates = decltype(create_relation_univariates_container<FF, Relations>());
     using RelationValues = decltype(create_relation_values_container<FF, Relations>());
 
-    // define utilities to extend univarates from RELATION_LENGTH to MAX_RELATION_LENGTH for each Relation
-    // using BarycentricUtils = decltype(create_barycentric_utils<FF, Relations, MAX_RELATION_LENGTH>());
-
   private:
     /**
      * @brief A base class labelling precomputed entities and (ordered) subsets of interest.

--- a/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
@@ -4,6 +4,7 @@
 
 #include "../polynomials/univariate.hpp"
 #include "relation_parameters.hpp"
+#include "relation_types.hpp"
 
 namespace proof_system::honk::sumcheck {
 
@@ -12,11 +13,14 @@ template <typename FF> class ArithmeticRelation {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 4;
 
-    static constexpr size_t NUM_CONSTRAINTS = 1;
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 4 };
+    static constexpr size_t LEN_1 = 4; // arithmetic sub-relation
+    using LENGTHS = LengthsWrapper<LEN_1>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Expression for the StandardArithmetic gate.
@@ -28,55 +32,47 @@ template <typename FF> class ArithmeticRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    void add_edge_contribution(RelationUnivariates& evals,
-                               const auto& extended_edges,
-                               const RelationParameters<FF>&,
-                               const FF& scaling_factor) const
+    template <typename TypeMuncher>
+    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulator,
+                                    const auto& extended_edges,
+                                    const RelationParameters<FF>&,
+                                    const FF& scaling_factor) const
     {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
 
-        auto w_l = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_l);
-        auto w_r = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_r);
-        auto w_o = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_o);
-        auto q_m = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_m);
-        auto q_l = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_l);
-        auto q_r = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_r);
-        auto q_o = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_o);
-        auto q_c = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_c);
+        using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+        auto w_l = View(extended_edges.w_l);
+        auto w_r = View(extended_edges.w_r);
+        auto w_o = View(extended_edges.w_o);
+        auto q_m = View(extended_edges.q_m);
+        auto q_l = View(extended_edges.q_l);
+        auto q_r = View(extended_edges.q_r);
+        auto q_o = View(extended_edges.q_o);
+        auto q_c = View(extended_edges.q_c);
 
         auto tmp = w_l * (q_m * w_r + q_l);
         tmp += q_r * w_r;
         tmp += q_o * w_o;
         tmp += q_c;
         tmp *= scaling_factor;
-        std::get<0>(evals) += tmp;
+        std::get<0>(accumulator) += tmp;
     };
 
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                              const auto& purported_evaluations,
-                                              const RelationParameters<FF>&) const
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
     {
-        auto w_l = purported_evaluations.w_l;
-        auto w_r = purported_evaluations.w_r;
-        auto w_o = purported_evaluations.w_o;
-        auto q_m = purported_evaluations.q_m;
-        auto q_l = purported_evaluations.q_l;
-        auto q_r = purported_evaluations.q_r;
-        auto q_o = purported_evaluations.q_o;
-        auto q_c = purported_evaluations.q_c;
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
-        std::get<0>(full_honk_relation_value) += w_l * (q_m * w_r + q_l);
-        std::get<0>(full_honk_relation_value) += q_r * w_r;
-        std::get<0>(full_honk_relation_value) += q_o * w_o;
-        std::get<0>(full_honk_relation_value) += q_c;
-    };
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
@@ -8,19 +8,13 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename FF> class ArithmeticRelation {
+template <typename FF> class ArithmeticRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 4;
 
     static constexpr size_t LEN_1 = 4; // arithmetic sub-relation
     using LENGTHS = LengthsWrapper<LEN_1>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the StandardArithmetic gate.
@@ -33,10 +27,10 @@ template <typename FF> class ArithmeticRelation {
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
     template <typename TypeMuncher>
-    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulator,
-                                    const auto& extended_edges,
-                                    const RelationParameters<FF>&,
-                                    const FF& scaling_factor) const
+    void static add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulator,
+                                           const auto& extended_edges,
+                                           const RelationParameters<FF>&,
+                                           const FF& scaling_factor)
     {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
@@ -58,21 +52,7 @@ template <typename FF> class ArithmeticRelation {
         tmp *= scaling_factor;
         std::get<0>(accumulator) += tmp;
     };
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
 };
+
+template <typename FF> using ArithmeticRelation = RelationWrapper<FF, ArithmeticRelationBase>;
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
@@ -16,11 +16,11 @@ template <typename FF> class ArithmeticRelation {
     static constexpr size_t LEN_1 = 4; // arithmetic sub-relation
     using LENGTHS = LengthsWrapper<LEN_1>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the StandardArithmetic gate.
@@ -64,7 +64,7 @@ template <typename FF> class ArithmeticRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -72,7 +72,7 @@ template <typename FF> class ArithmeticRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
@@ -9,7 +9,7 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename FF> class AuxiliaryRelation {
+template <typename FF> class AuxiliaryRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6;
@@ -21,12 +21,6 @@ template <typename FF> class AuxiliaryRelation {
     static constexpr size_t LEN_5 = 6; // RAM consistency sub-relation 2
     static constexpr size_t LEN_6 = 6; // RAM consistency sub-relation 3
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4, LEN_5, LEN_6>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -298,21 +292,7 @@ template <typename FF> class AuxiliaryRelation {
         auxiliary_identity *= (q_aux * scaling_factor);
         std::get<0>(accumulators) += auxiliary_identity;
     };
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
 };
+
+template <typename FF> using AuxiliaryRelation = RelationWrapper<FF, AuxiliaryRelationBase>;
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
@@ -22,11 +22,11 @@ template <typename FF> class AuxiliaryRelation {
     static constexpr size_t LEN_6 = 6; // RAM consistency sub-relation 3
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4, LEN_5, LEN_6>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -304,7 +304,7 @@ template <typename FF> class AuxiliaryRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -312,7 +312,7 @@ template <typename FF> class AuxiliaryRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
@@ -5,6 +5,7 @@
 #include "../polynomials/univariate.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "relation_parameters.hpp"
+#include "relation_types.hpp"
 
 namespace proof_system::honk::sumcheck {
 
@@ -13,16 +14,19 @@ template <typename FF> class AuxiliaryRelation {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6;
 
-    static constexpr size_t NUM_CONSTRAINTS = 6;
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 6, 6, 6, 6, 6, 6 }; // Each has degree 5
+    static constexpr size_t LEN_1 = 6; // auxiliary sub-relation
+    static constexpr size_t LEN_2 = 6; // ROM consistency sub-relation 1
+    static constexpr size_t LEN_3 = 6; // ROM consistency sub-relation 2
+    static constexpr size_t LEN_4 = 6; // RAM consistency sub-relation 1
+    static constexpr size_t LEN_5 = 6; // RAM consistency sub-relation 2
+    static constexpr size_t LEN_6 = 6; // RAM consistency sub-relation 3
+    using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4, LEN_5, LEN_6>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[1]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[2]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[3]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[4]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[5]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -58,33 +62,36 @@ template <typename FF> class AuxiliaryRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    void add_edge_contribution(RelationUnivariates& evals,
-                               const auto& extended_edges,
-                               const RelationParameters<FF>& relation_parameters,
-                               const FF& scaling_factor) const
+    template <typename TypeMuncher>
+    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+                                                  const auto& extended_edges,
+                                                  const RelationParameters<FF>& relation_parameters,
+                                                  const FF& scaling_factor)
     {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
 
         const auto& eta = relation_parameters.eta;
 
-        auto w_1 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_l);
-        auto w_2 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_r);
-        auto w_3 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_o);
-        auto w_4 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_4);
-        auto w_1_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_l_shift);
-        auto w_2_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_r_shift);
-        auto w_3_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_o_shift);
-        auto w_4_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_4_shift);
+        // All subrelations have the same length so we use the same length view for all calculations
+        using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+        auto w_1 = View(extended_edges.w_l);
+        auto w_2 = View(extended_edges.w_r);
+        auto w_3 = View(extended_edges.w_o);
+        auto w_4 = View(extended_edges.w_4);
+        auto w_1_shift = View(extended_edges.w_l_shift);
+        auto w_2_shift = View(extended_edges.w_r_shift);
+        auto w_3_shift = View(extended_edges.w_o_shift);
+        auto w_4_shift = View(extended_edges.w_4_shift);
 
-        auto q_1 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_l);
-        auto q_2 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_r);
-        auto q_3 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_o);
-        auto q_4 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_4);
-        auto q_m = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_m);
-        auto q_c = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_c);
-        auto q_arith = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_arith);
-        auto q_aux = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_aux);
+        auto q_1 = View(extended_edges.q_l);
+        auto q_2 = View(extended_edges.q_r);
+        auto q_3 = View(extended_edges.q_o);
+        auto q_4 = View(extended_edges.q_4);
+        auto q_m = View(extended_edges.q_m);
+        auto q_c = View(extended_edges.q_c);
+        auto q_arith = View(extended_edges.q_arith);
+        auto q_aux = View(extended_edges.q_aux);
 
         const FF LIMB_SIZE(uint256_t(1) << 68);
         const FF SUBLIMB_SHIFT(uint256_t(1) << 14);
@@ -211,8 +218,9 @@ template <typename FF> class AuxiliaryRelation {
 
         auto adjacent_values_match_if_adjacent_indices_match = (index_delta * FF(-1) + FF(1)) * record_delta;
 
-        std::get<1>(evals) += adjacent_values_match_if_adjacent_indices_match * (q_1 * q_2) * (q_aux * scaling_factor);
-        std::get<2>(evals) += index_is_monotonically_increasing * (q_1 * q_2) * (q_aux * scaling_factor);
+        std::get<1>(accumulators) +=
+            adjacent_values_match_if_adjacent_indices_match * (q_1 * q_2) * (q_aux * scaling_factor);
+        std::get<2>(accumulators) += index_is_monotonically_increasing * (q_1 * q_2) * (q_aux * scaling_factor);
         auto ROM_consistency_check_identity = memory_record_check * (q_1 * q_2);
 
         /**
@@ -256,10 +264,11 @@ template <typename FF> class AuxiliaryRelation {
         auto next_gate_access_type_is_boolean = next_gate_access_type * next_gate_access_type - next_gate_access_type;
 
         // Putting it all together...
-        std::get<3>(evals) += adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation *
-                              (q_arith) * (q_aux * scaling_factor);
-        std::get<4>(evals) += index_is_monotonically_increasing * (q_arith) * (q_aux * scaling_factor);
-        std::get<5>(evals) += next_gate_access_type_is_boolean * (q_arith) * (q_aux * scaling_factor);
+        std::get<3>(accumulators) +=
+            adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation * (q_arith) *
+            (q_aux * scaling_factor);
+        std::get<4>(accumulators) += index_is_monotonically_increasing * (q_arith) * (q_aux * scaling_factor);
+        std::get<5>(accumulators) += next_gate_access_type_is_boolean * (q_arith) * (q_aux * scaling_factor);
         auto RAM_consistency_check_identity = access_check * (q_arith);
 
         /**
@@ -287,247 +296,23 @@ template <typename FF> class AuxiliaryRelation {
 
         auto auxiliary_identity = memory_identity + non_native_field_identity + limb_accumulator_identity;
         auxiliary_identity *= (q_aux * scaling_factor);
-        std::get<0>(evals) += auxiliary_identity;
+        std::get<0>(accumulators) += auxiliary_identity;
     };
 
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                              const auto& purported_evaluations,
-                                              const RelationParameters<FF>& relation_parameters) const
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
     {
-        const auto& eta = relation_parameters.eta;
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
-        auto w_1 = purported_evaluations.w_l;
-        auto w_2 = purported_evaluations.w_r;
-        auto w_3 = purported_evaluations.w_o;
-        auto w_4 = purported_evaluations.w_4;
-        auto w_1_shift = purported_evaluations.w_l_shift;
-        auto w_2_shift = purported_evaluations.w_r_shift;
-        auto w_3_shift = purported_evaluations.w_o_shift;
-        auto w_4_shift = purported_evaluations.w_4_shift;
-
-        auto q_1 = purported_evaluations.q_l;
-        auto q_2 = purported_evaluations.q_r;
-        auto q_3 = purported_evaluations.q_o;
-        auto q_4 = purported_evaluations.q_4;
-        auto q_m = purported_evaluations.q_m;
-        auto q_c = purported_evaluations.q_c;
-        auto q_arith = purported_evaluations.q_arith;
-        auto q_aux = purported_evaluations.q_aux;
-
-        constexpr FF LIMB_SIZE(uint256_t(1) << 68);
-        constexpr FF SUBLIMB_SHIFT(uint256_t(1) << 14);
-
-        /**
-         * Non native field arithmetic gate 2
-         *
-         *             _                                                                               _
-         *            /   _                   _                               _       14                \
-         * q_2 . q_4 |   (w_1 . w_2) + (w_1 . w_2) + (w_1 . w_4 + w_2 . w_3 - w_3) . 2    - w_3 - w_4   |
-         *            \_                                                                               _/
-         *
-         **/
-        auto limb_subproduct = w_1 * w_2_shift + w_1_shift * w_2;
-        auto non_native_field_gate_2 = (w_1 * w_4 + w_2 * w_3 - w_3_shift);
-        non_native_field_gate_2 *= LIMB_SIZE;
-        non_native_field_gate_2 -= w_4_shift;
-        non_native_field_gate_2 += limb_subproduct;
-        non_native_field_gate_2 *= q_4;
-
-        limb_subproduct *= LIMB_SIZE;
-        limb_subproduct += (w_1_shift * w_2_shift);
-        auto non_native_field_gate_1 = limb_subproduct;
-        non_native_field_gate_1 -= (w_3 + w_4);
-        non_native_field_gate_1 *= q_3;
-
-        auto non_native_field_gate_3 = limb_subproduct;
-        non_native_field_gate_3 += w_4;
-        non_native_field_gate_3 -= (w_3_shift + w_4_shift);
-        non_native_field_gate_3 *= q_m;
-
-        auto non_native_field_identity = non_native_field_gate_1 + non_native_field_gate_2 + non_native_field_gate_3;
-        non_native_field_identity *= q_2;
-
-        auto limb_accumulator_1 = w_2_shift;
-        limb_accumulator_1 *= SUBLIMB_SHIFT;
-        limb_accumulator_1 += w_1_shift;
-        limb_accumulator_1 *= SUBLIMB_SHIFT;
-        limb_accumulator_1 += w_3;
-        limb_accumulator_1 *= SUBLIMB_SHIFT;
-        limb_accumulator_1 += w_2;
-        limb_accumulator_1 *= SUBLIMB_SHIFT;
-        limb_accumulator_1 += w_1;
-        limb_accumulator_1 -= w_4;
-        limb_accumulator_1 *= q_4;
-
-        auto limb_accumulator_2 = w_3_shift;
-        limb_accumulator_2 *= SUBLIMB_SHIFT;
-        limb_accumulator_2 += w_2_shift;
-        limb_accumulator_2 *= SUBLIMB_SHIFT;
-        limb_accumulator_2 += w_1_shift;
-        limb_accumulator_2 *= SUBLIMB_SHIFT;
-        limb_accumulator_2 += w_4;
-        limb_accumulator_2 *= SUBLIMB_SHIFT;
-        limb_accumulator_2 += w_3;
-        limb_accumulator_2 -= w_4_shift;
-        limb_accumulator_2 *= q_m;
-
-        auto limb_accumulator_identity = limb_accumulator_1 + limb_accumulator_2;
-        limb_accumulator_identity *= q_3;
-
-        /**
-         * MEMORY
-         *
-         * A RAM memory record contains a tuple of the following fields:
-         *  * i: `index` of memory cell being accessed
-         *  * t: `timestamp` of memory cell being accessed (used for RAM, set to 0 for ROM)
-         *  * v: `value` of memory cell being accessed
-         *  * a: `access` type of record. read: 0 = read, 1 = write
-         *  * r: `record` of memory cell. record = access + index * eta + timestamp * eta^2 + value * eta^3
-         *
-         * A ROM memory record contains a tuple of the following fields:
-         *  * i: `index` of memory cell being accessed
-         *  * v: `value1` of memory cell being accessed (ROM tables can store up to 2 values per index)
-         *  * v2:`value2` of memory cell being accessed (ROM tables can store up to 2 values per index)
-         *  * r: `record` of memory cell. record = index * eta + value2 * eta^2 + value1 * eta^3
-         *
-         *  When performing a read/write access, the values of i, t, v, v2, a, r are stored in the following wires +
-         * selectors, depending on whether the gate is a RAM read/write or a ROM read
-         *
-         *  | gate type | i  | v2/t  |  v | a  | r  |
-         *  | --------- | -- | ----- | -- | -- | -- |
-         *  | ROM       | w1 | w2    | w3 | -- | w4 |
-         *  | RAM       | w1 | w2    | w3 | qc | w4 |
-         *
-         * (for accesses where `index` is a circuit constant, it is assumed the circuit will apply a copy constraint on
-         * `w2` to fix its value)
-         *
-         **/
-
-        /**
-         * Memory Record Check
-         *
-         * A ROM/ROM access gate can be evaluated with the identity:
-         *
-         * qc + w1 \eta + w2 \eta^2 + w3 \eta^3 - w4 = 0
-         *
-         * For ROM gates, qc = 0
-         */
-        auto memory_record_check = w_3;
-        memory_record_check *= eta;
-        memory_record_check += w_2;
-        memory_record_check *= eta;
-        memory_record_check += w_1;
-        memory_record_check *= eta;
-        memory_record_check += q_c;
-        auto partial_record_check = memory_record_check; // used in RAM consistency check
-        memory_record_check = memory_record_check - w_4;
-
-        /**
-         * ROM Consistency Check
-         *
-         * For every ROM read, a set equivalence check is applied between the record witnesses, and a second set of
-         * records that are sorted.
-         *
-         * We apply the following checks for the sorted records:
-         *
-         * 1. w1, w2, w3 correctly map to 'index', 'v1, 'v2' for a given record value at w4
-         * 2. index values for adjacent records are monotonically increasing
-         * 3. if, at gate i, index_i == index_{i + 1}, then value1_i == value1_{i + 1} and value2_i == value2_{i + 1}
-         *
-         */
-        auto index_delta = w_1_shift - w_1;
-        auto record_delta = w_4_shift - w_4;
-
-        auto index_is_monotonically_increasing = index_delta.sqr() - index_delta;
-
-        auto adjacent_values_match_if_adjacent_indices_match = (FF(1) - index_delta) * record_delta;
-
-        std::get<1>(full_honk_relation_value) += adjacent_values_match_if_adjacent_indices_match * (q_1 * q_2) * q_aux;
-        std::get<2>(full_honk_relation_value) += index_is_monotonically_increasing * (q_1 * q_2) * q_aux;
-        auto ROM_consistency_check_identity = memory_record_check * (q_1 * q_2);
-
-        /**
-         * RAM Consistency Check
-         *
-         * The 'access' type of the record is extracted with the expression `w_4 - partial_record_check`
-         * (i.e. for an honest Prover `w1 * eta + w2 * eta^2 + w3 * eta^3 - w4 = access`.
-         * This is validated by requiring `access` to be boolean
-         *
-         * For two adjacent entries in the sorted list if _both_
-         *  A) index values match
-         *  B) adjacent access value is 0 (i.e. next gate is a READ)
-         * then
-         *  C) both values must match.
-         * The gate boolean check is
-         * (A && B) => C  === !(A && B) || C ===  !A || !B || C
-         *
-         * N.B. it is the responsibility of the circuit writer to ensure that every RAM cell is initialized
-         * with a WRITE operation.
-         */
-        auto access_type = (w_4 - partial_record_check);     // will be 0 or 1 for honest Prover
-        auto access_check = access_type.sqr() - access_type; // check value is 0 or 1
-
-        // TODO: oof nasty compute here. If we sorted in reverse order we could re-use `partial_record_check`
-        auto next_gate_access_type = w_3_shift;
-        next_gate_access_type *= eta;
-        next_gate_access_type += w_2_shift;
-        next_gate_access_type *= eta;
-        next_gate_access_type += w_1_shift;
-        next_gate_access_type *= eta;
-        next_gate_access_type = w_4_shift - next_gate_access_type;
-
-        auto value_delta = w_3_shift - w_3;
-        auto adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation =
-            (FF(1) - index_delta) * value_delta * (FF(1) - next_gate_access_type);
-
-        // We can't apply the RAM consistency check identity on the final entry in the sorted list (the wires in the
-        // next gate would make the identity fail).
-        // We need to validate that its 'access type' bool is correct. Can't do
-        // with an arithmetic gate because of the `eta` factors. We need to check that the *next* gate's access type is
-        // correct, to cover this edge case
-        auto next_gate_access_type_is_boolean = next_gate_access_type.sqr() - next_gate_access_type;
-
-        // Putting it all together...
-        std::get<3>(full_honk_relation_value) +=
-            adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation * (q_arith)*q_aux;
-        std::get<4>(full_honk_relation_value) += index_is_monotonically_increasing * (q_arith)*q_aux;
-        std::get<5>(full_honk_relation_value) += next_gate_access_type_is_boolean * (q_arith)*q_aux;
-        auto RAM_consistency_check_identity = access_check * (q_arith);
-
-        /**
-         * RAM Timestamp Consistency Check
-         *
-         * | w1 | w2 | w3 | w4 |
-         * | index | timestamp | timestamp_check | -- |
-         *
-         * Let delta_index = index_{i + 1} - index_{i}
-         *
-         * Iff delta_index == 0, timestamp_check = timestamp_{i + 1} - timestamp_i
-         * Else timestamp_check = 0
-         */
-        auto timestamp_delta = w_2_shift - w_2;
-        auto RAM_timestamp_check_identity = (FF(1) - index_delta) * timestamp_delta - w_3;
-
-        /**
-         * The complete RAM/ROM memory identity
-         *
-         */
-        auto memory_identity = ROM_consistency_check_identity;
-        memory_identity += RAM_timestamp_check_identity * q_1 * q_4;
-        memory_identity += memory_record_check * q_1 * q_m;
-        memory_identity += RAM_consistency_check_identity;
-
-        // auto auxiliary_identity = limb_accumulator_identity;
-        auto auxiliary_identity = memory_identity + non_native_field_identity + limb_accumulator_identity;
-        auxiliary_identity *= q_aux;
-        std::get<0>(full_honk_relation_value) += auxiliary_identity;
-    };
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
@@ -4,19 +4,24 @@
 
 #include "../polynomials/univariate.hpp"
 #include "relation_parameters.hpp"
+#include "relation_types.hpp"
 
 namespace proof_system::honk::sumcheck {
 
 template <typename FF> class EllipticRelation {
   public:
     // 1 + polynomial degree of this relation
-    static constexpr size_t RELATION_LENGTH = 5; // degree(q_elliptic * q_beta * x^3) = 5
+    static constexpr size_t RELATION_LENGTH = 6; // degree(q_elliptic * q_beta * x^3) = 5
 
-    static constexpr size_t NUM_CONSTRAINTS = 2;
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 6, 5 };
+    static constexpr size_t LEN_1 = 6; // x-coordinate sub-relation
+    static constexpr size_t LEN_2 = 5; // y-coordinate sub-relation
+    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>, Univariate<FF, CONSTRAINT_LENGTH[1]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -28,28 +33,29 @@ template <typename FF> class EllipticRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    void add_edge_contribution(RelationUnivariates& evals,
-                               const auto& extended_edges,
-                               const RelationParameters<FF>&,
-                               const FF& scaling_factor) const {
+    template <typename TypeMuncher>
+    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+                                    const auto& extended_edges,
+                                    const RelationParameters<FF>&,
+                                    const FF& scaling_factor) const {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
         // TODO(luke): Formatter doesnt properly handle explicit scoping below so turning off. Whats up?
         // clang-format off
         // Contribution (1)
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[0];
-            auto x_1 = UnivariateView<FF, LENGTH>(extended_edges.w_r);
-            auto y_1 = UnivariateView<FF, LENGTH>(extended_edges.w_o);
+            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            auto x_1 = View(extended_edges.w_r);
+            auto y_1 = View(extended_edges.w_o);
 
-            auto x_2 = UnivariateView<FF, LENGTH>(extended_edges.w_l_shift);
-            auto y_2 = UnivariateView<FF, LENGTH>(extended_edges.w_4_shift);
-            auto x_3 = UnivariateView<FF, LENGTH>(extended_edges.w_r_shift);
+            auto x_2 = View(extended_edges.w_l_shift);
+            auto y_2 = View(extended_edges.w_4_shift);
+            auto x_3 = View(extended_edges.w_r_shift);
 
-            auto q_sign = UnivariateView<FF, LENGTH>(extended_edges.q_l);
-            auto q_beta = UnivariateView<FF, LENGTH>(extended_edges.q_o);
-            auto q_beta_sqr = UnivariateView<FF, LENGTH>(extended_edges.q_4);
-            auto q_elliptic = UnivariateView<FF, LENGTH>(extended_edges.q_elliptic);
+            auto q_sign = View(extended_edges.q_l);
+            auto q_beta = View(extended_edges.q_o);
+            auto q_beta_sqr = View(extended_edges.q_4);
+            auto q_elliptic = View(extended_edges.q_elliptic);
 
             auto beta_term = x_2 * x_1 * (x_3 + x_3 + x_1) * FF(-1); // -x_1 * x_2 * (2 * x_3 + x_1)
             auto beta_sqr_term = x_2 * x_2;                          // x_2^2
@@ -68,22 +74,22 @@ template <typename FF> class EllipticRelation {
             auto x_identity = beta_term + beta_sqr_term + sign_term + leftovers;
             x_identity *= q_elliptic;
             x_identity *= scaling_factor;
-            std::get<0>(evals) += x_identity;
+            std::get<0>(accumulators) += x_identity;
         }
         // Contribution (2)
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[1];
-            auto x_1 = UnivariateView<FF, LENGTH>(extended_edges.w_r);
-            auto y_1 = UnivariateView<FF, LENGTH>(extended_edges.w_o);
+            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            auto x_1 = View(extended_edges.w_r);
+            auto y_1 = View(extended_edges.w_o);
 
-            auto x_2 = UnivariateView<FF, LENGTH>(extended_edges.w_l_shift);
-            auto y_2 = UnivariateView<FF, LENGTH>(extended_edges.w_4_shift);
-            auto x_3 = UnivariateView<FF, LENGTH>(extended_edges.w_r_shift);
-            auto y_3 = UnivariateView<FF, LENGTH>(extended_edges.w_o_shift);
+            auto x_2 = View(extended_edges.w_l_shift);
+            auto y_2 = View(extended_edges.w_4_shift);
+            auto x_3 = View(extended_edges.w_r_shift);
+            auto y_3 = View(extended_edges.w_o_shift);
 
-            auto q_sign = UnivariateView<FF, LENGTH>(extended_edges.q_l);
-            auto q_beta = UnivariateView<FF, LENGTH>(extended_edges.q_o);
-            auto q_elliptic = UnivariateView<FF, LENGTH>(extended_edges.q_elliptic);
+            auto q_sign = View(extended_edges.q_l);
+            auto q_beta = View(extended_edges.q_o);
+            auto q_elliptic = View(extended_edges.q_elliptic);
 
             auto beta_term = x_2 * (y_3 + y_1) * q_beta;          // β * x_2 * (y_3 + y_1)
             auto sign_term = y_2 * (x_1 - x_3) * q_sign * FF(-1); // - signt * y_2 * (x_1 - x_3)
@@ -93,63 +99,25 @@ template <typename FF> class EllipticRelation {
             auto y_identity = beta_term + sign_term + leftovers;
             y_identity *= q_elliptic;
             y_identity *= scaling_factor;
-            std::get<1>(evals) += y_identity;
+            std::get<1>(accumulators) += y_identity;
         }
     };
 
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                              const auto& purported_evaluations,
-                                              const RelationParameters<FF>&) const
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
     {
-        auto x_1 = purported_evaluations.w_r;
-        auto y_1 = purported_evaluations.w_o;
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
-        auto x_2 = purported_evaluations.w_l_shift;
-        auto y_2 = purported_evaluations.w_4_shift;
-        auto x_3 = purported_evaluations.w_r_shift;
-        auto y_3 = purported_evaluations.w_o_shift;
-
-        auto q_sign = purported_evaluations.q_l;
-        auto q_beta = purported_evaluations.q_o;
-        auto q_beta_sqr = purported_evaluations.q_4;
-        auto q_elliptic = purported_evaluations.q_elliptic;
-
-        // Contribution (1)
-        auto beta_term = x_2 * x_1 * (x_3 + x_3 + x_1) * FF(-1); // -x_1 * x_2 * (2 * x_3 + x_1)
-        auto beta_sqr_term = x_2 * x_2;                          // x_2^2
-        auto leftovers = beta_sqr_term;                          // x_2^2
-        beta_sqr_term *= (x_3 - x_1);                            // x_2^2 * (x_3 - x_1)
-        auto sign_term = y_2 * y_1;                              // y_1 * y_2
-        sign_term += sign_term;                                  // 2 * y_1 * y_2
-        beta_term *= q_beta;                                     // -β * x_1 * x_2 * (2 * x_3 + x_1)
-        beta_sqr_term *= q_beta_sqr;                             // β^2 * x_2^2 * (x_3 - x_1)
-        sign_term *= q_sign;                                     // 2 * y_1 * y_2 * sign
-        leftovers *= x_2;                                        // x_2^3
-        leftovers += x_1 * x_1 * (x_3 + x_1);                    // x_2^3 + x_1 * (x_3 + x_1)
-        leftovers -= (y_2 * y_2 + y_1 * y_1);                    // x_2^3 + x_1 * (x_3 + x_1) - y_2^2 - y_1^2
-
-        // Can be found in class description
-        auto x_identity = beta_term + beta_sqr_term + sign_term + leftovers;
-        x_identity *= q_elliptic;
-        std::get<0>(full_honk_relation_value) += x_identity;
-
-        // Contribution (2)
-        beta_term = x_2 * (y_3 + y_1) * q_beta;          // β * x_2 * (y_3 + y_1)
-        sign_term = y_2 * (x_1 - x_3) * q_sign * FF(-1); // - signt * y_2 * (x_1 - x_3)
-        // TODO: remove extra additions if we decide to stay with this implementation
-        leftovers = x_1 * (y_3 + y_1) * FF(-1) + y_1 * (x_1 - x_3); // -x_1 * y_3 - x_1 * y_1 + y_1 * x_1 - y_1 * x_3
-
-        auto y_identity = beta_term + sign_term + leftovers;
-        y_identity *= q_elliptic;
-        std::get<1>(full_honk_relation_value) += y_identity;
-    };
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 };
 // clang-format on
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
@@ -17,11 +17,11 @@ template <typename FF> class EllipticRelation {
     static constexpr size_t LEN_2 = 5; // y-coordinate sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -108,7 +108,7 @@ template <typename FF> class EllipticRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -116,7 +116,7 @@ template <typename FF> class EllipticRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 };
 // clang-format on

--- a/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
@@ -8,7 +8,7 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename FF> class EllipticRelation {
+template <typename FF> class EllipticRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6; // degree(q_elliptic * q_beta * x^3) = 5
@@ -16,12 +16,6 @@ template <typename FF> class EllipticRelation {
     static constexpr size_t LEN_1 = 6; // x-coordinate sub-relation
     static constexpr size_t LEN_2 = 5; // y-coordinate sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -34,10 +28,10 @@ template <typename FF> class EllipticRelation {
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
     template <typename TypeMuncher>
-    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
-                                    const auto& extended_edges,
-                                    const RelationParameters<FF>&,
-                                    const FF& scaling_factor) const {
+    static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+                                           const auto& extended_edges,
+                                           const RelationParameters<FF>&,
+                                           const FF& scaling_factor){
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
         // TODO(luke): Formatter doesnt properly handle explicit scoping below so turning off. Whats up?
@@ -102,22 +96,9 @@ template <typename FF> class EllipticRelation {
             std::get<1>(accumulators) += y_identity;
         }
     };
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
 };
+
+template <typename FF>
+using EllipticRelation = RelationWrapper<FF, EllipticRelationBase>;
 // clang-format on
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
@@ -19,11 +19,11 @@ template <typename FF> class GenPermSortRelation {
     static constexpr size_t LEN_4 = 6; // range constrain sub-relation 4
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -109,7 +109,7 @@ template <typename FF> class GenPermSortRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -117,7 +117,7 @@ template <typename FF> class GenPermSortRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
@@ -4,6 +4,7 @@
 
 #include "../polynomials/univariate.hpp"
 #include "relation_parameters.hpp"
+#include "relation_types.hpp"
 
 namespace proof_system::honk::sumcheck {
 
@@ -12,14 +13,17 @@ template <typename FF> class GenPermSortRelation {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6; // degree(q_sort * D(D - 1)(D - 2)(D - 3)) = 5
 
-    static constexpr size_t NUM_CONSTRAINTS = 4;
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 6, 6, 6, 6 };
+    static constexpr size_t LEN_1 = 6; // range constrain sub-relation 1
+    static constexpr size_t LEN_2 = 6; // range constrain sub-relation 2
+    static constexpr size_t LEN_3 = 6; // range constrain sub-relation 3
+    static constexpr size_t LEN_4 = 6; // range constrain sub-relation 4
+    using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[1]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[2]>,
-                                           Univariate<FF, CONSTRAINT_LENGTH[3]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -36,20 +40,22 @@ template <typename FF> class GenPermSortRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    void add_edge_contribution(RelationUnivariates& evals,
-                               const auto& extended_edges,
-                               const RelationParameters<FF>&,
-                               const FF& scaling_factor) const
+    template <typename TypeMuncher>
+    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+                                    const auto& extended_edges,
+                                    const RelationParameters<FF>&,
+                                    const FF& scaling_factor) const
     {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
 
-        auto w_1 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_l);
-        auto w_2 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_r);
-        auto w_3 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_o);
-        auto w_4 = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_4);
-        auto w_1_shift = UnivariateView<FF, RELATION_LENGTH>(extended_edges.w_l_shift);
-        auto q_sort = UnivariateView<FF, RELATION_LENGTH>(extended_edges.q_sort);
+        using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+        auto w_1 = View(extended_edges.w_l);
+        auto w_2 = View(extended_edges.w_r);
+        auto w_3 = View(extended_edges.w_o);
+        auto w_4 = View(extended_edges.w_4);
+        auto w_1_shift = View(extended_edges.w_l_shift);
+        auto q_sort = View(extended_edges.q_sort);
 
         static const FF minus_one = FF(-1);
         static const FF minus_two = FF(-2);
@@ -68,7 +74,7 @@ template <typename FF> class GenPermSortRelation {
         tmp_1 *= (delta_1 + minus_three);
         tmp_1 *= q_sort;
         tmp_1 *= scaling_factor;
-        std::get<0>(evals) += tmp_1;
+        std::get<0>(accumulators) += tmp_1;
 
         // Contribution (2)
         auto tmp_2 = delta_2;
@@ -77,7 +83,7 @@ template <typename FF> class GenPermSortRelation {
         tmp_2 *= (delta_2 + minus_three);
         tmp_2 *= q_sort;
         tmp_2 *= scaling_factor;
-        std::get<1>(evals) += tmp_2;
+        std::get<1>(accumulators) += tmp_2;
 
         // Contribution (3)
         auto tmp_3 = delta_3;
@@ -86,7 +92,7 @@ template <typename FF> class GenPermSortRelation {
         tmp_3 *= (delta_3 + minus_three);
         tmp_3 *= q_sort;
         tmp_3 *= scaling_factor;
-        std::get<2>(evals) += tmp_3;
+        std::get<2>(accumulators) += tmp_3;
 
         // Contribution (4)
         auto tmp_4 = delta_4;
@@ -95,64 +101,23 @@ template <typename FF> class GenPermSortRelation {
         tmp_4 *= (delta_4 + minus_three);
         tmp_4 *= q_sort;
         tmp_4 *= scaling_factor;
-        std::get<3>(evals) += tmp_4;
+        std::get<3>(accumulators) += tmp_4;
     };
 
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                              const auto& purported_evaluations,
-                                              const RelationParameters<FF>&) const
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
     {
-        auto w_1 = purported_evaluations.w_l;
-        auto w_2 = purported_evaluations.w_r;
-        auto w_3 = purported_evaluations.w_o;
-        auto w_4 = purported_evaluations.w_4;
-        auto w_1_shift = purported_evaluations.w_l_shift;
-        auto q_sort = purported_evaluations.q_sort;
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
-        static const FF minus_one = FF(-1);
-        static const FF minus_two = FF(-2);
-        static const FF minus_three = FF(-3);
-
-        // Compute wire differences
-        auto delta_1 = w_2 - w_1;
-        auto delta_2 = w_3 - w_2;
-        auto delta_3 = w_4 - w_3;
-        auto delta_4 = w_1_shift - w_4;
-
-        auto tmp_1 = delta_1;
-        tmp_1 *= (delta_1 + minus_one);
-        tmp_1 *= (delta_1 + minus_two);
-        tmp_1 *= (delta_1 + minus_three);
-        tmp_1 *= q_sort;
-        std::get<0>(full_honk_relation_value) += tmp_1;
-
-        auto tmp_2 = delta_2;
-        tmp_2 *= (delta_2 + minus_one);
-        tmp_2 *= (delta_2 + minus_two);
-        tmp_2 *= (delta_2 + minus_three);
-        tmp_2 *= q_sort;
-        std::get<1>(full_honk_relation_value) += tmp_2;
-
-        auto tmp_3 = delta_3;
-        tmp_3 *= (delta_3 + minus_one);
-        tmp_3 *= (delta_3 + minus_two);
-        tmp_3 *= (delta_3 + minus_three);
-        tmp_3 *= q_sort;
-        std::get<2>(full_honk_relation_value) += tmp_3;
-
-        auto tmp_4 = delta_4;
-        tmp_4 *= (delta_4 + minus_one);
-        tmp_4 *= (delta_4 + minus_two);
-        tmp_4 *= (delta_4 + minus_three);
-        tmp_4 *= q_sort;
-        std::get<3>(full_honk_relation_value) += tmp_4;
-    };
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
@@ -8,7 +8,7 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename FF> class GenPermSortRelation {
+template <typename FF> class GenPermSortRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6; // degree(q_sort * D(D - 1)(D - 2)(D - 3)) = 5
@@ -18,12 +18,6 @@ template <typename FF> class GenPermSortRelation {
     static constexpr size_t LEN_3 = 6; // range constrain sub-relation 3
     static constexpr size_t LEN_4 = 6; // range constrain sub-relation 4
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -41,10 +35,10 @@ template <typename FF> class GenPermSortRelation {
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
     template <typename TypeMuncher>
-    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
-                                    const auto& extended_edges,
-                                    const RelationParameters<FF>&,
-                                    const FF& scaling_factor) const
+    void static add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+                                           const auto& extended_edges,
+                                           const RelationParameters<FF>&,
+                                           const FF& scaling_factor)
     {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
@@ -103,21 +97,8 @@ template <typename FF> class GenPermSortRelation {
         tmp_4 *= scaling_factor;
         std::get<3>(accumulators) += tmp_4;
     };
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
 };
+
+template <typename FF> using GenPermSortRelation = RelationWrapper<FF, GenPermSortRelationBase>;
+
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
@@ -8,7 +8,7 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename FF> class LookupRelation {
+template <typename FF> class LookupRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6; // deg(z_lookup * column_selector * wire * q_lookup * table) = 5
@@ -16,12 +16,6 @@ template <typename FF> class LookupRelation {
     static constexpr size_t LEN_1 = 6; // grand product construction sub-relation
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the lookup grand prod relation for a given edge (internal function)
@@ -120,21 +114,8 @@ template <typename FF> class LookupRelation {
             std::get<1>(accumulators) += (lagrange_last * z_lookup_shift) * scaling_factor;
         }
     };
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
 };
+
+template <typename FF> using LookupRelation = RelationWrapper<FF, LookupRelationBase>;
+
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
@@ -17,11 +17,11 @@ template <typename FF> class LookupRelation {
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the lookup grand prod relation for a given edge (internal function)
@@ -126,7 +126,7 @@ template <typename FF> class LookupRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -134,7 +134,7 @@ template <typename FF> class LookupRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "relation_parameters.hpp"
 #include "../polynomials/univariate.hpp"
+#include "relation_types.hpp"
 
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -12,11 +13,15 @@ template <typename FF> class LookupRelation {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6; // deg(z_lookup * column_selector * wire * q_lookup * table) = 5
 
-    static constexpr size_t NUM_CONSTRAINTS = 2;
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 6, 3 };
+    static constexpr size_t LEN_1 = 6; // grand product construction sub-relation
+    static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
+    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>, Univariate<FF, CONSTRAINT_LENGTH[1]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the lookup grand prod relation for a given edge (internal function)
@@ -36,10 +41,11 @@ template <typename FF> class LookupRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    inline void add_edge_contribution(RelationUnivariates& evals,
-                                      const auto& extended_edges,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
+    template <typename TypeMuncher>
+    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+                                                  const auto& extended_edges,
+                                                  const RelationParameters<FF>& relation_parameters,
+                                                  const FF& scaling_factor)
     {
         const auto& eta = relation_parameters.eta;
         const auto& beta = relation_parameters.beta;
@@ -53,39 +59,39 @@ template <typename FF> class LookupRelation {
 
         // Contribution (1)
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[0];
-            auto w_1 = UnivariateView<FF, LENGTH>(extended_edges.w_l);
-            auto w_2 = UnivariateView<FF, LENGTH>(extended_edges.w_r);
-            auto w_3 = UnivariateView<FF, LENGTH>(extended_edges.w_o);
+            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            auto w_1 = View(extended_edges.w_l);
+            auto w_2 = View(extended_edges.w_r);
+            auto w_3 = View(extended_edges.w_o);
 
-            auto w_1_shift = UnivariateView<FF, LENGTH>(extended_edges.w_l_shift);
-            auto w_2_shift = UnivariateView<FF, LENGTH>(extended_edges.w_r_shift);
-            auto w_3_shift = UnivariateView<FF, LENGTH>(extended_edges.w_o_shift);
+            auto w_1_shift = View(extended_edges.w_l_shift);
+            auto w_2_shift = View(extended_edges.w_r_shift);
+            auto w_3_shift = View(extended_edges.w_o_shift);
 
-            auto table_1 = UnivariateView<FF, LENGTH>(extended_edges.table_1);
-            auto table_2 = UnivariateView<FF, LENGTH>(extended_edges.table_2);
-            auto table_3 = UnivariateView<FF, LENGTH>(extended_edges.table_3);
-            auto table_4 = UnivariateView<FF, LENGTH>(extended_edges.table_4);
+            auto table_1 = View(extended_edges.table_1);
+            auto table_2 = View(extended_edges.table_2);
+            auto table_3 = View(extended_edges.table_3);
+            auto table_4 = View(extended_edges.table_4);
 
-            auto table_1_shift = UnivariateView<FF, LENGTH>(extended_edges.table_1_shift);
-            auto table_2_shift = UnivariateView<FF, LENGTH>(extended_edges.table_2_shift);
-            auto table_3_shift = UnivariateView<FF, LENGTH>(extended_edges.table_3_shift);
-            auto table_4_shift = UnivariateView<FF, LENGTH>(extended_edges.table_4_shift);
+            auto table_1_shift = View(extended_edges.table_1_shift);
+            auto table_2_shift = View(extended_edges.table_2_shift);
+            auto table_3_shift = View(extended_edges.table_3_shift);
+            auto table_4_shift = View(extended_edges.table_4_shift);
 
-            auto s_accum = UnivariateView<FF, LENGTH>(extended_edges.sorted_accum);
-            auto s_accum_shift = UnivariateView<FF, LENGTH>(extended_edges.sorted_accum_shift);
+            auto s_accum = View(extended_edges.sorted_accum);
+            auto s_accum_shift = View(extended_edges.sorted_accum_shift);
 
-            auto z_lookup = UnivariateView<FF, LENGTH>(extended_edges.z_lookup);
-            auto z_lookup_shift = UnivariateView<FF, LENGTH>(extended_edges.z_lookup_shift);
+            auto z_lookup = View(extended_edges.z_lookup);
+            auto z_lookup_shift = View(extended_edges.z_lookup_shift);
 
-            auto table_index = UnivariateView<FF, LENGTH>(extended_edges.q_o);
-            auto column_1_step_size = UnivariateView<FF, LENGTH>(extended_edges.q_r);
-            auto column_2_step_size = UnivariateView<FF, LENGTH>(extended_edges.q_m);
-            auto column_3_step_size = UnivariateView<FF, LENGTH>(extended_edges.q_c);
-            auto q_lookup = UnivariateView<FF, LENGTH>(extended_edges.q_lookup);
+            auto table_index = View(extended_edges.q_o);
+            auto column_1_step_size = View(extended_edges.q_r);
+            auto column_2_step_size = View(extended_edges.q_m);
+            auto column_3_step_size = View(extended_edges.q_c);
+            auto q_lookup = View(extended_edges.q_lookup);
 
-            auto lagrange_first = UnivariateView<FF, LENGTH>(extended_edges.lagrange_first);
-            auto lagrange_last = UnivariateView<FF, LENGTH>(extended_edges.lagrange_last);
+            auto lagrange_first = View(extended_edges.lagrange_first);
+            auto lagrange_last = View(extended_edges.lagrange_last);
 
             // (w_1 + q_2*w_1_shift) + η(w_2 + q_m*w_2_shift) + η²(w_3 + q_c*w_3_shift) + η³q_index.
             auto wire_accum = (w_1 + column_1_step_size * w_1_shift) + (w_2 + column_2_step_size * w_2_shift) * eta +
@@ -103,93 +109,32 @@ template <typename FF> class LookupRelation {
             tmp *= (z_lookup + lagrange_first);
             tmp -= (z_lookup_shift + lagrange_last * grand_product_delta) *
                    (s_accum + s_accum_shift * beta + gamma_by_one_plus_beta);
-            std::get<0>(evals) += tmp * scaling_factor;
+            std::get<0>(accumulators) += tmp * scaling_factor;
         }
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[1];
-            auto z_lookup_shift = UnivariateView<FF, LENGTH>(extended_edges.z_lookup_shift);
-            auto lagrange_last = UnivariateView<FF, LENGTH>(extended_edges.lagrange_last);
+            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            auto z_lookup_shift = View(extended_edges.z_lookup_shift);
+            auto lagrange_last = View(extended_edges.lagrange_last);
 
             // Contribution (2)
-            std::get<1>(evals) += (lagrange_last * z_lookup_shift) * scaling_factor;
+            std::get<1>(accumulators) += (lagrange_last * z_lookup_shift) * scaling_factor;
         }
     };
 
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                              auto& purported_evaluations,
-                                              const RelationParameters<FF>& relation_parameters) const
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
     {
-        const auto& eta = relation_parameters.eta;
-        const auto& beta = relation_parameters.beta;
-        const auto& gamma = relation_parameters.gamma;
-        const auto& grand_product_delta = relation_parameters.lookup_grand_product_delta;
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
-        const auto one_plus_beta = FF::one() + beta;
-        const auto gamma_by_one_plus_beta = gamma * one_plus_beta;
-        const auto eta_sqr = eta * eta;
-        const auto eta_cube = eta_sqr * eta;
-
-        auto w_1 = purported_evaluations.w_l;
-        auto w_2 = purported_evaluations.w_r;
-        auto w_3 = purported_evaluations.w_o;
-
-        auto w_1_shift = purported_evaluations.w_l_shift;
-        auto w_2_shift = purported_evaluations.w_r_shift;
-        auto w_3_shift = purported_evaluations.w_o_shift;
-
-        auto table_1 = purported_evaluations.table_1;
-        auto table_2 = purported_evaluations.table_2;
-        auto table_3 = purported_evaluations.table_3;
-        auto table_4 = purported_evaluations.table_4;
-
-        auto table_1_shift = purported_evaluations.table_1_shift;
-        auto table_2_shift = purported_evaluations.table_2_shift;
-        auto table_3_shift = purported_evaluations.table_3_shift;
-        auto table_4_shift = purported_evaluations.table_4_shift;
-
-        auto s_accum = purported_evaluations.sorted_accum;
-        auto s_accum_shift = purported_evaluations.sorted_accum_shift;
-
-        auto z_lookup = purported_evaluations.z_lookup;
-        auto z_lookup_shift = purported_evaluations.z_lookup_shift;
-
-        auto table_index = purported_evaluations.q_o;
-        auto column_1_step_size = purported_evaluations.q_r;
-        auto column_2_step_size = purported_evaluations.q_m;
-        auto column_3_step_size = purported_evaluations.q_c;
-        auto q_lookup = purported_evaluations.q_lookup;
-
-        auto lagrange_first = purported_evaluations.lagrange_first;
-        auto lagrange_last = purported_evaluations.lagrange_last;
-
-        // (w_1 + q_2*w_1_shift) + η(w_2 + q_m*w_2_shift) + η²(w_3 + q_c*w_3_shift) + η³q_index.
-        auto wire_accum = (w_1 + column_1_step_size * w_1_shift) + (w_2 + column_2_step_size * w_2_shift) * eta +
-                          (w_3 + column_3_step_size * w_3_shift) * eta_sqr + table_index * eta_cube;
-
-        // t_1 + ηt_2 + η²t_3 + η³t_4
-        auto table_accum = table_1 + table_2 * eta + table_3 * eta_sqr + table_4 * eta_cube;
-        // t_1_shift + ηt_2_shift + η²t_3_shift + η³t_4_shift
-        auto table_accum_shift =
-            table_1_shift + table_2_shift * eta + table_3_shift * eta_sqr + table_4_shift * eta_cube;
-
-        // Contribution (1)
-        auto tmp = (q_lookup * wire_accum + gamma);
-        tmp *= (table_accum + beta * table_accum_shift + gamma_by_one_plus_beta);
-        tmp *= one_plus_beta;
-        tmp *= (z_lookup + lagrange_first);
-        tmp -= (z_lookup_shift + lagrange_last * grand_product_delta) *
-               (s_accum + beta * s_accum_shift + gamma_by_one_plus_beta);
-        std::get<0>(full_honk_relation_value) += tmp;
-
-        // Contribution (2)
-        std::get<1>(full_honk_relation_value) += lagrange_last * z_lookup_shift;
-    };
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
@@ -15,11 +15,11 @@ template <typename FF> class PermutationRelation {
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -88,7 +88,7 @@ template <typename FF> class PermutationRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -96,7 +96,7 @@ template <typename FF> class PermutationRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     /**
@@ -119,11 +119,11 @@ template <typename FF> class UltraPermutationRelation {
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -188,7 +188,7 @@ template <typename FF> class UltraPermutationRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -196,7 +196,7 @@ template <typename FF> class UltraPermutationRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "relation_parameters.hpp"
 #include "../polynomials/univariate.hpp"
+#include "relation_types.hpp"
 // TODO(luke): change name of this file to permutation_grand_product_relation(s).hpp and move 'init' relation into it.
 
 namespace proof_system::honk::sumcheck {
@@ -10,11 +11,15 @@ template <typename FF> class PermutationRelation {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 5;
 
-    static constexpr size_t NUM_CONSTRAINTS = 2;
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 5, 3 };
+    static constexpr size_t LEN_1 = 5; // grand product construction sub-relation
+    static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
+    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>, Univariate<FF, CONSTRAINT_LENGTH[1]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -34,33 +39,34 @@ template <typename FF> class PermutationRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    inline void add_edge_contribution(RelationUnivariates& evals,
-                                      const auto& extended_edges,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
+    template <typename TypeMuncher>
+    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulator,
+                                                  const auto& input,
+                                                  const RelationParameters<FF>& relation_parameters,
+                                                  const FF& scaling_factor)
     {
         const auto& beta = relation_parameters.beta;
         const auto& gamma = relation_parameters.gamma;
         const auto& public_input_delta = relation_parameters.public_input_delta;
 
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[0];
-            auto w_1 = UnivariateView<FF, LENGTH>(extended_edges.w_l);
-            auto w_2 = UnivariateView<FF, LENGTH>(extended_edges.w_r);
-            auto w_3 = UnivariateView<FF, LENGTH>(extended_edges.w_o);
-            auto sigma_1 = UnivariateView<FF, LENGTH>(extended_edges.sigma_1);
-            auto sigma_2 = UnivariateView<FF, LENGTH>(extended_edges.sigma_2);
-            auto sigma_3 = UnivariateView<FF, LENGTH>(extended_edges.sigma_3);
-            auto id_1 = UnivariateView<FF, LENGTH>(extended_edges.id_1);
-            auto id_2 = UnivariateView<FF, LENGTH>(extended_edges.id_2);
-            auto id_3 = UnivariateView<FF, LENGTH>(extended_edges.id_3);
-            auto z_perm = UnivariateView<FF, LENGTH>(extended_edges.z_perm);
-            auto z_perm_shift = UnivariateView<FF, LENGTH>(extended_edges.z_perm_shift);
-            auto lagrange_first = UnivariateView<FF, LENGTH>(extended_edges.lagrange_first);
-            auto lagrange_last = UnivariateView<FF, LENGTH>(extended_edges.lagrange_last);
+            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            auto w_1 = View(input.w_l);
+            auto w_2 = View(input.w_r);
+            auto w_3 = View(input.w_o);
+            auto sigma_1 = View(input.sigma_1);
+            auto sigma_2 = View(input.sigma_2);
+            auto sigma_3 = View(input.sigma_3);
+            auto id_1 = View(input.id_1);
+            auto id_2 = View(input.id_2);
+            auto id_3 = View(input.id_3);
+            auto z_perm = View(input.z_perm);
+            auto z_perm_shift = View(input.z_perm_shift);
+            auto lagrange_first = View(input.lagrange_first);
+            auto lagrange_last = View(input.lagrange_last);
 
             // Contribution (1)
-            std::get<0>(evals) +=
+            std::get<0>(accumulator) +=
                 (((z_perm + lagrange_first) * (w_1 + id_1 * beta + gamma) * (w_2 + id_2 * beta + gamma) *
                   (w_3 + id_3 * beta + gamma)) -
                  ((z_perm_shift + lagrange_last * public_input_delta) * (w_1 + sigma_1 * beta + gamma) *
@@ -68,14 +74,30 @@ template <typename FF> class PermutationRelation {
                 scaling_factor;
         }
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[1];
-            auto z_perm_shift = UnivariateView<FF, LENGTH>(extended_edges.z_perm_shift);
-            auto lagrange_last = UnivariateView<FF, LENGTH>(extended_edges.lagrange_last);
+            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            auto z_perm_shift = View(input.z_perm_shift);
+            auto lagrange_last = View(input.lagrange_last);
 
             // Contribution (2)
-            std::get<1>(evals) += (lagrange_last * z_perm_shift) * scaling_factor;
+            std::get<1>(accumulator) += (lagrange_last * z_perm_shift) * scaling_factor;
         }
     };
+
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
+    {
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
+
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
     /**
      * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
@@ -84,38 +106,6 @@ template <typename FF> class PermutationRelation {
      * @param full_honk_relation_value
      * @param purported_evaluations
      */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                              auto& purported_evaluations,
-                                              const RelationParameters<FF>& relation_parameters) const
-    {
-        const auto& beta = relation_parameters.beta;
-        const auto& gamma = relation_parameters.gamma;
-        const auto& public_input_delta = relation_parameters.public_input_delta;
-
-        auto w_1 = purported_evaluations.w_l;
-        auto w_2 = purported_evaluations.w_r;
-        auto w_3 = purported_evaluations.w_o;
-        auto sigma_1 = purported_evaluations.sigma_1;
-        auto sigma_2 = purported_evaluations.sigma_2;
-        auto sigma_3 = purported_evaluations.sigma_3;
-        auto id_1 = purported_evaluations.id_1;
-        auto id_2 = purported_evaluations.id_2;
-        auto id_3 = purported_evaluations.id_3;
-        auto z_perm = purported_evaluations.z_perm;
-        auto z_perm_shift = purported_evaluations.z_perm_shift;
-        auto lagrange_first = purported_evaluations.lagrange_first;
-        auto lagrange_last = purported_evaluations.lagrange_last;
-
-        // Contribution (1)
-        std::get<0>(full_honk_relation_value) +=
-            ((z_perm + lagrange_first) * (w_1 + beta * id_1 + gamma) * (w_2 + beta * id_2 + gamma) *
-                 (w_3 + beta * id_3 + gamma) -
-             (z_perm_shift + lagrange_last * public_input_delta) * (w_1 + beta * sigma_1 + gamma) *
-                 (w_2 + beta * sigma_2 + gamma) * (w_3 + beta * sigma_3 + gamma));
-
-        // Contribution (2)
-        std::get<1>(full_honk_relation_value) += lagrange_last * z_perm_shift;
-    };
 };
 
 // TODO(luke): With Cody's Flavor work it should be easier to create a simple templated relation
@@ -125,11 +115,15 @@ template <typename FF> class UltraPermutationRelation {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6;
 
-    static constexpr size_t NUM_CONSTRAINTS = 2;
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 6, 3 };
+    static constexpr size_t LEN_1 = 6; // grand product construction sub-relation
+    static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
+    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>, Univariate<FF, CONSTRAINT_LENGTH[1]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -142,10 +136,11 @@ template <typename FF> class UltraPermutationRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    inline void add_edge_contribution(RelationUnivariates& evals,
-                                      const auto& extended_edges,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
+    template <typename TypeMuncher>
+    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+                                                  const auto& extended_edges,
+                                                  const RelationParameters<FF>& relation_parameters,
+                                                  const FF& scaling_factor)
     {
         const auto& beta = relation_parameters.beta;
         const auto& gamma = relation_parameters.gamma;
@@ -153,25 +148,25 @@ template <typename FF> class UltraPermutationRelation {
 
         // Contribution (1)
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[0];
-            auto w_1 = UnivariateView<FF, LENGTH>(extended_edges.w_l);
-            auto w_2 = UnivariateView<FF, LENGTH>(extended_edges.w_r);
-            auto w_3 = UnivariateView<FF, LENGTH>(extended_edges.w_o);
-            auto w_4 = UnivariateView<FF, LENGTH>(extended_edges.w_4);
-            auto sigma_1 = UnivariateView<FF, LENGTH>(extended_edges.sigma_1);
-            auto sigma_2 = UnivariateView<FF, LENGTH>(extended_edges.sigma_2);
-            auto sigma_3 = UnivariateView<FF, LENGTH>(extended_edges.sigma_3);
-            auto sigma_4 = UnivariateView<FF, LENGTH>(extended_edges.sigma_4);
-            auto id_1 = UnivariateView<FF, LENGTH>(extended_edges.id_1);
-            auto id_2 = UnivariateView<FF, LENGTH>(extended_edges.id_2);
-            auto id_3 = UnivariateView<FF, LENGTH>(extended_edges.id_3);
-            auto id_4 = UnivariateView<FF, LENGTH>(extended_edges.id_4);
-            auto z_perm = UnivariateView<FF, LENGTH>(extended_edges.z_perm);
-            auto z_perm_shift = UnivariateView<FF, LENGTH>(extended_edges.z_perm_shift);
-            auto lagrange_first = UnivariateView<FF, LENGTH>(extended_edges.lagrange_first);
-            auto lagrange_last = UnivariateView<FF, LENGTH>(extended_edges.lagrange_last);
+            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            auto w_1 = View(extended_edges.w_l);
+            auto w_2 = View(extended_edges.w_r);
+            auto w_3 = View(extended_edges.w_o);
+            auto w_4 = View(extended_edges.w_4);
+            auto sigma_1 = View(extended_edges.sigma_1);
+            auto sigma_2 = View(extended_edges.sigma_2);
+            auto sigma_3 = View(extended_edges.sigma_3);
+            auto sigma_4 = View(extended_edges.sigma_4);
+            auto id_1 = View(extended_edges.id_1);
+            auto id_2 = View(extended_edges.id_2);
+            auto id_3 = View(extended_edges.id_3);
+            auto id_4 = View(extended_edges.id_4);
+            auto z_perm = View(extended_edges.z_perm);
+            auto z_perm_shift = View(extended_edges.z_perm_shift);
+            auto lagrange_first = View(extended_edges.lagrange_first);
+            auto lagrange_last = View(extended_edges.lagrange_last);
 
-            std::get<0>(evals) +=
+            std::get<0>(accumulators) +=
                 (((z_perm + lagrange_first) * (w_1 + id_1 * beta + gamma) * (w_2 + id_2 * beta + gamma) *
                   (w_3 + id_3 * beta + gamma) * (w_4 + id_4 * beta + gamma)) -
                  ((z_perm_shift + lagrange_last * public_input_delta) * (w_1 + sigma_1 * beta + gamma) *
@@ -180,55 +175,28 @@ template <typename FF> class UltraPermutationRelation {
         }
         // Contribution (2)
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[1];
-            auto z_perm_shift = UnivariateView<FF, LENGTH>(extended_edges.z_perm_shift);
-            auto lagrange_last = UnivariateView<FF, LENGTH>(extended_edges.lagrange_last);
+            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            auto z_perm_shift = View(extended_edges.z_perm_shift);
+            auto lagrange_last = View(extended_edges.lagrange_last);
 
-            std::get<1>(evals) += (lagrange_last * z_perm_shift) * scaling_factor;
+            std::get<1>(accumulators) += (lagrange_last * z_perm_shift) * scaling_factor;
         }
     };
 
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                              auto& purported_evaluations,
-                                              const RelationParameters<FF>& relation_parameters) const
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
     {
-        const auto& beta = relation_parameters.beta;
-        const auto& gamma = relation_parameters.gamma;
-        const auto& public_input_delta = relation_parameters.public_input_delta;
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
-        auto w_1 = purported_evaluations.w_l;
-        auto w_2 = purported_evaluations.w_r;
-        auto w_3 = purported_evaluations.w_o;
-        auto w_4 = purported_evaluations.w_4;
-        auto sigma_1 = purported_evaluations.sigma_1;
-        auto sigma_2 = purported_evaluations.sigma_2;
-        auto sigma_3 = purported_evaluations.sigma_3;
-        auto sigma_4 = purported_evaluations.sigma_4;
-        auto id_1 = purported_evaluations.id_1;
-        auto id_2 = purported_evaluations.id_2;
-        auto id_3 = purported_evaluations.id_3;
-        auto id_4 = purported_evaluations.id_4;
-        auto z_perm = purported_evaluations.z_perm;
-        auto z_perm_shift = purported_evaluations.z_perm_shift;
-        auto lagrange_first = purported_evaluations.lagrange_first;
-        auto lagrange_last = purported_evaluations.lagrange_last;
-
-        // Contribution (1)
-        std::get<0>(full_honk_relation_value) +=
-            ((z_perm + lagrange_first) * (w_1 + beta * id_1 + gamma) * (w_2 + beta * id_2 + gamma) *
-                 (w_3 + beta * id_3 + gamma) * (w_4 + beta * id_4 + gamma) -
-             (z_perm_shift + lagrange_last * public_input_delta) * (w_1 + beta * sigma_1 + gamma) *
-                 (w_2 + beta * sigma_2 + gamma) * (w_3 + beta * sigma_3 + gamma) * (w_4 + beta * sigma_4 + gamma));
-
-        // Contribution (2)
-        std::get<1>(full_honk_relation_value) += lagrange_last * z_perm_shift;
-    };
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 };
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
@@ -6,7 +6,7 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename FF> class PermutationRelation {
+template <typename FF> class PermutationRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 5;
@@ -14,12 +14,6 @@ template <typename FF> class PermutationRelation {
     static constexpr size_t LEN_1 = 5; // grand product construction sub-relation
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -82,35 +76,11 @@ template <typename FF> class PermutationRelation {
             std::get<1>(accumulator) += (lagrange_last * z_perm_shift) * scaling_factor;
         }
     };
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
 };
 
 // TODO(luke): With Cody's Flavor work it should be easier to create a simple templated relation
 // for handling arbitrary width. For now I'm duplicating the width 3 logic for width 4.
-template <typename FF> class UltraPermutationRelation {
+template <typename FF> class UltraPermutationRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6;
@@ -118,12 +88,6 @@ template <typename FF> class UltraPermutationRelation {
     static constexpr size_t LEN_1 = 6; // grand product construction sub-relation
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -182,21 +146,9 @@ template <typename FF> class UltraPermutationRelation {
             std::get<1>(accumulators) += (lagrange_last * z_perm_shift) * scaling_factor;
         }
     };
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
 };
+
+template <typename FF> using PermutationRelation = RelationWrapper<FF, PermutationRelationBase>;
+
+template <typename FF> using UltraPermutationRelation = RelationWrapper<FF, UltraPermutationRelationBase>;
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_consistency.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_consistency.test.cpp
@@ -216,8 +216,8 @@ TEST_F(StandardRelationConsistency, ArithmeticRelation)
 
         // Compute expected full length Univariates using straight forward expressions.
         // Note: expect { { 5, 22, 57, 116, 205} } for input polynomial {1, 2}
-        constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-        auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+        constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+        auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
         expected_full_length_univariates[0] = (q_m * w_r * w_l) + (q_r * w_r) + (q_l * w_l) + (q_o * w_o) + (q_c);
         validate_evaluations(expected_full_length_univariates, relation, extended_edges, relation_parameters);
@@ -274,8 +274,8 @@ TEST_F(StandardRelationConsistency, PermutationRelation)
         const auto& lagrange_last = extended_edges.lagrange_last;
 
         // Compute expected full length Univariates using straight forward expressions
-        constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-        auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+        constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+        auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
         expected_full_length_univariates[0] = (z_perm + lagrange_first) * (w_1 + id_1 * beta + gamma) *
                                                   (w_2 + id_2 * beta + gamma) * (w_3 + id_3 * beta + gamma) -

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_types.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_types.hpp
@@ -7,6 +7,21 @@
 
 namespace proof_system::honk::sumcheck {
 
+/**
+ * @brief The templates defined herein facilitate sharing the relation arithmetic between the prover and the verifier.
+ *
+ * The sumcheck prover and verifier accumulate the contributions from each relation (really, each sub-relation) into,
+ * respectively, Univariates and individual field elements. When performing relation arithmetic on Univariates, we
+ * introduce UnivariateViews to reduce full length Univariates to the minimum required length and to avoid unnecessary
+ * copies.
+ *
+ * To share the relation arithmetic, we introduce simple structs that specify two types: Accumulators and
+ * AccumulatorViews. For the prover, who accumulates Univariates, these are respectively std::tuple<Univariate> and
+ * std::tuple<UnivariateView>. For the verifier, who accumulates FFs, both types are simply aliases for std::array<FF>
+ * (since no "view" type is necessary). The containers std::tuple and std::array are needed to accommodate multiple
+ * sub-relations within each relation, where, for efficiency, each sub-relation has its own specified degree.
+ */
+
 // Helper struct to allow passing an arbitrary collection of lengths to the AccumulatorTypes
 template <size_t... Values> struct LengthsWrapper {};
 
@@ -17,7 +32,7 @@ template <typename FF, typename LengthsWrapper> struct ValueAccumulatorTypesHelp
 // Helper to define value (FF) based accumulator types
 template <typename FF, size_t... Values> struct ValueAccumulatorTypesHelper<FF, LengthsWrapper<Values...>> {
     using Accumulators = std::array<FF, sizeof...(Values)>;
-    using AccumulatorViews = std::array<FF, sizeof...(Values)>;
+    using AccumulatorViews = std::array<FF, sizeof...(Values)>; // there is no "view" type here
 };
 
 // Accumulator types for values (FFs)

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_types.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_types.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <array>
+#include <tuple>
+
+#include "../polynomials/univariate.hpp"
+#include "relation_parameters.hpp"
+
+namespace proof_system::honk::sumcheck {
+
+// Helper struct to allow passing an arbitrary collection of lengths to the AccumulatorTypes
+template <size_t... Values> struct LengthsWrapper {};
+
+// Forward declarations of AccumulatorTypesHelpers
+template <typename FF, typename LengthsWrapper> struct UnivariateAccumulatorTypesHelper;
+template <typename FF, typename LengthsWrapper> struct ValueAccumulatorTypesHelper;
+
+// Helper to define value (FF) based accumulator types
+template <typename FF, size_t... Values> struct ValueAccumulatorTypesHelper<FF, LengthsWrapper<Values...>> {
+    using Accumulators = std::array<FF, sizeof...(Values)>;
+    using AccumulatorViews = std::array<FF, sizeof...(Values)>;
+};
+
+// Accumulator types for values (FFs)
+template <typename FF, typename Lengths> using ValueAccumulatorTypes = ValueAccumulatorTypesHelper<FF, Lengths>;
+
+// Helper to define Univariate based accumulator types
+template <typename FF, size_t... Values> struct UnivariateAccumulatorTypesHelper<FF, LengthsWrapper<Values...>> {
+    using Accumulators = std::tuple<Univariate<FF, Values>...>;
+    using AccumulatorViews = std::tuple<UnivariateView<FF, Values>...>;
+};
+
+// Accumulator types for Univariates
+template <typename FF, typename Lengths>
+using UnivariateAccumulatorTypes = UnivariateAccumulatorTypesHelper<FF, Lengths>;
+
+} // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
@@ -8,7 +8,7 @@
 
 namespace proof_system::honk::sumcheck {
 
-template <typename FF> class UltraArithmeticRelation {
+template <typename FF> class UltraArithmeticRelationBase {
   public:
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6; // degree(q_arith^2 * q_m * w_r * w_l) = 5
@@ -16,12 +16,6 @@ template <typename FF> class UltraArithmeticRelation {
     static constexpr size_t LEN_1 = 6; // primary arithmetic sub-relation
     static constexpr size_t LEN_2 = 5; // secondary arithmetic sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
-
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
-
-    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
-    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -75,10 +69,10 @@ template <typename FF> class UltraArithmeticRelation {
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
     template <typename TypeMuncher>
-    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& evals,
-                                    const auto& extended_edges,
-                                    const RelationParameters<FF>&,
-                                    const FF& scaling_factor) const {
+    void static add_edge_contribution_impl(typename TypeMuncher::Accumulators& evals,
+                                           const auto& extended_edges,
+                                           const RelationParameters<FF>&,
+                                           const FF& scaling_factor){
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
         // clang-format off
@@ -124,22 +118,10 @@ template <typename FF> class UltraArithmeticRelation {
             std::get<1>(evals) += tmp;
         }
     }; // namespace proof_system::honk::sumcheck
-
-    inline void add_edge_contribution(auto& accumulator,
-                                      const auto& input,
-                                      const RelationParameters<FF>& relation_parameters,
-                                      const FF& scaling_factor) const
-    {
-        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
-
-    void add_full_relation_value_contribution(RelationValues& accumulator,
-                                              auto& input,
-                                              const RelationParameters<FF>& relation_parameters,
-                                              const FF& scaling_factor = 1) const
-    {
-        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
-    }
 };
+
+template <typename FF>
+using UltraArithmeticRelation = RelationWrapper<FF, UltraArithmeticRelationBase>;
+
 // clang-format on
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
@@ -4,6 +4,7 @@
 
 #include "../polynomials/univariate.hpp"
 #include "relation_parameters.hpp"
+#include "relation_types.hpp"
 
 namespace proof_system::honk::sumcheck {
 
@@ -12,12 +13,15 @@ template <typename FF> class UltraArithmeticRelation {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6; // degree(q_arith^2 * q_m * w_r * w_l) = 5
 
-    static constexpr size_t NUM_CONSTRAINTS = 2;
-    // TODO(luke): The degree of the identities varies based on q_arith. Can we do something to improve efficiency here?
-    static constexpr std::array<size_t, NUM_CONSTRAINTS> CONSTRAINT_LENGTH = { 6, 5 };
+    static constexpr size_t LEN_1 = 6; // primary arithmetic sub-relation
+    static constexpr size_t LEN_2 = 5; // secondary arithmetic sub-relation
+    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using RelationUnivariates = std::tuple<Univariate<FF, CONSTRAINT_LENGTH[0]>, Univariate<FF, CONSTRAINT_LENGTH[1]>>;
-    using RelationValues = std::array<FF, NUM_CONSTRAINTS>;
+    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+
+    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
+    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -70,28 +74,29 @@ template <typename FF> class UltraArithmeticRelation {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    void add_edge_contribution(RelationUnivariates& evals,
-                               const auto& extended_edges,
-                               const RelationParameters<FF>&,
-                               const FF& scaling_factor) const {
+    template <typename TypeMuncher>
+    void add_edge_contribution_impl(typename TypeMuncher::Accumulators& evals,
+                                    const auto& extended_edges,
+                                    const RelationParameters<FF>&,
+                                    const FF& scaling_factor) const {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
         // clang-format off
         // Contribution 1
         {   
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[0];
-            auto w_l = UnivariateView<FF, LENGTH>(extended_edges.w_l);
-            auto w_r = UnivariateView<FF, LENGTH>(extended_edges.w_r);
-            auto w_o = UnivariateView<FF, LENGTH>(extended_edges.w_o);
-            auto w_4 = UnivariateView<FF, LENGTH>(extended_edges.w_4);
-            auto w_4_shift = UnivariateView<FF, LENGTH>(extended_edges.w_4_shift);
-            auto q_m = UnivariateView<FF, LENGTH>(extended_edges.q_m);
-            auto q_l = UnivariateView<FF, LENGTH>(extended_edges.q_l);
-            auto q_r = UnivariateView<FF, LENGTH>(extended_edges.q_r);
-            auto q_o = UnivariateView<FF, LENGTH>(extended_edges.q_o);
-            auto q_4 = UnivariateView<FF, LENGTH>(extended_edges.q_4);
-            auto q_c = UnivariateView<FF, LENGTH>(extended_edges.q_c);
-            auto q_arith = UnivariateView<FF, LENGTH>(extended_edges.q_arith);
+            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            auto w_l = View(extended_edges.w_l);
+            auto w_r = View(extended_edges.w_r);
+            auto w_o = View(extended_edges.w_o);
+            auto w_4 = View(extended_edges.w_4);
+            auto w_4_shift = View(extended_edges.w_4_shift);
+            auto q_m = View(extended_edges.q_m);
+            auto q_l = View(extended_edges.q_l);
+            auto q_r = View(extended_edges.q_r);
+            auto q_o = View(extended_edges.q_o);
+            auto q_4 = View(extended_edges.q_4);
+            auto q_c = View(extended_edges.q_c);
+            auto q_arith = View(extended_edges.q_arith);
 
             static const FF neg_half = FF(-2).invert();
 
@@ -104,12 +109,12 @@ template <typename FF> class UltraArithmeticRelation {
         }
         // Contribution 2
         {
-            static constexpr size_t LENGTH = CONSTRAINT_LENGTH[1];
-            auto w_l = UnivariateView<FF, LENGTH>(extended_edges.w_l);
-            auto w_4 = UnivariateView<FF, LENGTH>(extended_edges.w_4);
-            auto w_l_shift = UnivariateView<FF, LENGTH>(extended_edges.w_l_shift);
-            auto q_m = UnivariateView<FF, LENGTH>(extended_edges.q_m);
-            auto q_arith = UnivariateView<FF, LENGTH>(extended_edges.q_arith);
+            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            auto w_l = View(extended_edges.w_l);
+            auto w_4 = View(extended_edges.w_4);
+            auto w_l_shift = View(extended_edges.w_l_shift);
+            auto q_m = View(extended_edges.q_m);
+            auto q_arith = View(extended_edges.q_arith);
 
             auto tmp = w_l + w_4 - w_l_shift + q_m;
             tmp *= (q_arith - 2);
@@ -120,47 +125,21 @@ template <typename FF> class UltraArithmeticRelation {
         }
     }; // namespace proof_system::honk::sumcheck
 
-    /**
-     * @brief Add the result of each identity in this relation evaluated at the multivariate evaluations produced by the
-     * Sumcheck Prover.
-     *
-     * @param full_honk_relation_value
-     * @param purported_evaluations
-     */
-    void add_full_relation_value_contribution(RelationValues& full_honk_relation_value,
-                                          const auto& purported_evaluations,
-                                          const RelationParameters<FF>&) const
+    inline void add_edge_contribution(auto& accumulator,
+                                      const auto& input,
+                                      const RelationParameters<FF>& relation_parameters,
+                                      const FF& scaling_factor) const
     {
-        auto w_l = purported_evaluations.w_l;
-        auto w_l_shift = purported_evaluations.w_l_shift;
-        auto w_r = purported_evaluations.w_r;
-        auto w_o = purported_evaluations.w_o;
-        auto w_4 = purported_evaluations.w_4;
-        auto w_4_shift = purported_evaluations.w_4_shift;
-        auto q_m = purported_evaluations.q_m;
-        auto q_l = purported_evaluations.q_l;
-        auto q_r = purported_evaluations.q_r;
-        auto q_o = purported_evaluations.q_o;
-        auto q_4 = purported_evaluations.q_4;
-        auto q_c = purported_evaluations.q_c;
-        auto q_arith = purported_evaluations.q_arith;
+        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 
-        static const FF neg_half = FF(-2).invert();
-
-        // Contribution 1
-        auto tmp = (q_arith - 3) * (q_m * w_r * w_l) * neg_half;
-        tmp += (q_l * w_l) + (q_r * w_r) + (q_o * w_o) + (q_4 * w_4) + q_c;
-        tmp += (q_arith - 1) * w_4_shift;
-        tmp *= q_arith;
-        std::get<0>(full_honk_relation_value) += tmp;
-
-        // Contribution 2
-        tmp = w_l + w_4 - w_l_shift + q_m;
-        tmp *= (q_arith - 2);
-        tmp *= (q_arith - 1);
-        tmp *= q_arith;
-        std::get<1>(full_honk_relation_value) += tmp;
-    };
+    void add_full_relation_value_contribution(RelationValues& accumulator,
+                                              auto& input,
+                                              const RelationParameters<FF>& relation_parameters,
+                                              const FF& scaling_factor = 1) const
+    {
+        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+    }
 };
 // clang-format on
 } // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
@@ -17,11 +17,11 @@ template <typename FF> class UltraArithmeticRelation {
     static constexpr size_t LEN_2 = 5; // secondary arithmetic sub-relation
     using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
 
-    using UnivariateAccumulatorTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
-    using ValueAccumulatorTypes = ValueAccumulatorTypes<FF, LENGTHS>;
+    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, LENGTHS>;
+    using ValueAccumTypes = ValueAccumulatorTypes<FF, LENGTHS>;
 
-    using RelationUnivariates = typename UnivariateAccumulatorTypes::Accumulators;
-    using RelationValues = typename ValueAccumulatorTypes::Accumulators;
+    using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
+    using RelationValues = typename ValueAccumTypes::Accumulators;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -130,7 +130,7 @@ template <typename FF> class UltraArithmeticRelation {
                                       const RelationParameters<FF>& relation_parameters,
                                       const FF& scaling_factor) const
     {
-        add_edge_contribution_impl<UnivariateAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<UnivariateAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 
     void add_full_relation_value_contribution(RelationValues& accumulator,
@@ -138,7 +138,7 @@ template <typename FF> class UltraArithmeticRelation {
                                               const RelationParameters<FF>& relation_parameters,
                                               const FF& scaling_factor = 1) const
     {
-        add_edge_contribution_impl<ValueAccumulatorTypes>(accumulator, input, relation_parameters, scaling_factor);
+        add_edge_contribution_impl<ValueAccumTypes>(accumulator, input, relation_parameters, scaling_factor);
     }
 };
 // clang-format on

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ultra_relation_consistency.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ultra_relation_consistency.test.cpp
@@ -220,8 +220,8 @@ TEST_F(UltraRelationConsistency, UltraArithmeticRelation)
 
     static const FF neg_half = FF(-2).invert();
 
-    constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+    constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
     // Contribution 1
     auto contribution_1 = (q_arith - 3) * (q_m * w_2 * w_1) * neg_half;
@@ -280,8 +280,8 @@ TEST_F(UltraRelationConsistency, UltraPermutationRelation)
     const auto& lagrange_first = extended_edges.lagrange_first;
     const auto& lagrange_last = extended_edges.lagrange_last;
 
-    constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+    constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
     // Compute the expected result using a simple to read version of the relation expression
 
@@ -369,8 +369,8 @@ TEST_F(UltraRelationConsistency, LookupRelation)
     auto table_accum = table_1 + table_2 * eta + table_3 * eta_sqr + table_4 * eta_cube;
     auto table_accum_shift = table_1_shift + table_2_shift * eta + table_3_shift * eta_sqr + table_4_shift * eta_cube;
 
-    constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+    constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
     // Compute the expected result using a simple to read version of the relation expression
 
@@ -425,8 +425,8 @@ TEST_F(UltraRelationConsistency, GenPermSortRelation)
     auto delta_3 = w_4 - w_3;
     auto delta_4 = w_1_shift - w_4;
 
-    constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+    constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
     // Compute the expected result using a simple to read version of the relation expression
     auto contribution_1 = delta_1 * (delta_1 - 1) * (delta_1 - 2) * (delta_1 - 3);
@@ -476,8 +476,8 @@ TEST_F(UltraRelationConsistency, EllipticRelation)
     const auto& q_beta_sqr = extended_edges.q_4;
     const auto& q_elliptic = extended_edges.q_elliptic;
 
-    constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+    constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
     // Compute x/y coordinate identities
 
@@ -539,8 +539,8 @@ TEST_F(UltraRelationConsistency, AuxiliaryRelation)
     const auto& q_arith = extended_edges.q_arith;
     const auto& q_aux = extended_edges.q_aux;
 
-    constexpr std::size_t NUM_CONSTRAINTS = decltype(relation)::NUM_CONSTRAINTS;
-    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_CONSTRAINTS>();
+    constexpr std::size_t NUM_SUBRELATIONS = std::tuple_size_v<decltype(relation)::RelationUnivariates>;
+    auto expected_full_length_univariates = std::array<Univariate<FF, FULL_RELATION_LENGTH>, NUM_SUBRELATIONS>();
 
     constexpr FF LIMB_SIZE(uint256_t(1) << 68);
     constexpr FF SUBLIMB_SHIFT(uint256_t(1) << 14);

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -269,23 +269,6 @@ template <class FF, size_t ExtendedLength, std::size_t Length = 2> static conste
     }
 }
 
-/**
- * @brief Recursive helper function to construct BarycentricData to extend each Relation in a tuple
- *
- */
-template <class FF, typename Tuple, size_t ExtendedLength, std::size_t Index = 0>
-static constexpr auto create_barycentric_utils()
-{
-    if constexpr (Index >= std::tuple_size<Tuple>::value) {
-        return std::tuple<>{}; // Return empty when reach end of the tuple
-    } else {
-        constexpr size_t relation_length = std::tuple_element_t<Index, Tuple>::RELATION_LENGTH;
-        using BarycentricType = sumcheck::BarycentricData<FF, relation_length, ExtendedLength>;
-        return std::tuple_cat(std::tuple<BarycentricType>{},
-                              create_barycentric_utils<FF, Tuple, ExtendedLength, Index + 1>());
-    }
-}
-
 } // namespace proof_system::honk::flavor
 
 // Forward declare honk flavors


### PR DESCRIPTION
# Description

Introduces a framework that allows the relation arithmetic to be shared between the prover and verifier.

The sumcheck prover and verifier accumulate the contributions from each relation (really, each sub-relation) into, respectively, Univariates and individual field elements. When performing relation arithmetic on Univariates, we introduce UnivariateViews to reduce full length Univariates to the minimum required length and to avoid unnecessary copies. 

To share the relation arithmetic. we introduce simple structs that specify two types: `Accumulators` and `AccumulatorViews`. For the prover, who accumulates Univariates, these are respectively `std::tuple<Univariate>` and `std::tuple<UnivariateView>`. For the verifier, who accumulates `FF`s, both types are simply aliases for `std::array<FF>` (since no "view" type is necessary). The containers `std::tuple` and `std::array` are needed to accommodate multiple sub-relations within each relation, where, for efficiency, each sub-relation has its own specified degree.


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
