### PR TITLE
CRS factory refactor

### DIFF
--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
@@ -133,7 +133,7 @@ StandardVerifier StandardHonkComposerHelper::create_verifier(const CircuitConstr
     StandardVerifier output_state(verification_key);
 
     auto pcs_verification_key =
-        std::make_unique<PCSParams::VerificationKey>(verification_key->circuit_size, crs_factory_->get_verifier_crs());
+        std::make_unique<PCSParams::VerificationKey>(verification_key->circuit_size, crs_factory_);
 
     output_state.pcs_verification_key = std::move(pcs_verification_key);
 

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
@@ -47,7 +47,8 @@ std::shared_ptr<StandardHonkComposerHelper::VerificationKey> StandardHonkCompose
 {
     auto key = std::make_shared<VerificationKey>(
         proving_key->circuit_size, proving_key->num_public_inputs, proving_key->composer_type);
-    auto commitment_key = PCSParams::CommitmentKey(proving_key->circuit_size, proving_key->crs);
+
+    auto commitment_key = PCSParams::CommitmentKey(proving_key->circuit_size, crs_factory_);
 
     // Compute and store commitments to all precomputed polynomials
     key->q_m = commitment_key.commit(proving_key->q_m);
@@ -158,8 +159,7 @@ StandardProver StandardHonkComposerHelper::create_prover(const CircuitConstructo
     compute_witness(circuit_constructor);
     StandardProver output_state(proving_key);
 
-    auto pcs_commitment_key = std::make_unique<PCSParams::CommitmentKey>(
-        proving_key->circuit_size, crs_factory_->get_prover_crs(proving_key->circuit_size));
+    auto pcs_commitment_key = std::make_unique<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
 
     output_state.pcs_commitment_key = std::move(pcs_commitment_key);
 

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
@@ -67,7 +67,6 @@ void StandardHonkComposerHelper::compute_witness(const CircuitConstructor& circu
  *
  * @return Proving key with saved computed polynomials.
  * */
-
 std::shared_ptr<StandardHonkComposerHelper::ProvingKey> StandardHonkComposerHelper::compute_proving_key(
     const CircuitConstructor& circuit_constructor)
 {
@@ -98,29 +97,24 @@ std::shared_ptr<StandardHonkComposerHelper::VerificationKey> StandardHonkCompose
     if (verification_key) {
         return verification_key;
     }
-    if (!proving_key) {
-        compute_proving_key(circuit_constructor);
-    }
 
     verification_key = std::make_shared<VerificationKey>(
         proving_key->circuit_size, proving_key->num_public_inputs, proving_key->composer_type);
 
-    auto commitment_key = PCSParams::CommitmentKey(proving_key->circuit_size, crs_factory_);
-
     // Compute and store commitments to all precomputed polynomials
-    verification_key->q_m = commitment_key.commit(proving_key->q_m);
-    verification_key->q_l = commitment_key.commit(proving_key->q_l);
-    verification_key->q_r = commitment_key.commit(proving_key->q_r);
-    verification_key->q_o = commitment_key.commit(proving_key->q_o);
-    verification_key->q_c = commitment_key.commit(proving_key->q_c);
-    verification_key->sigma_1 = commitment_key.commit(proving_key->sigma_1);
-    verification_key->sigma_2 = commitment_key.commit(proving_key->sigma_2);
-    verification_key->sigma_3 = commitment_key.commit(proving_key->sigma_3);
-    verification_key->id_1 = commitment_key.commit(proving_key->id_1);
-    verification_key->id_2 = commitment_key.commit(proving_key->id_2);
-    verification_key->id_3 = commitment_key.commit(proving_key->id_3);
-    verification_key->lagrange_first = commitment_key.commit(proving_key->lagrange_first);
-    verification_key->lagrange_last = commitment_key.commit(proving_key->lagrange_last);
+    verification_key->q_m = commitment_key->commit(proving_key->q_m);
+    verification_key->q_l = commitment_key->commit(proving_key->q_l);
+    verification_key->q_r = commitment_key->commit(proving_key->q_r);
+    verification_key->q_o = commitment_key->commit(proving_key->q_o);
+    verification_key->q_c = commitment_key->commit(proving_key->q_c);
+    verification_key->sigma_1 = commitment_key->commit(proving_key->sigma_1);
+    verification_key->sigma_2 = commitment_key->commit(proving_key->sigma_2);
+    verification_key->sigma_3 = commitment_key->commit(proving_key->sigma_3);
+    verification_key->id_1 = commitment_key->commit(proving_key->id_1);
+    verification_key->id_2 = commitment_key->commit(proving_key->id_2);
+    verification_key->id_3 = commitment_key->commit(proving_key->id_3);
+    verification_key->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
+    verification_key->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
 
     verification_key->composer_type = proving_key->composer_type;
 
@@ -145,7 +139,7 @@ StandardProver StandardHonkComposerHelper::create_prover(const CircuitConstructo
     compute_proving_key(circuit_constructor);
     compute_witness(circuit_constructor);
 
-    commitment_key = std::make_shared<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
+    compute_commitment_key(proving_key->circuit_size, crs_factory_);
 
     StandardProver output_state(proving_key, commitment_key);
 

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
@@ -37,38 +37,6 @@ std::shared_ptr<StandardHonkComposerHelper::ProvingKey> StandardHonkComposerHelp
 }
 
 /**
- * @brief Computes the verification key by computing the:
- * (1) commitments to the selector, permutation, and lagrange (first/last) polynomials,
- * (2) sets the polynomial manifest using the data from proving key.
- */
-
-std::shared_ptr<StandardHonkComposerHelper::VerificationKey> StandardHonkComposerHelper::compute_verification_key_base(
-    std::shared_ptr<StandardHonkComposerHelper::ProvingKey> const& proving_key)
-{
-    auto key = std::make_shared<VerificationKey>(
-        proving_key->circuit_size, proving_key->num_public_inputs, proving_key->composer_type);
-
-    auto commitment_key = PCSParams::CommitmentKey(proving_key->circuit_size, crs_factory_);
-
-    // Compute and store commitments to all precomputed polynomials
-    key->q_m = commitment_key.commit(proving_key->q_m);
-    key->q_l = commitment_key.commit(proving_key->q_l);
-    key->q_r = commitment_key.commit(proving_key->q_r);
-    key->q_o = commitment_key.commit(proving_key->q_o);
-    key->q_c = commitment_key.commit(proving_key->q_c);
-    key->sigma_1 = commitment_key.commit(proving_key->sigma_1);
-    key->sigma_2 = commitment_key.commit(proving_key->sigma_2);
-    key->sigma_3 = commitment_key.commit(proving_key->sigma_3);
-    key->id_1 = commitment_key.commit(proving_key->id_1);
-    key->id_2 = commitment_key.commit(proving_key->id_2);
-    key->id_3 = commitment_key.commit(proving_key->id_3);
-    key->lagrange_first = commitment_key.commit(proving_key->lagrange_first);
-    key->lagrange_last = commitment_key.commit(proving_key->lagrange_last);
-
-    return key;
-}
-
-/**
  * Compute witness polynomials (w_1, w_2, w_3, w_4).
  *
  * @details Fills 3 or 4 witness polynomials w_1, w_2, w_3, w_4 with the values of in-circuit variables. The beginning
@@ -134,7 +102,26 @@ std::shared_ptr<StandardHonkComposerHelper::VerificationKey> StandardHonkCompose
         compute_proving_key(circuit_constructor);
     }
 
-    verification_key = StandardHonkComposerHelper::compute_verification_key_base(proving_key);
+    verification_key = std::make_shared<VerificationKey>(
+        proving_key->circuit_size, proving_key->num_public_inputs, proving_key->composer_type);
+
+    auto commitment_key = PCSParams::CommitmentKey(proving_key->circuit_size, crs_factory_);
+
+    // Compute and store commitments to all precomputed polynomials
+    verification_key->q_m = commitment_key.commit(proving_key->q_m);
+    verification_key->q_l = commitment_key.commit(proving_key->q_l);
+    verification_key->q_r = commitment_key.commit(proving_key->q_r);
+    verification_key->q_o = commitment_key.commit(proving_key->q_o);
+    verification_key->q_c = commitment_key.commit(proving_key->q_c);
+    verification_key->sigma_1 = commitment_key.commit(proving_key->sigma_1);
+    verification_key->sigma_2 = commitment_key.commit(proving_key->sigma_2);
+    verification_key->sigma_3 = commitment_key.commit(proving_key->sigma_3);
+    verification_key->id_1 = commitment_key.commit(proving_key->id_1);
+    verification_key->id_2 = commitment_key.commit(proving_key->id_2);
+    verification_key->id_3 = commitment_key.commit(proving_key->id_3);
+    verification_key->lagrange_first = commitment_key.commit(proving_key->lagrange_first);
+    verification_key->lagrange_last = commitment_key.commit(proving_key->lagrange_last);
+
     verification_key->composer_type = proving_key->composer_type;
 
     return verification_key;

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.cpp
@@ -144,11 +144,10 @@ StandardProver StandardHonkComposerHelper::create_prover(const CircuitConstructo
 {
     compute_proving_key(circuit_constructor);
     compute_witness(circuit_constructor);
-    StandardProver output_state(proving_key);
 
-    auto pcs_commitment_key = std::make_unique<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
+    commitment_key = std::make_shared<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
 
-    output_state.pcs_commitment_key = std::move(pcs_commitment_key);
+    StandardProver output_state(proving_key, commitment_key);
 
     return output_state;
 }

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
@@ -27,7 +27,7 @@ class StandardHonkComposerHelper {
     std::shared_ptr<VerificationKey> verification_key;
 
     // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
+    std::shared_ptr<srs::factories::CrsFactory> crs_factory_;
 
     // The commitment key is passed to the prover but also used herein to compute the verfication key commitments
     std::shared_ptr<PCSCommitmentKey> commitment_key;
@@ -35,14 +35,14 @@ class StandardHonkComposerHelper {
     bool computed_witness = false;
     // TODO(Luke): use make_shared
     StandardHonkComposerHelper()
-        : StandardHonkComposerHelper(std::shared_ptr<barretenberg::srs::factories::CrsFactory>(
-              new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition")))
+        : StandardHonkComposerHelper(
+              std::shared_ptr<srs::factories::CrsFactory>(new srs::factories::FileCrsFactory("../srs_db/ignition")))
     {}
-    StandardHonkComposerHelper(std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
+    StandardHonkComposerHelper(std::shared_ptr<srs::factories::CrsFactory> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
 
-    StandardHonkComposerHelper(std::unique_ptr<barretenberg::srs::factories::CrsFactory>&& crs_factory)
+    StandardHonkComposerHelper(std::unique_ptr<srs::factories::CrsFactory>&& crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
     StandardHonkComposerHelper(std::shared_ptr<ProvingKey> p_key, std::shared_ptr<VerificationKey> v_key)
@@ -68,6 +68,11 @@ class StandardHonkComposerHelper {
                                                          const size_t num_randomized_gates = NUM_RESERVED_GATES);
 
     void compute_witness(const CircuitConstructor& circuit_constructor, const size_t minimum_circuit_size = 0);
+
+    void compute_commitment_key(size_t circuit_size, std::shared_ptr<srs::factories::CrsFactory> crs_factory)
+    {
+        commitment_key = std::make_shared<PCSParams::CommitmentKey>(circuit_size, crs_factory_);
+    };
 };
 
 } // namespace proof_system::honk

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
@@ -19,14 +19,19 @@ class StandardHonkComposerHelper {
     using CircuitConstructor = Flavor::CircuitConstructor;
     using ProvingKey = Flavor::ProvingKey;
     using VerificationKey = Flavor::VerificationKey;
+    using PCSCommitmentKey = PCSParams::CommitmentKey;
 
     static constexpr size_t NUM_RESERVED_GATES = 2; // equal to the number of multilinear evaluations leaked
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;
     std::shared_ptr<ProvingKey> proving_key;
     std::shared_ptr<VerificationKey> verification_key;
-    // TODO(#218)(kesha): we need to put this into the commitment key, so that the composer doesn't have to handle srs
-    // at all
+
+    // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
     std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
+
+    // The commitment key is passed to the prover but also used herein to compute the verfication key commitments
+    std::shared_ptr<PCSCommitmentKey> commitment_key;
+
     bool computed_witness = false;
     // TODO(Luke): use make_shared
     StandardHonkComposerHelper()

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
@@ -63,8 +63,7 @@ class StandardHonkComposerHelper {
                                                          const size_t num_randomized_gates = NUM_RESERVED_GATES);
     // This needs to be static as it may be used only to compute the selector commitments.
 
-    static std::shared_ptr<VerificationKey> compute_verification_key_base(
-        std::shared_ptr<ProvingKey> const& proving_key);
+    std::shared_ptr<VerificationKey> compute_verification_key_base(std::shared_ptr<ProvingKey> const& proving_key);
 
     void compute_witness(const CircuitConstructor& circuit_constructor, const size_t minimum_circuit_size = 0);
 };

--- a/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/standard_honk_composer_helper.hpp
@@ -61,9 +61,6 @@ class StandardHonkComposerHelper {
     std::shared_ptr<ProvingKey> compute_proving_key_base(const CircuitConstructor& circuit_constructor,
                                                          const size_t minimum_circuit_size = 0,
                                                          const size_t num_randomized_gates = NUM_RESERVED_GATES);
-    // This needs to be static as it may be used only to compute the selector commitments.
-
-    std::shared_ptr<VerificationKey> compute_verification_key_base(std::shared_ptr<ProvingKey> const& proving_key);
 
     void compute_witness(const CircuitConstructor& circuit_constructor, const size_t minimum_circuit_size = 0);
 };

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
@@ -162,8 +162,7 @@ UltraVerifier UltraHonkComposerHelper::create_verifier(const CircuitConstructor&
 
     UltraVerifier output_state(verification_key);
 
-    auto pcs_verification_key = std::make_unique<PCSVerificationKey>(
-        verification_key->circuit_size, crs_factory_->get_prover_crs(verification_key->circuit_size));
+    auto pcs_verification_key = std::make_unique<PCSVerificationKey>(verification_key->circuit_size, crs_factory_);
 
     output_state.pcs_verification_key = std::move(pcs_verification_key);
 

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
@@ -141,7 +141,7 @@ UltraProver UltraHonkComposerHelper::create_prover(CircuitConstructor& circuit_c
     compute_proving_key(circuit_constructor);
     compute_witness(circuit_constructor);
 
-    commitment_key = std::make_unique<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
+    compute_commitment_key(proving_key->circuit_size, crs_factory_);
 
     UltraProver output_state(proving_key, commitment_key);
 
@@ -314,34 +314,32 @@ std::shared_ptr<UltraHonkComposerHelper::VerificationKey> UltraHonkComposerHelpe
     verification_key = std::make_shared<UltraHonkComposerHelper::VerificationKey>(
         proving_key->circuit_size, proving_key->num_public_inputs, proving_key->composer_type);
 
-    auto commitment_key = PCSCommitmentKey(proving_key->circuit_size, crs_factory_);
-
     // Compute and store commitments to all precomputed polynomials
-    verification_key->q_m = commitment_key.commit(proving_key->q_m);
-    verification_key->q_l = commitment_key.commit(proving_key->q_l);
-    verification_key->q_r = commitment_key.commit(proving_key->q_r);
-    verification_key->q_o = commitment_key.commit(proving_key->q_o);
-    verification_key->q_4 = commitment_key.commit(proving_key->q_4);
-    verification_key->q_c = commitment_key.commit(proving_key->q_c);
-    verification_key->q_arith = commitment_key.commit(proving_key->q_arith);
-    verification_key->q_sort = commitment_key.commit(proving_key->q_sort);
-    verification_key->q_elliptic = commitment_key.commit(proving_key->q_elliptic);
-    verification_key->q_aux = commitment_key.commit(proving_key->q_aux);
-    verification_key->q_lookup = commitment_key.commit(proving_key->q_lookup);
-    verification_key->sigma_1 = commitment_key.commit(proving_key->sigma_1);
-    verification_key->sigma_2 = commitment_key.commit(proving_key->sigma_2);
-    verification_key->sigma_3 = commitment_key.commit(proving_key->sigma_3);
-    verification_key->sigma_4 = commitment_key.commit(proving_key->sigma_4);
-    verification_key->id_1 = commitment_key.commit(proving_key->id_1);
-    verification_key->id_2 = commitment_key.commit(proving_key->id_2);
-    verification_key->id_3 = commitment_key.commit(proving_key->id_3);
-    verification_key->id_4 = commitment_key.commit(proving_key->id_4);
-    verification_key->table_1 = commitment_key.commit(proving_key->table_1);
-    verification_key->table_2 = commitment_key.commit(proving_key->table_2);
-    verification_key->table_3 = commitment_key.commit(proving_key->table_3);
-    verification_key->table_4 = commitment_key.commit(proving_key->table_4);
-    verification_key->lagrange_first = commitment_key.commit(proving_key->lagrange_first);
-    verification_key->lagrange_last = commitment_key.commit(proving_key->lagrange_last);
+    verification_key->q_m = commitment_key->commit(proving_key->q_m);
+    verification_key->q_l = commitment_key->commit(proving_key->q_l);
+    verification_key->q_r = commitment_key->commit(proving_key->q_r);
+    verification_key->q_o = commitment_key->commit(proving_key->q_o);
+    verification_key->q_4 = commitment_key->commit(proving_key->q_4);
+    verification_key->q_c = commitment_key->commit(proving_key->q_c);
+    verification_key->q_arith = commitment_key->commit(proving_key->q_arith);
+    verification_key->q_sort = commitment_key->commit(proving_key->q_sort);
+    verification_key->q_elliptic = commitment_key->commit(proving_key->q_elliptic);
+    verification_key->q_aux = commitment_key->commit(proving_key->q_aux);
+    verification_key->q_lookup = commitment_key->commit(proving_key->q_lookup);
+    verification_key->sigma_1 = commitment_key->commit(proving_key->sigma_1);
+    verification_key->sigma_2 = commitment_key->commit(proving_key->sigma_2);
+    verification_key->sigma_3 = commitment_key->commit(proving_key->sigma_3);
+    verification_key->sigma_4 = commitment_key->commit(proving_key->sigma_4);
+    verification_key->id_1 = commitment_key->commit(proving_key->id_1);
+    verification_key->id_2 = commitment_key->commit(proving_key->id_2);
+    verification_key->id_3 = commitment_key->commit(proving_key->id_3);
+    verification_key->id_4 = commitment_key->commit(proving_key->id_4);
+    verification_key->table_1 = commitment_key->commit(proving_key->table_1);
+    verification_key->table_2 = commitment_key->commit(proving_key->table_2);
+    verification_key->table_3 = commitment_key->commit(proving_key->table_3);
+    verification_key->table_4 = commitment_key->commit(proving_key->table_4);
+    verification_key->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
+    verification_key->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
 
     // // See `add_recusrive_proof()` for how this recursive data is assigned.
     // verification_key->recursive_proof_public_input_indices =

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
@@ -141,11 +141,9 @@ UltraProver UltraHonkComposerHelper::create_prover(CircuitConstructor& circuit_c
     compute_proving_key(circuit_constructor);
     compute_witness(circuit_constructor);
 
-    UltraProver output_state(proving_key);
+    commitment_key = std::make_unique<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
 
-    auto pcs_commitment_key = std::make_unique<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
-
-    output_state.pcs_commitment_key = std::move(pcs_commitment_key);
+    UltraProver output_state(proving_key, commitment_key);
 
     return output_state;
 }

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
@@ -143,7 +143,7 @@ UltraProver UltraHonkComposerHelper::create_prover(CircuitConstructor& circuit_c
 
     UltraProver output_state(proving_key);
 
-    auto pcs_commitment_key = std::make_unique<PCSParams::CommitmentKey>(proving_key->circuit_size, proving_key->crs);
+    auto pcs_commitment_key = std::make_unique<PCSParams::CommitmentKey>(proving_key->circuit_size, crs_factory_);
 
     output_state.pcs_commitment_key = std::move(pcs_commitment_key);
 
@@ -317,7 +317,7 @@ std::shared_ptr<UltraHonkComposerHelper::VerificationKey> UltraHonkComposerHelpe
     verification_key = std::make_shared<UltraHonkComposerHelper::VerificationKey>(
         proving_key->circuit_size, proving_key->num_public_inputs, proving_key->composer_type);
 
-    auto commitment_key = PCSCommitmentKey(proving_key->circuit_size, proving_key->crs);
+    auto commitment_key = PCSCommitmentKey(proving_key->circuit_size, crs_factory_);
 
     // Compute and store commitments to all precomputed polynomials
     verification_key->q_m = commitment_key.commit(proving_key->q_m);

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
@@ -29,7 +29,7 @@ class UltraHonkComposerHelper {
     std::shared_ptr<ProvingKey> proving_key;
     std::shared_ptr<VerificationKey> verification_key;
 
-    // The crs_factory holds the path to the srs and exposes methods to extract either srs elements
+    // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
     std::shared_ptr<srs::factories::CrsFactory> crs_factory_;
 
     // The commitment key is passed to the prover but also used herein to compute the verfication key commitments

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
@@ -30,7 +30,7 @@ class UltraHonkComposerHelper {
     std::shared_ptr<VerificationKey> verification_key;
 
     // The crs_factory holds the path to the srs and exposes methods to extract either srs elements
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
+    std::shared_ptr<srs::factories::CrsFactory> crs_factory_;
 
     // The commitment key is passed to the prover but also used herein to compute the verfication key commitments
     std::shared_ptr<PCSCommitmentKey> commitment_key;
@@ -45,7 +45,7 @@ class UltraHonkComposerHelper {
     // vanishing_polynomial cannot be trivially fetched here, I am directly setting this to 4 - 1 = 3.
     static constexpr size_t s_randomness = 3;
 
-    explicit UltraHonkComposerHelper(std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
+    explicit UltraHonkComposerHelper(std::shared_ptr<srs::factories::CrsFactory> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
 
@@ -71,6 +71,11 @@ class UltraHonkComposerHelper {
     UltraVerifier create_verifier(const CircuitConstructor& circuit_constructor);
 
     void add_table_column_selector_poly_to_proving_key(polynomial& small, const std::string& tag);
+
+    void compute_commitment_key(size_t circuit_size, std::shared_ptr<srs::factories::CrsFactory> crs_factory)
+    {
+        commitment_key = std::make_shared<PCSParams::CommitmentKey>(circuit_size, crs_factory_);
+    };
 };
 
 } // namespace proof_system::honk

--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.hpp
@@ -28,9 +28,12 @@ class UltraHonkComposerHelper {
     static constexpr size_t NUM_WIRES = CircuitConstructor::NUM_WIRES;
     std::shared_ptr<ProvingKey> proving_key;
     std::shared_ptr<VerificationKey> verification_key;
-    // TODO(#218)(kesha): we need to put this into the commitment key, so that the composer doesn't have to handle srs
-    // at all
+
+    // The crs_factory holds the path to the srs and exposes methods to extract either srs elements
     std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
+
+    // The commitment key is passed to the prover but also used herein to compute the verfication key commitments
+    std::shared_ptr<PCSCommitmentKey> commitment_key;
 
     std::vector<uint32_t> recursive_proof_public_input_indices;
     bool contains_recursive_proof = false;

--- a/cpp/src/barretenberg/honk/composer/standard_honk_composer.test.cpp
+++ b/cpp/src/barretenberg/honk/composer/standard_honk_composer.test.cpp
@@ -303,6 +303,7 @@ TEST_F(StandardHonkComposerTests, VerificationKeyCreation)
         composer.create_add_gate({ a_idx, b_idx, c_idx, fr::one(), fr::one(), fr::neg_one(), fr::zero() });
         composer.create_add_gate({ d_idx, c_idx, a_idx, fr::one(), fr::neg_one(), fr::neg_one(), fr::zero() });
     }
+    composer.create_prover();
     auto verification_key = composer.compute_verification_key();
     // There is nothing we can really check apart from the fact that constraint selectors and permutation selectors were
     // committed to, we simply check that the verification key now contains the appropriate number of constraint and

--- a/cpp/src/barretenberg/honk/flavor/flavor.test.cpp
+++ b/cpp/src/barretenberg/honk/flavor/flavor.test.cpp
@@ -15,9 +15,7 @@ TEST(Flavor, StandardGetters)
     using ProvingKey = typename Flavor::ProvingKey;
 
     ProvingKey proving_key = []() {
-        auto crs_factory = barretenberg::srs::factories::CrsFactory();
-        auto crs = crs_factory.get_prover_crs(4);
-        return Flavor::ProvingKey(/*circuit_size=*/4, /*num_public_inputs=*/0, crs, ComposerType::STANDARD);
+        return Flavor::ProvingKey(/*circuit_size=*/4, /*num_public_inputs=*/0, ComposerType::STANDARD);
     }();
 
     // set

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -86,9 +86,9 @@ struct Params {
          * @param num_points
          * @param verifier_srs verifier G2 point
          */
-        VerificationKey(size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
-            : pippenger_runtime_state(num_points)
-            , verifier_srs(crs_factory->get_verifier_crs())
+        VerificationKey([[maybe_unused]] size_t num_points,
+                        std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
+            : verifier_srs(crs_factory->get_verifier_crs())
         {}
 
         /**
@@ -109,7 +109,6 @@ struct Params {
             return (result == barretenberg::fq12::one());
         }
 
-        barretenberg::scalar_multiplication::pippenger_runtime_state<curve::BN254> pippenger_runtime_state;
         std::shared_ptr<barretenberg::srs::factories::VerifierCrs> verifier_srs;
     };
 };

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -52,9 +52,9 @@ struct Params {
          * @param path
          *
          */
-        CommitmentKey(const size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> prover_crs)
+        CommitmentKey(const size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
             : pippenger_runtime_state(num_points)
-            , srs(prover_crs->get_prover_crs(num_points))
+            , srs(crs_factory->get_prover_crs(num_points))
         {}
 
         /**
@@ -86,9 +86,9 @@ struct Params {
          * @param num_points
          * @param verifier_srs verifier G2 point
          */
-        VerificationKey(size_t num_points, std::shared_ptr<barretenberg::srs::factories::VerifierCrs> verifier_crs)
+        VerificationKey(size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
             : pippenger_runtime_state(num_points)
-            , verifier_srs(verifier_crs)
+            , verifier_srs(crs_factory->get_verifier_crs())
         {}
 
         /**
@@ -200,9 +200,9 @@ struct Params {
          * @param path
          *
          */
-        CommitmentKey(const size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> prover_crs)
+        CommitmentKey(const size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
             : pippenger_runtime_state(num_points)
-            , srs(prover_crs->get_prover_crs(num_points))
+            , srs(crs_factory->get_prover_crs(num_points))
         {}
 
         /**
@@ -234,10 +234,9 @@ struct Params {
          * @param num_points specifies the length of the SRS
          * @param path is the location to the SRS file
          */
-        VerificationKey(const size_t num_points,
-                        std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> crs)
+        VerificationKey(size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
             : pippenger_runtime_state(num_points)
-            , srs(crs)
+            , srs(crs_factory->get_prover_crs(num_points))
         {}
 
         barretenberg::scalar_multiplication::pippenger_runtime_state<curve::BN254> pippenger_runtime_state;

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -57,6 +57,14 @@ struct Params {
             , srs(crs_factory->get_prover_crs(num_points))
         {}
 
+        // Note: This constructor is used only by Plonk; For Honk the CommitmentKey is solely responsible for extracting
+        // the srs.
+        CommitmentKey(const size_t num_points,
+                      std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> prover_srs)
+            : pippenger_runtime_state(num_points)
+            , srs(prover_srs)
+        {}
+
         /**
          * @brief Uses the ProverSRS to create a commitment to p(X)
          *

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -52,10 +52,9 @@ struct Params {
          * @param path
          *
          */
-        CommitmentKey(const size_t num_points,
-                      std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> prover_crs)
+        CommitmentKey(const size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> prover_crs)
             : pippenger_runtime_state(num_points)
-            , srs(prover_crs)
+            , srs(prover_crs->get_prover_crs(num_points))
         {}
 
         /**
@@ -201,10 +200,9 @@ struct Params {
          * @param path
          *
          */
-        CommitmentKey(const size_t num_points,
-                      std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> prover_crs)
+        CommitmentKey(const size_t num_points, std::shared_ptr<barretenberg::srs::factories::CrsFactory> prover_crs)
             : pippenger_runtime_state(num_points)
-            , srs(prover_crs)
+            , srs(prover_crs->get_prover_crs(num_points))
         {}
 
         /**

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.hpp
@@ -3,8 +3,8 @@
 /**
  * @brief Provides interfaces for different 'CommitmentKey' classes.
  *
- * TODO(#218)(Adrian / Mara): This class should take ownership of the SRS, and handle reading the file from disk as well
- * as carrying out any modification to the SRS (e.g compute pippenger point table) to simplify the codebase.
+ * TODO(#218)(Mara): This class should handle any modification to the SRS (e.g compute pippenger point table) to
+ * simplify the codebase.
  */
 
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
@@ -25,15 +25,17 @@ template <class CK> inline std::shared_ptr<CK> CreateCommitmentKey();
 template <> inline std::shared_ptr<kzg::Params::CommitmentKey> CreateCommitmentKey<kzg::Params::CommitmentKey>()
 {
     constexpr size_t n = 128;
-    barretenberg::srs::factories::FileCrsFactory kzg_srs("../srs_db/ignition");
-    return std::make_shared<kzg::Params::CommitmentKey>(n, kzg_srs.get_prover_crs(n));
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    return std::make_shared<kzg::Params::CommitmentKey>(n, crs_factory);
 }
 // For IPA
 template <> inline std::shared_ptr<ipa::Params::CommitmentKey> CreateCommitmentKey<ipa::Params::CommitmentKey>()
 {
     constexpr size_t n = 128;
-    barretenberg::srs::factories::FileCrsFactory kzg_srs("../srs_db/ignition");
-    return std::make_shared<ipa::Params::CommitmentKey>(n, kzg_srs.get_prover_crs(n));
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    return std::make_shared<ipa::Params::CommitmentKey>(n, crs_factory);
 }
 
 template <typename CK> inline std::shared_ptr<CK> CreateCommitmentKey()

--- a/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
+++ b/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
@@ -49,15 +49,17 @@ template <class VK> inline std::shared_ptr<VK> CreateVerificationKey();
 template <> inline std::shared_ptr<kzg::Params::VerificationKey> CreateVerificationKey<kzg::Params::VerificationKey>()
 {
     constexpr size_t n = 128;
-    barretenberg::srs::factories::FileCrsFactory kzg_srs("../srs_db/ignition");
-    return std::make_shared<kzg::Params::VerificationKey>(n, kzg_srs.get_verifier_crs());
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    return std::make_shared<kzg::Params::VerificationKey>(n, crs_factory);
 }
 // For IPA
 template <> inline std::shared_ptr<ipa::Params::VerificationKey> CreateVerificationKey<ipa::Params::VerificationKey>()
 {
     constexpr size_t n = 128;
-    barretenberg::srs::factories::FileCrsFactory kzg_srs("../srs_db/ignition");
-    return std::make_shared<ipa::Params::VerificationKey>(n, kzg_srs.get_prover_crs(n));
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    return std::make_shared<ipa::Params::VerificationKey>(n, crs_factory);
 }
 template <typename VK> inline std::shared_ptr<VK> CreateVerificationKey()
 // requires std::default_initializable<VK>

--- a/cpp/src/barretenberg/honk/proof_system/prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.cpp
@@ -16,11 +16,12 @@ namespace proof_system::honk {
  * @tparam settings Settings class.
  * */
 template <StandardFlavor Flavor>
-StandardProver_<Flavor>::StandardProver_(const std::shared_ptr<ProvingKey> input_key)
+StandardProver_<Flavor>::StandardProver_(const std::shared_ptr<ProvingKey> input_key,
+                                         const std::shared_ptr<PCSCommitmentKey> commitment_key)
     : key(input_key)
-    , queue(input_key->circuit_size, transcript)
+    , queue(commitment_key, transcript)
+    , pcs_commitment_key(commitment_key)
 {
-
     prover_polynomials.q_c = key->q_c;
     prover_polynomials.q_l = key->q_l;
     prover_polynomials.q_r = key->q_r;

--- a/cpp/src/barretenberg/honk/proof_system/prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover.hpp
@@ -28,7 +28,7 @@ template <StandardFlavor Flavor> class StandardProver_ {
     using PCS = typename Flavor::PCS;
 
   public:
-    explicit StandardProver_(std::shared_ptr<ProvingKey> input_key = nullptr);
+    explicit StandardProver_(std::shared_ptr<ProvingKey> input_key, std::shared_ptr<PCSCommitmentKey> commitment_key);
 
     void execute_preamble_round();
     void execute_wire_commitments_round();

--- a/cpp/src/barretenberg/honk/proof_system/prover_library.test.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover_library.test.cpp
@@ -57,12 +57,10 @@ template <class FF> class ProverLibraryTests : public testing::Test {
         // Define some mock inputs for proving key constructor
         static const size_t num_gates = 8;
         static const size_t num_public_inputs = 0;
-        auto reference_string = std::make_shared<barretenberg::srs::factories::FileProverCrs<curve::BN254>>(
-            num_gates + 1, "../srs_db/ignition");
 
         // Instatiate a proving_key and make a pointer to it. This will be used to instantiate a Prover.
-        auto proving_key = std::make_shared<typename Flavor::ProvingKey>(
-            num_gates, num_public_inputs, reference_string, ComposerType::STANDARD_HONK);
+        auto proving_key =
+            std::make_shared<typename Flavor::ProvingKey>(num_gates, num_public_inputs, ComposerType::STANDARD_HONK);
 
         // static const size_t program_width = StandardProver::settings_::program_width;
 
@@ -171,13 +169,11 @@ template <class FF> class ProverLibraryTests : public testing::Test {
         // Define some mock inputs for proving key constructor
         static const size_t circuit_size = 8;
         static const size_t num_public_inputs = 0;
-        auto reference_string = std::make_shared<barretenberg::srs::factories::FileProverCrs<curve::BN254>>(
-            circuit_size + 1, "../srs_db/ignition");
 
         // Instatiate a proving_key and make a pointer to it. This will be used to instantiate a Prover.
         using Flavor = honk::flavor::Ultra;
-        auto proving_key = std::make_shared<typename Flavor::ProvingKey>(
-            circuit_size, num_public_inputs, reference_string, ComposerType::STANDARD_HONK);
+        auto proving_key =
+            std::make_shared<typename Flavor::ProvingKey>(circuit_size, num_public_inputs, ComposerType::STANDARD_HONK);
 
         // Construct mock wire and permutation polynomials.
         // Note: for the purpose of checking the consistency between two methods of computing z_lookup, these
@@ -308,11 +304,9 @@ template <class FF> class ProverLibraryTests : public testing::Test {
         // Construct a proving_key
         static const size_t circuit_size = 8;
         static const size_t num_public_inputs = 0;
-        auto reference_string = std::make_shared<barretenberg::srs::factories::FileProverCrs<curve::BN254>>(
-            circuit_size + 1, "../srs_db/ignition");
         using Flavor = honk::flavor::Ultra;
-        auto proving_key = std::make_shared<typename Flavor::ProvingKey>(
-            circuit_size, num_public_inputs, reference_string, ComposerType::STANDARD_HONK);
+        auto proving_key =
+            std::make_shared<typename Flavor::ProvingKey>(circuit_size, num_public_inputs, ComposerType::STANDARD_HONK);
 
         // Get random challenge eta
         auto eta = FF::random_element();

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
@@ -29,9 +29,11 @@ namespace proof_system::honk {
  * @tparam settings Settings class.
  * */
 template <UltraFlavor Flavor>
-UltraProver_<Flavor>::UltraProver_(std::shared_ptr<typename Flavor::ProvingKey> input_key)
+UltraProver_<Flavor>::UltraProver_(std::shared_ptr<typename Flavor::ProvingKey> input_key,
+                                   std::shared_ptr<PCSCommitmentKey> commitment_key)
     : key(input_key)
-    , queue(input_key->circuit_size, transcript)
+    , queue(commitment_key, transcript)
+    , pcs_commitment_key(commitment_key)
 {
     prover_polynomials.q_c = key->q_c;
     prover_polynomials.q_l = key->q_l;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
@@ -25,7 +25,7 @@ template <UltraFlavor Flavor> class UltraProver_ {
     using CommitmentLabels = typename Flavor::CommitmentLabels;
 
   public:
-    explicit UltraProver_(std::shared_ptr<ProvingKey> input_key = nullptr);
+    explicit UltraProver_(std::shared_ptr<ProvingKey> input_key, std::shared_ptr<PCSCommitmentKey> commitment_key);
 
     void execute_preamble_round();
     void execute_wire_commitments_round();

--- a/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
@@ -39,7 +39,7 @@ template <typename Params> class work_queue {
     explicit work_queue(size_t circuit_size, proof_system::honk::ProverTranscript<FF>& prover_transcript)
         : transcript(prover_transcript)
         // TODO(luke): make this properly parameterized
-        , commitment_key(circuit_size, barretenberg::srs::get_crs_factory()->get_prover_crs(circuit_size)){};
+        , commitment_key(circuit_size, barretenberg::srs::get_crs_factory()){};
 
     work_queue(const work_queue& other) = default;
     work_queue(work_queue&& other) noexcept = default;

--- a/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/work_queue.hpp
@@ -32,14 +32,13 @@ template <typename Params> class work_queue {
   private:
     // TODO(luke): Consider handling all transcript interactions in the prover rather than embedding them in the queue.
     proof_system::honk::ProverTranscript<FF>& transcript;
-    CommitmentKey commitment_key;
+    std::shared_ptr<CommitmentKey> commitment_key;
     std::vector<work_item> work_item_queue;
 
   public:
-    explicit work_queue(size_t circuit_size, proof_system::honk::ProverTranscript<FF>& prover_transcript)
+    explicit work_queue(auto commitment_key, proof_system::honk::ProverTranscript<FF>& prover_transcript)
         : transcript(prover_transcript)
-        // TODO(luke): make this properly parameterized
-        , commitment_key(circuit_size, barretenberg::srs::get_crs_factory()){};
+        , commitment_key(commitment_key){};
 
     work_queue(const work_queue& other) = default;
     work_queue(work_queue&& other) noexcept = default;
@@ -113,7 +112,7 @@ template <typename Params> class work_queue {
             case WorkType::SCALAR_MULTIPLICATION: {
 
                 // Run pippenger multi-scalar multiplication.
-                auto commitment = commitment_key.commit(item.mul_scalars);
+                auto commitment = commitment_key->commit(item.mul_scalars);
 
                 transcript.send_to_verifier(item.label, commitment);
 

--- a/cpp/src/barretenberg/plonk/composer/composer_helper/composer_helper_lib.cpp
+++ b/cpp/src/barretenberg/plonk/composer/composer_helper/composer_helper_lib.cpp
@@ -51,8 +51,10 @@ std::shared_ptr<plonk::verification_key> compute_verification_key_common(
     auto circuit_verification_key = std::make_shared<plonk::verification_key>(
         proving_key->circuit_size, proving_key->num_public_inputs, vrs, proving_key->composer_type);
     // TODO(kesha): Dirty hack for now. Need to actually make commitment-agnositc
-    auto commitment_key =
-        proof_system::honk::pcs::kzg::Params::CommitmentKey(proving_key->circuit_size, proving_key->reference_string);
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+
+    auto commitment_key = proof_system::honk::pcs::kzg::Params::CommitmentKey(proving_key->circuit_size, crs_factory);
 
     for (size_t i = 0; i < proving_key->polynomial_manifest.size(); ++i) {
         const auto& poly_info = proving_key->polynomial_manifest[i];

--- a/cpp/src/barretenberg/plonk/composer/composer_helper/composer_helper_lib.cpp
+++ b/cpp/src/barretenberg/plonk/composer/composer_helper/composer_helper_lib.cpp
@@ -51,10 +51,8 @@ std::shared_ptr<plonk::verification_key> compute_verification_key_common(
     auto circuit_verification_key = std::make_shared<plonk::verification_key>(
         proving_key->circuit_size, proving_key->num_public_inputs, vrs, proving_key->composer_type);
     // TODO(kesha): Dirty hack for now. Need to actually make commitment-agnositc
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
-        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
-
-    auto commitment_key = proof_system::honk::pcs::kzg::Params::CommitmentKey(proving_key->circuit_size, crs_factory);
+    auto commitment_key =
+        proof_system::honk::pcs::kzg::Params::CommitmentKey(proving_key->circuit_size, proving_key->reference_string);
 
     for (size_t i = 0; i < proving_key->polynomial_manifest.size(); ++i) {
         const auto& poly_info = proving_key->polynomial_manifest[i];

--- a/cpp/src/barretenberg/plonk/composer/composer_helper/standard_plonk_composer_helper.hpp
+++ b/cpp/src/barretenberg/plonk/composer/composer_helper/standard_plonk_composer_helper.hpp
@@ -21,8 +21,8 @@ class StandardPlonkComposerHelper {
     static constexpr size_t program_width = CircuitConstructor::program_width;
     std::shared_ptr<plonk::proving_key> circuit_proving_key;
     std::shared_ptr<plonk::verification_key> circuit_verification_key;
-    // TODO(#218)(kesha): we need to put this into the commitment key, so that the composer doesn't have to handle srs
-    // at all
+
+    // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
     std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
 
     std::vector<uint32_t> recursive_proof_public_input_indices;

--- a/cpp/src/barretenberg/plonk/composer/composer_helper/turbo_plonk_composer_helper.hpp
+++ b/cpp/src/barretenberg/plonk/composer/composer_helper/turbo_plonk_composer_helper.hpp
@@ -20,8 +20,7 @@ class TurboPlonkComposerHelper {
     std::shared_ptr<plonk::proving_key> circuit_proving_key;
     std::shared_ptr<plonk::verification_key> circuit_verification_key;
 
-    // TODO(#218)(kesha): we need to put this into the commitment key, so that the composer doesn't have to handle srs
-    // at all
+    // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
     std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
 
     std::vector<uint32_t> recursive_proof_public_input_indices;

--- a/cpp/src/barretenberg/plonk/composer/composer_helper/ultra_plonk_composer_helper.hpp
+++ b/cpp/src/barretenberg/plonk/composer/composer_helper/ultra_plonk_composer_helper.hpp
@@ -22,8 +22,8 @@ class UltraPlonkComposerHelper {
     static constexpr size_t program_width = CircuitConstructor::NUM_WIRES;
     std::shared_ptr<plonk::proving_key> circuit_proving_key;
     std::shared_ptr<plonk::verification_key> circuit_verification_key;
-    // TODO(#218)(kesha): we need to put this into the commitment key, so that the composer doesn't have to handle srs
-    // at all
+
+    // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
     std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
 
     std::vector<uint32_t> recursive_proof_public_input_indices;

--- a/cpp/src/barretenberg/proof_system/composer/composer_helper_lib.test.cpp
+++ b/cpp/src/barretenberg/proof_system/composer/composer_helper_lib.test.cpp
@@ -16,7 +16,7 @@ class ComposerLibTests : public ::testing::Test {
     Flavor::ProvingKey proving_key = []() {
         auto crs_factory = barretenberg::srs::factories::CrsFactory();
         auto crs = crs_factory.get_prover_crs(4);
-        return Flavor::ProvingKey(/*circuit_size=*/4, /*num_public_inputs=*/0, crs, ComposerType::STANDARD);
+        return Flavor::ProvingKey(/*circuit_size=*/4, /*num_public_inputs=*/0, ComposerType::STANDARD);
     }();
 };
 

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -142,16 +142,11 @@ class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
 
     bool contains_recursive_proof;
     std::vector<uint32_t> recursive_proof_public_input_indices;
-    std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> crs;
     barretenberg::EvaluationDomain<FF> evaluation_domain;
 
     ProvingKey_() = default;
-    ProvingKey_(const size_t circuit_size,
-                const size_t num_public_inputs,
-                std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> const& crs,
-                ComposerType composer_type)
+    ProvingKey_(const size_t circuit_size, const size_t num_public_inputs, ComposerType composer_type)
     {
-        this->crs = crs;
         this->evaluation_domain = barretenberg::EvaluationDomain<FF>(circuit_size, circuit_size);
         PrecomputedPolynomials::circuit_size = circuit_size;
         this->log_circuit_size = numeric::get_msb(circuit_size);


### PR DESCRIPTION
# Description

Largely addresses https://github.com/AztecProtocol/barretenberg/issues/218. The model is as follows:

A composer helper owns a crs_factory which is essentially a container for a path to the srs plus methods for extracting the prover srs (g1 elements) or verfiier srs (g2 x) from the indicated file
This crs_factory is passed directly to the constructors for CommitmentKey and VerificationKey, which internally call get_prover_srs(circuit_size) or get_verifier_srs(). (Note: the IPA VerificationKey needs to compute MSMs rather than pairings and thus calls get_prover_srs()).
A composer helper also owns a shared pointer to a CommitmentKey which is used for two purposes: 1) instantiating a commitment_key pointer in the prover, and 2) computing the commitments for the VerificationKey
# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
