### PR TITLE
WASM handles stdout and stderr (at last).

### DIFF
--- a/cpp/src/barretenberg/common/c_bind.cpp
+++ b/cpp/src/barretenberg/common/c_bind.cpp
@@ -70,6 +70,15 @@ WASM_EXPORT void test_abort()
 
 #endif
 
+WASM_EXPORT void test_stdout_stderr()
+{
+    fprintf(stdout, "c: hello stdout!");
+    fflush(stdout);
+    fprintf(stderr, "c: hello stderr!");
+    std::cout << "c++: hello stdout!" << std::flush;
+    std::cerr << "c++: hello stderr!";
+}
+
 WASM_EXPORT void common_init_slab_allocator(uint32_t const* circuit_size)
 {
     barretenberg::init_slab_allocator(ntohl(*circuit_size));

--- a/cpp/src/barretenberg/common/c_bind.hpp
+++ b/cpp/src/barretenberg/common/c_bind.hpp
@@ -4,8 +4,4 @@
 
 WASM_EXPORT void test_threads(uint32_t const* threads, uint32_t const* iterations, uint32_t* out);
 
-WASM_EXPORT void test_thread_abort();
-
-WASM_EXPORT void test_abort();
-
 WASM_EXPORT void common_init_slab_allocator(uint32_t const* circuit_size);

--- a/cpp/src/barretenberg/wasi/wasi_stubs.cpp
+++ b/cpp/src/barretenberg/wasi/wasi_stubs.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <barretenberg/common/log.hpp>
+#include <string.h>
 
 extern "C" {
 
@@ -23,10 +24,24 @@ int32_t __imported_wasi_snapshot_preview1_poll_oneoff(int32_t, int32_t, int32_t,
 //     abort();
 // }
 
-int32_t __imported_wasi_snapshot_preview1_fd_write(int32_t, int32_t, int32_t, int32_t)
+struct iovs_struct {
+    char* data;
+    size_t len;
+};
+
+int32_t __imported_wasi_snapshot_preview1_fd_write(int32_t fd, iovs_struct* iovs_ptr, size_t iovs_len, size_t* ret_ptr)
 {
-    info("fd_write not implemented.");
-    abort();
+    if (fd != 1 && fd != 2) {
+        info("fd_write to unsupported file descriptor: ", fd);
+        abort();
+    }
+    std::string str;
+    for (size_t i = 0; i < iovs_len; ++i) {
+        auto iovs = iovs_ptr[i];
+        str += std::string(iovs.data, iovs.len);
+    }
+    logstr(str.c_str());
+    *ret_ptr = str.length();
     return 0;
 }
 
@@ -65,10 +80,16 @@ int32_t __imported_wasi_snapshot_preview1_environ_sizes_get(int32_t, int32_t)
 //     return 0;
 // }
 
-int32_t __imported_wasi_snapshot_preview1_fd_fdstat_get(int32_t, int32_t)
+int32_t __imported_wasi_snapshot_preview1_fd_fdstat_get(int32_t fd, void* buf)
 {
-    info("fd_fdstat_get not implemented.");
-    abort();
+    // info("fd_fdstat_get not implemented.");
+    // abort();
+    if (fd != 1 && fd != 2) {
+        info("fd_fdstat_get with unsupported file descriptor: ", fd);
+        abort();
+    }
+    memset(buf, 0, 20);
+    *(uint8_t*)buf = (uint8_t)fd;
     return 0;
 }
 

--- a/ts/src/barretenberg_wasm/barretenberg_wasm.test.ts
+++ b/ts/src/barretenberg_wasm/barretenberg_wasm.test.ts
@@ -25,6 +25,11 @@ describe('barretenberg wasm', () => {
   it('test abort', () => {
     expect(() => wasm.call('test_abort')).toThrow();
   });
+
+  it('test c/c++ stdout/stderr', () => {
+    // We're checking we don't crash, but you can manually confirm you see log lines handled by logstr.
+    wasm.call('test_stdout_stderr');
+  });
 });
 
 describe('barretenberg wasm worker', () => {

--- a/ts/src/barretenberg_wasm/barretenberg_wasm.ts
+++ b/ts/src/barretenberg_wasm/barretenberg_wasm.ts
@@ -121,7 +121,7 @@ export class BarretenbergWasm {
           view.setBigUint64(out, ts, true);
         },
         proc_exit: () => {
-          this.logger('HUNG: proc_exit was called. This is caused by unstable experimental wasi pthreads. Try again.');
+          this.logger('PANIC: proc_exit was called. This is maybe caused by "joining" with unstable wasi pthreads.');
           this.logger(new Error().stack!);
           killSelf();
         },


### PR DESCRIPTION
# Description

I'm not sure if it was a restriction of WASI-12 (maybe something around static initialisation), or if I just never expended the small amount of effort, but our WASM code has never been able to handle writing to stdout/stderr. It's basically why we had logstr.

This PR stubs the writes to stdout/stderr in the C++ code, such that the text is then forwarded to our logstr import.
This means that both bb.js and circuits benefit without needing to writing their own host imports.

An alternative would be to get rid of logstr, but its a simpler function that already exists, and saves us writing some fd_write imports in our TS code.

Bit of side note, I'll mention it here, but one caveat to this kind of wasi stubbing, is that we will need to rethink things a bit if we choose to run the WASM in a full WASI runtime. It's not an issue when we run tests in wasmtime, because we dont link in the "wasi" module where these stubs exist.

Eventually we maybe able to use something like wasmer in the browser to provide a full WASI runtime with threading. Word on the street is that they recently introduced pthread support. We would need to make sure we can also provide our get_data/set_data functions for handling memory swapping.

![image](https://github.com/AztecProtocol/barretenberg/assets/5764343/66443918-fa58-4281-bd6f-6c22ab115e39)
