### PR TITLE
bug fix: UltraPlonk RAM witnesses affect verification key

### DIFF
--- a/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
+++ b/cpp/src/barretenberg/honk/composer/composer_helper/ultra_honk_composer_helper.cpp
@@ -131,6 +131,21 @@ void UltraHonkComposerHelper::compute_witness(CircuitConstructor& circuit_constr
     proving_key->sorted_3 = s_3;
     proving_key->sorted_4 = s_4;
 
+    // Copy memory read/write record data into proving key. Prover needs to know which gates contain a read/write
+    // 'record' witness on the 4th wire. This wire value can only be fully computed once the first 3 wire polynomials
+    // have been committed to. The 4th wire on these gates will be a random linear combination of the first 3 wires,
+    // using the plookup challenge `eta`
+    proving_key->memory_read_records = std::vector<uint32_t>();
+    proving_key->memory_write_records = std::vector<uint32_t>();
+    proving_key->memory_read_records.reserve(circuit_constructor.memory_read_records.size());
+    proving_key->memory_write_records.reserve(circuit_constructor.memory_write_records.size());
+    std::copy(circuit_constructor.memory_read_records.begin(),
+              circuit_constructor.memory_read_records.end(),
+              std::back_inserter(proving_key->memory_read_records));
+    std::copy(circuit_constructor.memory_write_records.begin(),
+              circuit_constructor.memory_write_records.end(),
+              std::back_inserter(proving_key->memory_write_records));
+
     computed_witness = true;
 }
 
@@ -278,17 +293,6 @@ std::shared_ptr<UltraHonkComposerHelper::Flavor::ProvingKey> UltraHonkComposerHe
     proving_key->table_2 = poly_q_table_column_2;
     proving_key->table_3 = poly_q_table_column_3;
     proving_key->table_4 = poly_q_table_column_4;
-
-    // Copy memory read/write record data into proving key. Prover needs to know which gates contain a read/write
-    // 'record' witness on the 4th wire. This wire value can only be fully computed once the first 3 wire polynomials
-    // have been committed to. The 4th wire on these gates will be a random linear combination of the first 3 wires,
-    // using the plookup challenge `eta`
-    std::copy(circuit_constructor.memory_read_records.begin(),
-              circuit_constructor.memory_read_records.end(),
-              std::back_inserter(proving_key->memory_read_records));
-    std::copy(circuit_constructor.memory_write_records.begin(),
-              circuit_constructor.memory_write_records.end(),
-              std::back_inserter(proving_key->memory_write_records));
 
     proving_key->recursive_proof_public_input_indices =
         std::vector<uint32_t>(recursive_proof_public_input_indices.begin(), recursive_proof_public_input_indices.end());


### PR DESCRIPTION
Fixed bug where UltraPlonk RAM constraints made verification key depend on witness

Fixed following issues:

1. `memory_read_records`, `memory_write_records` are a function of the input witness, and should be assigned to the proving key in `compute_witness` (not `compute_proving_key`)
2. `apply_aux_selectors(AUX_SELECTORS::RAM_TIMESTAMP_CHECK)` was being called on the original ram records witnesses and NOT the set of sorted ram record witnesses

# Description

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
