### PR TITLE
fix: assume block constraint is only using new witness

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -5,6 +5,11 @@
 using namespace proof_system::plonk;
 
 namespace acir_format {
+
+// Returns a field_ct representing the poly_triple
+// This function only works for constant or single witness poly_triple
+// Supporting more general poly_triple for block constraints yield to complications when we have no witness assignment
+// (e.g during verification or getting the circuit size)
 field_ct poly_to_field_ct(const poly_triple poly, Composer& composer)
 {
     ASSERT(poly.q_m == 0);
@@ -14,6 +19,8 @@ field_ct poly_to_field_ct(const poly_triple poly, Composer& composer)
         return field_ct(poly.q_c);
     }
     field_ct x = field_ct::from_witness_index(&composer, poly.a);
+    ASSERT(poly.q_c == 0);
+    ASSERT(poly.q_l == 1);
     x.additive_constant = poly.q_c;
     x.multiplicative_constant = poly.q_l;
     return x;
@@ -37,16 +44,7 @@ void create_block_constraints(Composer& composer, const BlockConstraint constrai
             // For a ROM table, constant read should be optimised out:
             // The rom_table won't work with a constant read because the table may not be initialised
             ASSERT(op.index.q_l != 0);
-            // We create a new witness w to avoid issues with non-valid witness assignements:
-            // if witness are not assigned, then w will be zero and table[w] will work
-            fr w_value = 0;
-            if (has_valid_witness_assignments) {
-                // If witness are assigned, we use the correct value for w
-                w_value = index.get_value();
-            }
-            field_ct w = field_ct::from_witness(&composer, w_value);
-            value.assert_equal(table[w]);
-            w.assert_equal(index);
+            value.assert_equal(table[index]);
         }
     } break;
     case BlockType::RAM: {
@@ -54,9 +52,6 @@ void create_block_constraints(Composer& composer, const BlockConstraint constrai
         for (auto& op : constraint.trace) {
             field_ct value = poly_to_field_ct(op.value, composer);
             field_ct index = poly_to_field_ct(op.index, composer);
-            if (has_valid_witness_assignments == false) {
-                index = field_ct(0);
-            }
             if (op.access_type == 0) {
                 value.assert_equal(table.read(index));
             } else {


### PR DESCRIPTION
# Description

This is the PR #525 for the Noir branch

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
