### PR TITLE
fix: add NUM_RESERVED_GATES before fetching subgroup size in composer

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
+++ b/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
@@ -27,7 +27,8 @@ void AcirComposer::create_circuit(acir_format::acir_format& constraint_system)
 
     exact_circuit_size_ = composer_.get_num_gates();
     total_circuit_size_ = composer_.get_total_circuit_size();
-    circuit_subgroup_size_ = composer_.get_circuit_subgroup_size(total_circuit_size_);
+    circuit_subgroup_size_ =
+        composer_.get_circuit_subgroup_size(total_circuit_size_ + composer_.composer_helper.NUM_RESERVED_GATES);
     size_hint_ = circuit_subgroup_size_;
 }
 
@@ -44,7 +45,8 @@ void AcirComposer::init_proving_key(std::shared_ptr<barretenberg::srs::factories
 
     exact_circuit_size_ = composer_.get_num_gates();
     total_circuit_size_ = composer_.get_total_circuit_size();
-    circuit_subgroup_size_ = composer_.get_circuit_subgroup_size(total_circuit_size_);
+    circuit_subgroup_size_ =
+        composer_.get_circuit_subgroup_size(total_circuit_size_ + composer_.composer_helper.NUM_RESERVED_GATES);
 
     info("computing proving key...");
     proving_key_ = composer_.compute_proving_key();


### PR DESCRIPTION
# Description

Check this old PR for the description: https://github.com/AztecProtocol/barretenberg/pull/507

# Checklist:

- [X] I have reviewed my diff in github, line by line.
- [X] Every change is related to the PR description.
- [X] The branch has been merged with/rebased against the head of its merge target.
- [X] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [X] There are no circuit changes, OR a cryptographer has been assigned for review.
- [X] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [X] No superfluous `include` directives have been added.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [X] I'm happy for the PR to be merged at the reviewer's next convenience.
