### PR TITLE
fix: Revert "fix: add NUM_RESERVED_GATES before fetching subgroup size in composer"

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
+++ b/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
@@ -27,8 +27,7 @@ void AcirComposer::create_circuit(acir_format::acir_format& constraint_system)
 
     exact_circuit_size_ = composer_.get_num_gates();
     total_circuit_size_ = composer_.get_total_circuit_size();
-    circuit_subgroup_size_ =
-        composer_.get_circuit_subgroup_size(total_circuit_size_ + composer_.composer_helper.NUM_RESERVED_GATES);
+    circuit_subgroup_size_ = composer_.get_circuit_subgroup_size(total_circuit_size_);
     size_hint_ = circuit_subgroup_size_;
 }
 
@@ -45,8 +44,7 @@ void AcirComposer::init_proving_key(std::shared_ptr<barretenberg::srs::factories
 
     exact_circuit_size_ = composer_.get_num_gates();
     total_circuit_size_ = composer_.get_total_circuit_size();
-    circuit_subgroup_size_ =
-        composer_.get_circuit_subgroup_size(total_circuit_size_ + composer_.composer_helper.NUM_RESERVED_GATES);
+    circuit_subgroup_size_ = composer_.get_circuit_subgroup_size(total_circuit_size_);
 
     info("computing proving key...");
     proving_key_ = composer_.compute_proving_key();


### PR DESCRIPTION
Reverts AztecProtocol/barretenberg#539