### PR TITLE
fix: Adds `VERSION` file to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,3 +23,4 @@ jobs:
           pull-request-title-pattern: "chore(barretenberg): Release ${version}"
           extra-files: |
             cpp/CMakeLists.txt
+            VERSION

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.0
+v0.1.0 x-release-please-version


### PR DESCRIPTION
# Description

This ensures that the VERSION file also gets updated. Asked @dbanks12 and he noted that it is needed for Circle CI and should probably be kept in sync with the version in the `project()` in CMakeLists.txt

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
