### PR TITLE
chore: Slight template cleanup in sumcheck

### DIFF
--- a/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp
@@ -14,7 +14,8 @@ template <typename FF> class ArithmeticRelationBase {
     static constexpr size_t RELATION_LENGTH = 4;
 
     static constexpr size_t LEN_1 = 4; // arithmetic sub-relation
-    using LENGTHS = LengthsWrapper<LEN_1>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1>;
 
     /**
      * @brief Expression for the StandardArithmetic gate.
@@ -26,8 +27,8 @@ template <typename FF> class ArithmeticRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    void static add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulator,
+    template <typename AccumulatorTypes>
+    void static add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulator,
                                            const auto& extended_edges,
                                            const RelationParameters<FF>&,
                                            const FF& scaling_factor)
@@ -35,7 +36,7 @@ template <typename FF> class ArithmeticRelationBase {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
 
-        using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+        using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
         auto w_l = View(extended_edges.w_l);
         auto w_r = View(extended_edges.w_r);
         auto w_o = View(extended_edges.w_o);

--- a/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp
@@ -20,7 +20,8 @@ template <typename FF> class AuxiliaryRelationBase {
     static constexpr size_t LEN_4 = 6; // RAM consistency sub-relation 1
     static constexpr size_t LEN_5 = 6; // RAM consistency sub-relation 2
     static constexpr size_t LEN_6 = 6; // RAM consistency sub-relation 3
-    using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4, LEN_5, LEN_6>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2, LEN_3, LEN_4, LEN_5, LEN_6>;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -56,8 +57,8 @@ template <typename FF> class AuxiliaryRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+    template <typename AccumulatorTypes>
+    inline static void add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulators,
                                                   const auto& extended_edges,
                                                   const RelationParameters<FF>& relation_parameters,
                                                   const FF& scaling_factor)
@@ -68,7 +69,7 @@ template <typename FF> class AuxiliaryRelationBase {
         const auto& eta = relation_parameters.eta;
 
         // All subrelations have the same length so we use the same length view for all calculations
-        using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+        using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
         auto w_1 = View(extended_edges.w_l);
         auto w_2 = View(extended_edges.w_r);
         auto w_3 = View(extended_edges.w_o);

--- a/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/elliptic_relation.hpp
@@ -15,7 +15,8 @@ template <typename FF> class EllipticRelationBase {
 
     static constexpr size_t LEN_1 = 6; // x-coordinate sub-relation
     static constexpr size_t LEN_2 = 5; // y-coordinate sub-relation
-    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2>;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -27,8 +28,8 @@ template <typename FF> class EllipticRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+    template <typename AccumulatorTypes>
+    static void add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulators,
                                            const auto& extended_edges,
                                            const RelationParameters<FF>&,
                                            const FF& scaling_factor){
@@ -38,7 +39,7 @@ template <typename FF> class EllipticRelationBase {
         // clang-format off
         // Contribution (1)
         {
-            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
             auto x_1 = View(extended_edges.w_r);
             auto y_1 = View(extended_edges.w_o);
 
@@ -72,7 +73,7 @@ template <typename FF> class EllipticRelationBase {
         }
         // Contribution (2)
         {
-            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<1, typename AccumulatorTypes::AccumulatorViews>::type;
             auto x_1 = View(extended_edges.w_r);
             auto y_1 = View(extended_edges.w_o);
 

--- a/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp
@@ -17,7 +17,8 @@ template <typename FF> class GenPermSortRelationBase {
     static constexpr size_t LEN_2 = 6; // range constrain sub-relation 2
     static constexpr size_t LEN_3 = 6; // range constrain sub-relation 3
     static constexpr size_t LEN_4 = 6; // range constrain sub-relation 4
-    using LENGTHS = LengthsWrapper<LEN_1, LEN_2, LEN_3, LEN_4>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2, LEN_3, LEN_4>;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
@@ -34,8 +35,8 @@ template <typename FF> class GenPermSortRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    void static add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+    template <typename AccumulatorTypes>
+    void static add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulators,
                                            const auto& extended_edges,
                                            const RelationParameters<FF>&,
                                            const FF& scaling_factor)
@@ -43,7 +44,7 @@ template <typename FF> class GenPermSortRelationBase {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
 
-        using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+        using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
         auto w_1 = View(extended_edges.w_l);
         auto w_2 = View(extended_edges.w_r);
         auto w_3 = View(extended_edges.w_o);

--- a/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/lookup_relation.hpp
@@ -15,7 +15,8 @@ template <typename FF> class LookupRelationBase {
 
     static constexpr size_t LEN_1 = 6; // grand product construction sub-relation
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
-    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2>;
 
     /**
      * @brief Compute contribution of the lookup grand prod relation for a given edge (internal function)
@@ -35,8 +36,8 @@ template <typename FF> class LookupRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+    template <typename AccumulatorTypes>
+    inline static void add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulators,
                                                   const auto& extended_edges,
                                                   const RelationParameters<FF>& relation_parameters,
                                                   const FF& scaling_factor)
@@ -53,7 +54,7 @@ template <typename FF> class LookupRelationBase {
 
         // Contribution (1)
         {
-            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
             auto w_1 = View(extended_edges.w_l);
             auto w_2 = View(extended_edges.w_r);
             auto w_3 = View(extended_edges.w_o);
@@ -106,7 +107,7 @@ template <typename FF> class LookupRelationBase {
             std::get<0>(accumulators) += tmp * scaling_factor;
         }
         {
-            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<1, typename AccumulatorTypes::AccumulatorViews>::type;
             auto z_lookup_shift = View(extended_edges.z_lookup_shift);
             auto lagrange_last = View(extended_edges.lagrange_last);
 

--- a/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/permutation_relation.hpp
@@ -13,7 +13,8 @@ template <typename FF> class PermutationRelationBase {
 
     static constexpr size_t LEN_1 = 5; // grand product construction sub-relation
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
-    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2>;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -33,8 +34,8 @@ template <typename FF> class PermutationRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulator,
+    template <typename AccumulatorTypes>
+    inline static void add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulator,
                                                   const auto& input,
                                                   const RelationParameters<FF>& relation_parameters,
                                                   const FF& scaling_factor)
@@ -44,7 +45,7 @@ template <typename FF> class PermutationRelationBase {
         const auto& public_input_delta = relation_parameters.public_input_delta;
 
         {
-            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
             auto w_1 = View(input.w_l);
             auto w_2 = View(input.w_r);
             auto w_3 = View(input.w_o);
@@ -68,7 +69,7 @@ template <typename FF> class PermutationRelationBase {
                 scaling_factor;
         }
         {
-            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<1, typename AccumulatorTypes::AccumulatorViews>::type;
             auto z_perm_shift = View(input.z_perm_shift);
             auto lagrange_last = View(input.lagrange_last);
 
@@ -87,7 +88,8 @@ template <typename FF> class UltraPermutationRelationBase {
 
     static constexpr size_t LEN_1 = 6; // grand product construction sub-relation
     static constexpr size_t LEN_2 = 3; // left-shiftable polynomial sub-relation
-    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2>;
 
     /**
      * @brief Compute contribution of the permutation relation for a given edge (internal function)
@@ -100,8 +102,8 @@ template <typename FF> class UltraPermutationRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    inline static void add_edge_contribution_impl(typename TypeMuncher::Accumulators& accumulators,
+    template <typename AccumulatorTypes>
+    inline static void add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulators,
                                                   const auto& extended_edges,
                                                   const RelationParameters<FF>& relation_parameters,
                                                   const FF& scaling_factor)
@@ -112,7 +114,7 @@ template <typename FF> class UltraPermutationRelationBase {
 
         // Contribution (1)
         {
-            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
             auto w_1 = View(extended_edges.w_l);
             auto w_2 = View(extended_edges.w_r);
             auto w_3 = View(extended_edges.w_o);
@@ -139,7 +141,7 @@ template <typename FF> class UltraPermutationRelationBase {
         }
         // Contribution (2)
         {
-            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<1, typename AccumulatorTypes::AccumulatorViews>::type;
             auto z_perm_shift = View(extended_edges.z_perm_shift);
             auto lagrange_last = View(extended_edges.lagrange_last);
 

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_types.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_types.hpp
@@ -22,32 +22,6 @@ namespace proof_system::honk::sumcheck {
  * sub-relations within each relation, where, for efficiency, each sub-relation has its own specified degree.
  */
 
-// Helper struct to allow passing an arbitrary collection of lengths to the AccumulatorTypes
-template <size_t... Values> struct LengthsWrapper {};
-
-// Forward declarations of AccumulatorTypesHelpers
-template <typename FF, typename LengthsWrapper> struct UnivariateAccumulatorTypesHelper;
-template <typename FF, typename LengthsWrapper> struct ValueAccumulatorTypesHelper;
-
-// Helper to define value (FF) based accumulator types
-template <typename FF, size_t... Values> struct ValueAccumulatorTypesHelper<FF, LengthsWrapper<Values...>> {
-    using Accumulators = std::array<FF, sizeof...(Values)>;
-    using AccumulatorViews = std::array<FF, sizeof...(Values)>; // there is no "view" type here
-};
-
-// Accumulator types for values (FFs)
-template <typename FF, typename Lengths> using ValueAccumulatorTypes = ValueAccumulatorTypesHelper<FF, Lengths>;
-
-// Helper to define Univariate based accumulator types
-template <typename FF, size_t... Values> struct UnivariateAccumulatorTypesHelper<FF, LengthsWrapper<Values...>> {
-    using Accumulators = std::tuple<Univariate<FF, Values>...>;
-    using AccumulatorViews = std::tuple<UnivariateView<FF, Values>...>;
-};
-
-// Accumulator types for Univariates
-template <typename FF, typename Lengths>
-using UnivariateAccumulatorTypes = UnivariateAccumulatorTypesHelper<FF, Lengths>;
-
 /**
  * @brief A wrapper for Relations to expose methods used by the Sumcheck prover or verifier to add the contribution of
  * a given relation to the corresponding accumulator.
@@ -56,10 +30,20 @@ using UnivariateAccumulatorTypes = UnivariateAccumulatorTypesHelper<FF, Lengths>
  * @tparam RelationBase Base class that implements the arithmetic for a given relation (or set of sub-relations)
  */
 template <typename FF, template <typename> typename RelationBase> class RelationWrapper {
+  private:
+    template <size_t... Values> struct UnivariateAccumulatorTypes {
+        using Accumulators = std::tuple<Univariate<FF, Values>...>;
+        using AccumulatorViews = std::tuple<UnivariateView<FF, Values>...>;
+    };
+    template <size_t... Values> struct ValueAccumulatorTypes {
+        using Accumulators = std::array<FF, sizeof...(Values)>;
+        using AccumulatorViews = std::array<FF, sizeof...(Values)>; // there is no "view" type here
+    };
+
   public:
     using Relation = RelationBase<FF>;
-    using UnivariateAccumTypes = UnivariateAccumulatorTypes<FF, typename Relation::LENGTHS>;
-    using ValueAccumTypes = ValueAccumulatorTypes<FF, typename Relation::LENGTHS>;
+    using UnivariateAccumTypes = typename Relation::template AccumulatorTypesBase<UnivariateAccumulatorTypes>;
+    using ValueAccumTypes = typename Relation::template AccumulatorTypesBase<ValueAccumulatorTypes>;
 
     using RelationUnivariates = typename UnivariateAccumTypes::Accumulators;
     using RelationValues = typename ValueAccumTypes::Accumulators;

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp
@@ -15,7 +15,8 @@ template <typename FF> class UltraArithmeticRelationBase {
 
     static constexpr size_t LEN_1 = 6; // primary arithmetic sub-relation
     static constexpr size_t LEN_2 = 5; // secondary arithmetic sub-relation
-    using LENGTHS = LengthsWrapper<LEN_1, LEN_2>;
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2>;
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
@@ -68,8 +69,8 @@ template <typename FF> class UltraArithmeticRelationBase {
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
-    template <typename TypeMuncher>
-    void static add_edge_contribution_impl(typename TypeMuncher::Accumulators& evals,
+    template <typename AccumulatorTypes>
+    void static add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& evals,
                                            const auto& extended_edges,
                                            const RelationParameters<FF>&,
                                            const FF& scaling_factor){
@@ -78,7 +79,7 @@ template <typename FF> class UltraArithmeticRelationBase {
         // clang-format off
         // Contribution 1
         {   
-            using View = typename std::tuple_element<0, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
             auto w_l = View(extended_edges.w_l);
             auto w_r = View(extended_edges.w_r);
             auto w_o = View(extended_edges.w_o);
@@ -103,7 +104,7 @@ template <typename FF> class UltraArithmeticRelationBase {
         }
         // Contribution 2
         {
-            using View = typename std::tuple_element<1, typename TypeMuncher::AccumulatorViews>::type;
+            using View = typename std::tuple_element<1, typename AccumulatorTypes::AccumulatorViews>::type;
             auto w_l = View(extended_edges.w_l);
             auto w_4 = View(extended_edges.w_4);
             auto w_l_shift = View(extended_edges.w_l_shift);


### PR DESCRIPTION
# Description

Attempt to reduce level of template abstraction in `relation_types.hpp`.

Previously we were relying on explicit template instantiation to forward a parameter pack of template parameters into structs that define the types we use to accumulate values in the sumcheck protocol (one parameter pack per relation).

This is replaced with requiring each sumcheck relation class to now define a type `AccumulatorTypesBase`, which directly instantiates a new type with the parameter pack that is specific to each relation. 


`TypeMuncher` is also renamed to `AccumulatorTypes` to better describe the intended purpose of the template parameter.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] The branch has been merged with/rebased against the head of its merge target.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
- [x] No superfluous `include` directives have been added.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
