### PR TITLE
fix: Update versioning in nix files when a release is made

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,3 +24,5 @@ jobs:
           extra-files: |
             cpp/CMakeLists.txt
             VERSION
+            barretenberg.nix
+            barretenberg-wasm.nix

--- a/barretenberg-wasm.nix
+++ b/barretenberg-wasm.nix
@@ -6,7 +6,7 @@ in
 stdenv.mkDerivation
 {
   pname = "barretenberg.wasm";
-  version = "0.1.0";
+  version = "0.1.0"; # x-release-please-version
 
   src = ./cpp;
 

--- a/barretenberg.nix
+++ b/barretenberg.nix
@@ -14,7 +14,7 @@ in
 buildEnv.mkDerivation
 {
   pname = "libbarretenberg";
-  version = "0.1.0";
+  version = "0.1.0"; # x-release-please-version
 
   src = ./cpp;
 


### PR DESCRIPTION
# Description

This updates the versioning number in nix files when we make releases.

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
