### PR TITLE
fix: Soundness issue in bigfield's `evaluate_multiply_add` method

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2148,38 +2148,40 @@ void bigfield<C, T>::unsafe_evaluate_multiply_add(const bigfield& input_left,
                 linear_terms =
                     linear_terms.add_two(-remainders[2 * i].prime_basis_limb, -remainders[2 * i + 1].prime_basis_limb);
             }
+        }
+        if ((remainders.size() & 1UL) == 1UL) {
+            linear_terms += -remainders[remainders.size() - 1].prime_basis_limb;
+        }
+        // This is where we show our identity is zero mod r (to use CRT we show it's zero mod r and mod 2^t)
+        field_t<C>::evaluate_polynomial_identity(
+            left.prime_basis_limb, to_mul.prime_basis_limb, quotient.prime_basis_limb * neg_prime, linear_terms);
 
-            // This is where we show our identity is zero mod r (to use CRT we show it's zero mod r and mod 2^t)
-            field_t<C>::evaluate_polynomial_identity(
-                left.prime_basis_limb, to_mul.prime_basis_limb, quotient.prime_basis_limb * neg_prime, linear_terms);
+        const uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
+        const uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);
 
-            const uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
-            const uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);
-
-            const barretenberg::fr carry_lo_shift(uint256_t(uint256_t(1) << carry_lo_msb));
-            if ((carry_hi_msb + carry_lo_msb) < field_t<C>::modulus.get_msb()) {
-                field_t carry_combined = carry_lo + (carry_hi * carry_lo_shift);
-                carry_combined = carry_combined.normalize();
-                const auto accumulators = ctx->decompose_into_base4_accumulators(
-                    carry_combined.witness_index,
-                    static_cast<size_t>(carry_lo_msb + carry_hi_msb),
-                    "bigfield: carry_combined too large in unsafe_evaluate_multiply_add.");
-                field_t<C> accumulator_midpoint =
-                    field_t<C>::from_witness_index(ctx, accumulators[static_cast<size_t>((carry_hi_msb / 2) - 1)]);
-                carry_hi.assert_equal(accumulator_midpoint, "bigfield multiply range check failed");
-            } else {
-                carry_lo = carry_lo.normalize();
-                carry_hi = carry_hi.normalize();
-                ctx->decompose_into_base4_accumulators(carry_lo.witness_index,
-                                                       static_cast<size_t>(carry_lo_msb),
-                                                       "bigfield: carry_lo too large in unsafe_evaluate_multiply_add.");
-                ctx->decompose_into_base4_accumulators(carry_hi.witness_index,
-                                                       static_cast<size_t>(carry_hi_msb),
-                                                       "bigfield: carry_hi too large in unsafe_evaluate_multiply_add.");
-            }
+        const barretenberg::fr carry_lo_shift(uint256_t(uint256_t(1) << carry_lo_msb));
+        if ((carry_hi_msb + carry_lo_msb) < field_t<C>::modulus.get_msb()) {
+            field_t carry_combined = carry_lo + (carry_hi * carry_lo_shift);
+            carry_combined = carry_combined.normalize();
+            const auto accumulators = ctx->decompose_into_base4_accumulators(
+                carry_combined.witness_index,
+                static_cast<size_t>(carry_lo_msb + carry_hi_msb),
+                "bigfield: carry_combined too large in unsafe_evaluate_multiply_add.");
+            field_t<C> accumulator_midpoint =
+                field_t<C>::from_witness_index(ctx, accumulators[static_cast<size_t>((carry_hi_msb / 2) - 1)]);
+            carry_hi.assert_equal(accumulator_midpoint, "bigfield multiply range check failed");
+        } else {
+            carry_lo = carry_lo.normalize();
+            carry_hi = carry_hi.normalize();
+            ctx->decompose_into_base4_accumulators(carry_lo.witness_index,
+                                                   static_cast<size_t>(carry_lo_msb),
+                                                   "bigfield: carry_lo too large in unsafe_evaluate_multiply_add.");
+            ctx->decompose_into_base4_accumulators(carry_hi.witness_index,
+                                                   static_cast<size_t>(carry_hi_msb),
+                                                   "bigfield: carry_hi too large in unsafe_evaluate_multiply_add.");
         }
     }
-}
+} // namespace stdlib
 /**
  * Evaluate a quadratic relation involving multiple multiplications
  *

--- a/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2181,7 +2181,7 @@ void bigfield<C, T>::unsafe_evaluate_multiply_add(const bigfield& input_left,
                                                    "bigfield: carry_hi too large in unsafe_evaluate_multiply_add.");
         }
     }
-} // namespace stdlib
+}
 /**
  * Evaluate a quadratic relation involving multiple multiplications
  *


### PR DESCRIPTION
# Description

[This](https://github.com/AztecProtocol/barretenberg/pull/123) pull request made it so that unsafe_evaluate_multiply_add became unconstrained for cases, where there was just 1 remainder. As in, the prime limb and basis limb constraints that bound the relation together were gone, making bigfield once again a nice ctf task.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] The branch has been merged with/rebased against the head of its merge target.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
- [x] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
