### PR TITLE
chore: Run Benchmarks on all PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,10 +1,8 @@
 name: Barretenberg Benchmarks
 
-# Only run on push to master
+# Run on push to any branch (only record official bench result on push to master)
 on:
   push:
-    branches:
-      - master
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
@@ -56,8 +54,8 @@ jobs:
           output-file-path: cpp/src/barretenberg/benchmark/honk_bench/bench_results.json
           # Access token to deploy GitHub Pages branch
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Push and deploy GitHub pages branch automatically
-          auto-push: true
+          # For master branch only, push and deploy results to GitHub pages branch
+          auto-push: ${{ github.ref == 'master' }}
           # Enable Job Summary for PRs
           summary-always: true
           # Show alert with commit comment on detecting possible performance regression


### PR DESCRIPTION
# Description

Run benchmarks on all PRs but only update plots based on pushes to master

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
