### PR TITLE
refactor: Move nullifier tree batch insertion logic into bberg

### DIFF
--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
@@ -111,7 +111,6 @@ class WrappedNullifierLeaf {
     std::optional<nullifier_leaf> data;
 };
 
-// TODO(SEAN): Come back to
 inline std::ostream& operator<<(std::ostream& os, WrappedNullifierLeaf const& leaf)
 {
     if (!leaf.has_value()) {

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -85,7 +85,29 @@ bool check_has_less_than(std::vector<fr> const& values, fr const& value)
     return false;
 }
 
-// handle synthetic membership assertions
+/**
+ * @brief Insert a batch of values into the tree, returning the low nullifiers membership information (leaf, sibling
+ * path, index)
+ *
+ * Special Considerations
+ *
+ * Short algorithm description:
+ * When batch inserting values into the tree, we first update their "low_nullifiers" (the node that will insert to the
+ * inserted value).
+ *  - For each low nullifier that we update, we need to perform a membership check against the current root of the tree.
+ *  - Once membership is confirmed, we can update the leaf, then use the same sibling path to update the root.
+ *  - The next membership check will be against the new root.
+ *
+ * If the low nullifier for a value exists within the batch being inserted, then we cannot perform a membership check,
+ * as it has not yet been inserted! In this case we provide an all 0 sibling path and all 0 low nullifier, all
+ * corresponding aztec circuits account for this case.
+ *
+ * A description of the algorithm can be found here:
+ * https://colab.research.google.com/drive/1A0gizduSi4FIiIJZ8OylwIpO9-OTqV-R
+ *
+ * @param values - An array of values to insert into the tree.
+ * @return std::vector<LowLeafWitnessData>
+ */
 LowLeafWitnessData NullifierMemoryTree::batch_insert(std::vector<fr> const& values)
 {
     // Start insertion index

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -89,7 +89,7 @@ bool check_has_less_than(std::vector<fr> const& values, fr const& value)
 LowLeafWitnessData NullifierMemoryTree::batch_insert(std::vector<fr> const& values)
 {
     // Start insertion index
-    fr const start_insertion_index = this->size();
+    size_t const start_insertion_index = this->size();
 
     // Low nullifiers
     auto values_size = values.size();
@@ -201,8 +201,6 @@ LowLeafWitnessData NullifierMemoryTree::batch_insert(std::vector<fr> const& valu
             // update old value in tree
             update_element_in_place(current, new_leaf);
         }
-
-        info("pending at index ", i, " ", pending_insertion_tree);
     }
 
     // resize leaves array
@@ -212,7 +210,7 @@ LowLeafWitnessData NullifierMemoryTree::batch_insert(std::vector<fr> const& valu
 
         // Update the old leaf in the tree
         // update old value in tree
-        update_element_in_place(size_t(start_insertion_index) + i, pending);
+        update_element_in_place(start_insertion_index + i, pending);
     }
 
     // Return tuple of low nullifiers and sibling paths

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -72,6 +72,160 @@ fr NullifierMemoryTree::update_element(fr const& value)
     return root;
 }
 
+// Check for a larger value in an array
+bool check_has_less_than(std::vector<fr> const& values, fr const& value)
+{
+    // Must perform comparisons on integers
+    auto const value_as_uint = uint256_t(value);
+    for (auto const& v : values) {
+        if (uint256_t(v) < value_as_uint) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// handle synthetic membership assertions
+LowLeafWitnessData NullifierMemoryTree::batch_insert(std::vector<fr> const& values)
+{
+    // Start insertion index
+    fr const start_insertion_index = this->size();
+
+    // Low nullifiers
+    auto values_size = values.size();
+    std::vector<nullifier_leaf> low_nullifiers(values_size);
+    std::vector<nullifier_leaf> pending_insertion_tree(values_size);
+
+    // Low nullifier sibling paths
+    std::vector<std::vector<fr>> sibling_paths(values_size);
+
+    // Low nullifier indexes
+    std::vector<uint32_t> low_nullifier_indexes(values_size);
+
+    // Keep track of the currently touched nodes while updating
+    std::map<size_t, std::vector<fr>> touched_nodes;
+
+    // Keep track of 0 values
+    std::vector<fr> const empty_sp(depth_, 0);
+    auto const empty_leaf = nullifier_leaf::empty();
+    uint32_t const empty_index = 0;
+
+    // Find the leaf with the value closest and less than `value` for each value
+    for (size_t i = 0; i < values.size(); ++i) {
+
+        auto new_value = values[i];
+        auto insertion_index = start_insertion_index + i;
+
+        size_t current = 0;
+        bool is_already_present = false;
+        std::tie(current, is_already_present) = find_closest_leaf(leaves_, new_value);
+
+        // If the inserted value is 0, then we ignore and provide a dummy low nullifier
+        if (new_value == 0) {
+            sibling_paths[i] = empty_sp;
+            low_nullifier_indexes[i] = empty_index;
+            low_nullifiers[i] = empty_leaf;
+            pending_insertion_tree[i] = empty_leaf;
+            continue;
+        }
+
+        // If the low_nullifier node has been touched this sub tree insertion, we provide a dummy sibling path
+        // It will be up to the circuit to check if the included node is valid vs the other nodes that have been
+        // inserted before it If it has not been touched, we provide a sibling path then update the nodes pointers
+        auto prev_nodes = touched_nodes.find(current);
+
+        bool has_less_than = false;
+        if (prev_nodes != touched_nodes.end()) {
+            has_less_than = check_has_less_than(prev_nodes->second, new_value);
+        }
+        // If there is a lower value in the tree, we need to check the current low nullifiers for one that can be used
+        if (has_less_than) {
+            for (size_t j = 0; j < pending_insertion_tree.size(); ++j) {
+
+                nullifier_leaf& pending = pending_insertion_tree[j];
+                // Skip checking empty values
+                if (pending.is_empty()) {
+                    continue;
+                }
+
+                if (uint256_t(pending.value) < uint256_t(new_value) &&
+                    (uint256_t(pending.nextValue) > uint256_t(new_value) || pending.nextValue == fr::zero())) {
+
+                    // Add a new pending low nullifier for this value
+                    nullifier_leaf const current_low_leaf = { .value = new_value,
+                                                              .nextIndex = pending_insertion_tree[j].nextIndex,
+                                                              .nextValue = pending_insertion_tree[j].nextValue };
+
+                    pending_insertion_tree[i] = current_low_leaf;
+
+                    // Update the pending low nullifier to point at the new value
+                    pending.nextValue = new_value;
+                    pending.nextIndex = insertion_index;
+
+                    break;
+                }
+            }
+
+            // add empty low nullifier
+            sibling_paths[i] = empty_sp;
+            low_nullifier_indexes[i] = empty_index;
+            low_nullifiers[i] = empty_leaf;
+        } else {
+            // Update the touched mapping
+            if (prev_nodes == touched_nodes.end()) {
+                std::vector<fr> const new_touched_values = { new_value };
+                touched_nodes[current] = new_touched_values;
+            } else {
+                prev_nodes->second.push_back(new_value);
+            }
+
+            nullifier_leaf const low_nullifier = leaves_[current].unwrap();
+            std::vector<fr> const sibling_path = this->get_sibling_path(current);
+
+            sibling_paths[i] = sibling_path;
+            low_nullifier_indexes[i] = static_cast<uint32_t>(current);
+            low_nullifiers[i] = low_nullifier;
+
+            // TODO(SEAN): rename this and new leaf
+            nullifier_leaf insertion_leaf = { .value = new_value,
+                                              .nextIndex = low_nullifier.nextIndex,
+                                              .nextValue = low_nullifier.nextValue };
+            pending_insertion_tree[i] = insertion_leaf;
+
+            // Update the current low nullifier
+            nullifier_leaf const new_leaf = { .value = low_nullifier.value,
+                                              .nextIndex = insertion_index,
+                                              .nextValue = new_value };
+
+            // Update the old leaf in the tree
+            // update old value in tree
+            update_element_in_place(current, new_leaf);
+        }
+
+        info("pending at index ", i, " ", pending_insertion_tree);
+    }
+
+    // resize leaves array
+    this->leaves_.resize(this->leaves_.size() + pending_insertion_tree.size());
+    for (size_t i = 0; i < pending_insertion_tree.size(); ++i) {
+        nullifier_leaf const pending = pending_insertion_tree[i];
+
+        // Update the old leaf in the tree
+        // update old value in tree
+        update_element_in_place(size_t(start_insertion_index) + i, pending);
+    }
+
+    // Return tuple of low nullifiers and sibling paths
+    return std::make_tuple(low_nullifiers, sibling_paths, low_nullifier_indexes);
+}
+
+// Update the value of a leaf in place
+fr NullifierMemoryTree::update_element_in_place(size_t index, const nullifier_leaf& leaf)
+{
+    this->leaves_[index].set(leaf);
+    return update_element(index, leaf.hash());
+}
+
 } // namespace merkle_tree
 } // namespace stdlib
 } // namespace proof_system::plonk

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
@@ -7,6 +7,9 @@ namespace proof_system::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
+// tuple(nullifier_leaf, sibling_path, index) // utility alias
+using LowLeafWitnessData = std::tuple<std::vector<nullifier_leaf>, std::vector<std::vector<fr>>, std::vector<uint32_t>>;
+
 using namespace barretenberg;
 
 /**
@@ -76,14 +79,21 @@ class NullifierMemoryTree : public MemoryTree {
     using MemoryTree::root;
     using MemoryTree::update_element;
 
-    fr update_element(fr const& value);
-
+    // Inspectors
+    fr size() { return leaves_.size(); }
+    fr total_size() const { return total_size_; }
+    fr depth() const { return depth_; }
     const std::vector<barretenberg::fr>& get_hashes() { return hashes_; }
     const WrappedNullifierLeaf get_leaf(size_t index)
     {
         return (index < leaves_.size()) ? leaves_[index] : WrappedNullifierLeaf::zero();
     }
     const std::vector<WrappedNullifierLeaf>& get_leaves() { return leaves_; }
+
+    // Mutators
+    fr update_element(fr const& value);
+    fr update_element_in_place(size_t index, const nullifier_leaf& value);
+    LowLeafWitnessData batch_insert(std::vector<fr> const& values);
 
   protected:
     using MemoryTree::depth_;

--- a/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
+++ b/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
@@ -80,7 +80,7 @@ class NullifierMemoryTree : public MemoryTree {
     using MemoryTree::update_element;
 
     // Inspectors
-    fr size() { return leaves_.size(); }
+    size_t size() { return leaves_.size(); }
     fr total_size() const { return total_size_; }
     fr depth() const { return depth_; }
     const std::vector<barretenberg::fr>& get_hashes() { return hashes_; }


### PR DESCRIPTION
# Description

linked to: https://github.com/AztecProtocol/aztec-packages/issues/335

Right now batch insertion info that is used by the circuits is currently implemented within a file called `nullifier_tree_testing_harness` it was placed here during the hackathon to get circuits up and running quickly. This pr moves the logic (just the batch insertion algorithm) into core bb.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
