### PR TITLE
chore: run acir-format-tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,18 @@ jobs:
           command: cond_spot_run_tests barretenberg-x86_64-linux-clang-assert 1 stdlib-tests
       - *save_logs
 
+  acir-format-tests:
+    docker:
+      - image: aztecprotocol/alpine-build-image
+    resource_class: small
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_spot_run_tests barretenberg-x86_64-linux-clang-assert 1 acir_format_tests
+      - *save_logs
+
   barretenberg-tests:
     docker:
       - image: aztecprotocol/alpine-build-image
@@ -331,6 +343,7 @@ workflows:
       - wasm-linux-clang: *defaults
       - proof-system-tests: *bb_test
       - honk-tests: *bb_test
+      - acir-format-tests: *bb_test
       - barretenberg-tests: *bb_test
       - stdlib-tests: *bb_test
       - stdlib-recursion-turbo-tests: *bb_test

--- a/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -12,29 +12,37 @@ size_t generate_block_constraint(acir_format::BlockConstraint& constraint, std::
     witness_values.emplace_back(1);
     witness_len++;
 
-    fr two = fr::one() + fr::one();
     poly_triple a0 = poly_triple{
-        .a = 1,
+        .a = 2,
         .b = 0,
         .c = 0,
         .q_m = 0,
-        .q_l = two,
+        .q_l = fr::one(),
         .q_r = 0,
         .q_o = 0,
         .q_c = 0,
     };
-    fr three = fr::one() + two;
     poly_triple a1 = poly_triple{
+        .a = 3,
+        .b = 0,
+        .c = 0,
+        .q_m = 0,
+        .q_l = fr::one(),
+        .q_r = 0,
+        .q_o = 0,
+        .q_c = 0,
+    };
+    poly_triple r1 = poly_triple{
         .a = 0,
         .b = 0,
         .c = 0,
         .q_m = 0,
-        .q_l = 0,
+        .q_l = fr::one(),
         .q_r = 0,
         .q_o = 0,
-        .q_c = three,
+        .q_c = 0,
     };
-    poly_triple r1 = poly_triple{
+    poly_triple r2 = poly_triple{
         .a = 1,
         .b = 0,
         .c = 0,
@@ -42,17 +50,7 @@ size_t generate_block_constraint(acir_format::BlockConstraint& constraint, std::
         .q_l = fr::one(),
         .q_r = 0,
         .q_o = 0,
-        .q_c = fr::neg_one(),
-    };
-    poly_triple r2 = poly_triple{
-        .a = 1,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = two,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = fr::neg_one(),
+        .q_c = 0,
     };
     poly_triple y = poly_triple{
         .a = 2,


### PR DESCRIPTION
# Description

This PR pulls across the changes in the master circleci config to run the acir-format tests to the "Noir master" branch.

This shows how #528 broke the acir-format tests which need to be updated (along with those in acvm-backend-barretenberg).

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] The branch has been merged with/rebased against the head of its merge target.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
- [x] No superfluous `include` directives have been added.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
