### PR TITLE
fix: Avoid bb.js memory issues.

### DIFF
--- a/cpp/src/barretenberg/common/slab_allocator.cpp
+++ b/cpp/src/barretenberg/common/slab_allocator.cpp
@@ -103,18 +103,7 @@ void SlabAllocator::init(size_t circuit_size_hint)
     //                                             1;        // Miscellaneous.
     // /*   6 MiB */ prealloc_num[base_size * 12] = 2 +      // next_var_index, prev_var_index
     //                                              2;       // real_variable_index, real_variable_tags
-    /*  16 MiB */ prealloc_num[base_size * 32] = 11 +     // Composer base selector vectors.
-                                                 4 +      // Monomial wires.
-                                                 4 +      // Lagrange wires.
-                                                 15 +     // Monomial constraint selectors.
-                                                 15 +     // Lagrange constraint selectors.
-                                                 8 +      // Monomial perm selectors.
-                                                 8 +      // Lagrange perm selectors.
-                                                 1 +      // Monomial sorted poly.
-                                                 5 +      // Lagrange sorted poly.
-                                                 2 +      // Perm poly.
-                                                 4;       // Quotient poly.
-                                                          //  8;       // Miscellaneous.
+    /*  16 MiB */ prealloc_num[base_size * 32] = 11;      // Composer base selector vectors.
     /*  32 MiB */ prealloc_num[base_size * 32 * 2] = 1;   // Miscellaneous.
     /*  50 MiB */ prealloc_num[base_size * 32 * 3] = 1;   // Variables.
     /*  64 MiB */ prealloc_num[base_size * 32 * 4] = 1 +  // SRS monomial points.

--- a/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_cache.cpp
+++ b/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_cache.cpp
@@ -3,7 +3,7 @@
 namespace proof_system {
 
 PolynomialStoreCache::PolynomialStoreCache()
-    : max_cache_size_(70)
+    : max_cache_size_(40)
 {}
 
 PolynomialStoreCache::PolynomialStoreCache(size_t max_cache_size)


### PR DESCRIPTION
# Description

Less aggressive slab allocation and sporadic memory errors (leading to a timeout in bb.js CI). Cache reduced accordingly. Parameters here are chosen heuristically, and the new values were arrived at in a call with @charlielye.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] The branch has been merged with/rebased against the head of its merge target.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
- [x] No superfluous `include` directives have been added.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
