### PR TITLE
chore: Run nix build for caching on noir branch

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,9 +3,7 @@ name: Nix builds
 on:
   push:
     branches:
-      - master
-  schedule:
-    - cron: "0 2 * * *" # run at 2 AM UTC
+      - acvm-backend-barretenberg
   workflow_dispatch:
 
 # This will cancel previous runs when a branch or PR is updated

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build barretenberg as ${{ matrix.target }}
         if: ${{ inputs.ref }}
         run: |
-          nix build -L AztecProtocol/barretenberg/${{ inputs.ref }}#${{ matrix.target }}
+          nix build -L github:AztecProtocol/barretenberg/${{ inputs.ref }}#${{ matrix.target }}
 
       - name: Prepare artifact
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - acvm-backend-barretenberg
   workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        description: An arbitrary ref to build
+        required: false
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
@@ -40,8 +45,14 @@ jobs:
           nix flake check
 
       - name: Build barretenberg as ${{ matrix.target }}
+        if: ${{ !inputs.ref }}
         run: |
           nix build -L .#${{ matrix.target }}
+
+      - name: Build barretenberg as ${{ matrix.target }}
+        if: ${{ inputs.ref }}
+        run: |
+          nix build -L AztecProtocol/barretenberg/${{ inputs.ref }}#${{ matrix.target }}
 
       - name: Prepare artifact
         run: |


### PR DESCRIPTION
# Description

We need to build and cache bb in nix to avoid building it on every Noir CI run.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
