### PR TITLE
chore(ci): Remove nix build on master branch & schedule

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,9 +3,7 @@ name: Nix builds
 on:
   push:
     branches:
-      - master
-  schedule:
-    - cron: "0 2 * * *" # run at 2 AM UTC
+      - acvm-backend-barretenberg
   workflow_dispatch:
 
 # This will cancel previous runs when a branch or PR is updated


### PR DESCRIPTION
# Description

We still need this workflow for noir, but the nix wasn't updated on master.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
