### PR TITLE
chore: Copy barretenberg.wasm when compiling typescript

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,18 +53,16 @@ jobs:
         cmake --build --preset default --target bb
 
         ./scripts/install-wasi-sdk.sh
-
-        cmake --preset wasm
-        cmake --build --preset wasm
     
-    - name: Copy Barretenberg.wasm to Root directory
-      run: cp cpp/build-wasm/bin/barretenberg.wasm ./
-      
+
     - name: Compile Typescript
       run: |
         cd ts
         yarn install && yarn && yarn build
-        
+    
+    - name: Copy Barretenberg.wasm to Root directory
+      run: cp cpp/build-wasm/bin/barretenberg.wasm ./
+      
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
# Description

This avoids the need to explicitly compile for the wasm target. We use the output from `yarn build` instead.


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
