### PR TITLE
feat: expanding NVP macro

### DIFF
--- a/cpp/src/barretenberg/serialize/msgpack_impl/name_value_pair_macro.hpp
+++ b/cpp/src/barretenberg/serialize/msgpack_impl/name_value_pair_macro.hpp
@@ -5,11 +5,113 @@
  * used in msgpack serialization. */
 
 // hacky counting of variadic macro params:
-#define VA_NARGS_IMPL(                                                                                                 \
-    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...)                 \
+#define VA_NARGS_IMPL(_1,                                                                                              \
+                      _2,                                                                                              \
+                      _3,                                                                                              \
+                      _4,                                                                                              \
+                      _5,                                                                                              \
+                      _6,                                                                                              \
+                      _7,                                                                                              \
+                      _8,                                                                                              \
+                      _9,                                                                                              \
+                      _10,                                                                                             \
+                      _11,                                                                                             \
+                      _12,                                                                                             \
+                      _13,                                                                                             \
+                      _14,                                                                                             \
+                      _15,                                                                                             \
+                      _16,                                                                                             \
+                      _17,                                                                                             \
+                      _18,                                                                                             \
+                      _19,                                                                                             \
+                      _20,                                                                                             \
+                      _21,                                                                                             \
+                      _22,                                                                                             \
+                      _23,                                                                                             \
+                      _24,                                                                                             \
+                      _25,                                                                                             \
+                      _26,                                                                                             \
+                      _27,                                                                                             \
+                      _28,                                                                                             \
+                      _29,                                                                                             \
+                      _30,                                                                                             \
+                      _31,                                                                                             \
+                      _32,                                                                                             \
+                      _33,                                                                                             \
+                      _34,                                                                                             \
+                      _35,                                                                                             \
+                      _36,                                                                                             \
+                      _37,                                                                                             \
+                      _38,                                                                                             \
+                      _39,                                                                                             \
+                      _40,                                                                                             \
+                      _41,                                                                                             \
+                      _42,                                                                                             \
+                      _43,                                                                                             \
+                      _44,                                                                                             \
+                      _45,                                                                                             \
+                      _46,                                                                                             \
+                      _47,                                                                                             \
+                      _48,                                                                                             \
+                      _49,                                                                                             \
+                      _50,                                                                                             \
+                      N,                                                                                               \
+                      ...)                                                                                             \
     N
-// AD: support for 20 fields!? one may ask. Well, after 15 not being enough...
-#define VA_NARGS(...) VA_NARGS_IMPL(__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+// AD: support for 50 fields!? one may ask. Well, after 15 not being enough...
+#define VA_NARGS(...)                                                                                                  \
+    VA_NARGS_IMPL(__VA_ARGS__,                                                                                         \
+                  50,                                                                                                  \
+                  49,                                                                                                  \
+                  48,                                                                                                  \
+                  47,                                                                                                  \
+                  46,                                                                                                  \
+                  45,                                                                                                  \
+                  44,                                                                                                  \
+                  43,                                                                                                  \
+                  42,                                                                                                  \
+                  41,                                                                                                  \
+                  40,                                                                                                  \
+                  39,                                                                                                  \
+                  38,                                                                                                  \
+                  37,                                                                                                  \
+                  36,                                                                                                  \
+                  35,                                                                                                  \
+                  34,                                                                                                  \
+                  33,                                                                                                  \
+                  32,                                                                                                  \
+                  31,                                                                                                  \
+                  30,                                                                                                  \
+                  29,                                                                                                  \
+                  28,                                                                                                  \
+                  27,                                                                                                  \
+                  26,                                                                                                  \
+                  25,                                                                                                  \
+                  24,                                                                                                  \
+                  23,                                                                                                  \
+                  22,                                                                                                  \
+                  21,                                                                                                  \
+                  20,                                                                                                  \
+                  19,                                                                                                  \
+                  18,                                                                                                  \
+                  17,                                                                                                  \
+                  16,                                                                                                  \
+                  15,                                                                                                  \
+                  14,                                                                                                  \
+                  13,                                                                                                  \
+                  12,                                                                                                  \
+                  11,                                                                                                  \
+                  10,                                                                                                  \
+                  9,                                                                                                   \
+                  8,                                                                                                   \
+                  7,                                                                                                   \
+                  6,                                                                                                   \
+                  5,                                                                                                   \
+                  4,                                                                                                   \
+                  3,                                                                                                   \
+                  2,                                                                                                   \
+                  1)
 
 // name-value pair expansion for variables
 // used in msgpack map expansion
@@ -35,6 +137,36 @@
 #define _NVP18(x, ...) _NVP1(x), _NVP17(__VA_ARGS__)
 #define _NVP19(x, ...) _NVP1(x), _NVP18(__VA_ARGS__)
 #define _NVP20(x, ...) _NVP1(x), _NVP19(__VA_ARGS__)
+#define _NVP21(x, ...) _NVP1(x), _NVP20(__VA_ARGS__)
+#define _NVP22(x, ...) _NVP1(x), _NVP21(__VA_ARGS__)
+#define _NVP23(x, ...) _NVP1(x), _NVP22(__VA_ARGS__)
+#define _NVP24(x, ...) _NVP1(x), _NVP23(__VA_ARGS__)
+#define _NVP25(x, ...) _NVP1(x), _NVP24(__VA_ARGS__)
+#define _NVP26(x, ...) _NVP1(x), _NVP25(__VA_ARGS__)
+#define _NVP27(x, ...) _NVP1(x), _NVP26(__VA_ARGS__)
+#define _NVP28(x, ...) _NVP1(x), _NVP27(__VA_ARGS__)
+#define _NVP29(x, ...) _NVP1(x), _NVP28(__VA_ARGS__)
+#define _NVP30(x, ...) _NVP1(x), _NVP29(__VA_ARGS__)
+#define _NVP31(x, ...) _NVP1(x), _NVP30(__VA_ARGS__)
+#define _NVP32(x, ...) _NVP1(x), _NVP31(__VA_ARGS__)
+#define _NVP33(x, ...) _NVP1(x), _NVP32(__VA_ARGS__)
+#define _NVP34(x, ...) _NVP1(x), _NVP33(__VA_ARGS__)
+#define _NVP35(x, ...) _NVP1(x), _NVP34(__VA_ARGS__)
+#define _NVP36(x, ...) _NVP1(x), _NVP35(__VA_ARGS__)
+#define _NVP37(x, ...) _NVP1(x), _NVP36(__VA_ARGS__)
+#define _NVP38(x, ...) _NVP1(x), _NVP37(__VA_ARGS__)
+#define _NVP39(x, ...) _NVP1(x), _NVP38(__VA_ARGS__)
+#define _NVP40(x, ...) _NVP1(x), _NVP39(__VA_ARGS__)
+#define _NVP41(x, ...) _NVP1(x), _NVP40(__VA_ARGS__)
+#define _NVP42(x, ...) _NVP1(x), _NVP41(__VA_ARGS__)
+#define _NVP43(x, ...) _NVP1(x), _NVP42(__VA_ARGS__)
+#define _NVP44(x, ...) _NVP1(x), _NVP43(__VA_ARGS__)
+#define _NVP45(x, ...) _NVP1(x), _NVP44(__VA_ARGS__)
+#define _NVP46(x, ...) _NVP1(x), _NVP45(__VA_ARGS__)
+#define _NVP47(x, ...) _NVP1(x), _NVP46(__VA_ARGS__)
+#define _NVP48(x, ...) _NVP1(x), _NVP47(__VA_ARGS__)
+#define _NVP49(x, ...) _NVP1(x), _NVP48(__VA_ARGS__)
+#define _NVP50(x, ...) _NVP1(x), _NVP49(__VA_ARGS__)
 
 #define CONCAT(a, b) a##b
 #define _NVP_N(n) CONCAT(_NVP, n)


### PR DESCRIPTION
# Description

Expanding NVP macro to be able to accommodate all the 44 constants.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
