### PR TITLE
chore: Minor increase in Pedersen generators for `HIGH`

### DIFF
--- a/cpp/src/barretenberg/crypto/generators/generator_data.cpp
+++ b/cpp/src/barretenberg/crypto/generators/generator_data.cpp
@@ -24,7 +24,7 @@ struct HashIndexParams {
 
 constexpr HashIndexParams LOW = { 32, 8 };
 constexpr HashIndexParams MID = { 8, 16 };
-constexpr HashIndexParams HIGH = { 4, 44 };
+constexpr HashIndexParams HIGH = { 4, 48 };
 
 constexpr size_t num_hash_indices = (LOW.num_indices + MID.num_indices + HIGH.num_indices);
 constexpr size_t num_indexed_generators = LOW.total_generators() + MID.total_generators() + HIGH.total_generators();


### PR DESCRIPTION
# Description

We need 48 generators for hashing in a3 instead of the current 44, for `HIGH` hash indices (i.e. hash_index ≥ 40).

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] The branch has been merged with/rebased against the head of its merge target.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
- [x] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
