### PR TITLE
feat: Goblin Honk Composer/Prover/Verifier

### DIFF
--- a/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
+++ b/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
@@ -56,4 +56,56 @@ TEST_F(GoblinUltraHonkComposerTests, Basic)
     auto composer = GoblinUltraComposer();
 }
 
+// WORKTODO: flesh this out!
+TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
+{
+    auto builder = UltraCircuitBuilder();
+
+    size_t num_ecc_ops = 3;
+    size_t num_gates_per_op = 2;
+    size_t num_ecc_op_gates = num_gates_per_op * num_ecc_ops;
+    size_t num_conventional_gates = 10;
+    size_t num_public_inputs = 5;
+    size_t num_zero_rows = honk::flavor::GoblinUltra::has_zero_row ? 1 : 0;
+
+    // Add some ecc op gates
+    for (size_t i = 0; i < num_ecc_ops; ++i) {
+        builder.queue_ecc_add_accum(g1::affine_one);
+    }
+
+    // Add some public inputs
+    for (size_t i = 0; i < num_public_inputs; ++i) {
+        builder.add_public_variable(fr::random_element());
+    }
+
+    // Add some conventional gates
+    for (size_t i = 0; i < num_conventional_gates; ++i) {
+        fr a = fr::random_element();
+        fr b = fr::random_element();
+        fr c = fr::random_element();
+        fr d = a + b + c;
+        uint32_t a_idx = builder.add_variable(a);
+        uint32_t b_idx = builder.add_variable(b);
+        uint32_t c_idx = builder.add_variable(c);
+        uint32_t d_idx = builder.add_variable(d);
+
+        builder.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
+    }
+
+    auto composer = GoblinUltraComposer();
+    auto prover = composer.create_prover(builder);
+    auto circuit_size = prover.key->circuit_size;
+
+    // Check that the ecc op selector is 1 on the block of ecc op gates and 0 elsewhere
+    auto q_ecc_op = prover.key->q_ecc_op_queue;
+    for (size_t i = 0; i < circuit_size; ++i) {
+        auto val = q_ecc_op[i];
+        if (i >= num_zero_rows && i < num_zero_rows + num_ecc_op_gates) {
+            EXPECT_EQ(val, 1);
+        } else {
+            EXPECT_EQ(val, 0);
+        }
+    }
+}
+
 } // namespace test_ultra_honk_composer

--- a/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
+++ b/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
@@ -1,0 +1,59 @@
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+#include "barretenberg/common/log.hpp"
+#include "barretenberg/honk/composer/ultra_composer.hpp"
+#include "barretenberg/honk/proof_system/prover.hpp"
+#include "barretenberg/honk/proof_system/ultra_prover.hpp"
+#include "barretenberg/honk/sumcheck/relations/permutation_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/relation_parameters.hpp"
+#include "barretenberg/honk/sumcheck/sumcheck_round.hpp"
+#include "barretenberg/honk/utils/grand_product_delta.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
+#include "barretenberg/proof_system/plookup_tables/types.hpp"
+
+using namespace proof_system::honk;
+
+namespace test_ultra_honk_composer {
+
+namespace {
+auto& engine = numeric::random::get_debug_engine();
+}
+
+class GoblinUltraHonkComposerTests : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() { barretenberg::srs::init_crs_factory("../srs_db/ignition"); }
+};
+
+/**
+ * @brief Test simple circuit with public inputs
+ *
+ */
+TEST_F(GoblinUltraHonkComposerTests, Basic)
+{
+    auto builder = UltraCircuitBuilder();
+    size_t num_gates = 10;
+
+    // Add some arbitrary arithmetic gates that utilize public inputs
+    for (size_t i = 0; i < num_gates; ++i) {
+        fr a = fr::random_element();
+        uint32_t a_idx = builder.add_public_variable(a);
+
+        fr b = fr::random_element();
+        fr c = fr::random_element();
+        fr d = a + b + c;
+        uint32_t b_idx = builder.add_variable(b);
+        uint32_t c_idx = builder.add_variable(c);
+        uint32_t d_idx = builder.add_variable(d);
+
+        builder.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
+    }
+
+    auto composer = GoblinUltraComposer();
+}
+
+} // namespace test_ultra_honk_composer

--- a/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
+++ b/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
@@ -71,7 +71,8 @@ TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
     // Add some ecc op gates
     for (size_t i = 0; i < num_ecc_ops; ++i) {
         auto point = g1::affine_one * fr::random_element();
-        builder.queue_ecc_add_accum(point);
+        auto scalar = fr::random_element();
+        builder.queue_ecc_mul_accum(point, scalar);
     }
 
     // Add some public inputs
@@ -95,6 +96,11 @@ TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
 
     auto composer = GoblinUltraComposer();
     auto prover = composer.create_prover(builder);
+    auto verifier = composer.create_verifier(builder);
+    auto proof = prover.construct_proof();
+    bool verified = verifier.verify_proof(proof);
+    EXPECT_EQ(verified, true);
+
     auto circuit_size = prover.key->circuit_size;
 
     // Check that the ecc op selector is 1 on the block of ecc op gates and 0 elsewhere

--- a/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
+++ b/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
@@ -70,7 +70,8 @@ TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
 
     // Add some ecc op gates
     for (size_t i = 0; i < num_ecc_ops; ++i) {
-        builder.queue_ecc_add_accum(g1::affine_one);
+        auto point = g1::affine_one * fr::random_element();
+        builder.queue_ecc_add_accum(point);
     }
 
     // Add some public inputs
@@ -107,6 +108,17 @@ TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
         } else {
             EXPECT_EQ(val, 0);
             EXPECT_EQ(anti_val, 1);
+        }
+    }
+
+    auto op_wire_2 = prover.key->ecc_op_wire_2;
+    auto w_2 = prover.key->w_r;
+    // q_ecc_op = prover.key->q_ecc_op_queue;
+    for (size_t i = 0; i < circuit_size; ++i) {
+        auto op_val = op_wire_2[i];
+        auto val = w_2[i];
+        if (i >= num_zero_rows && i < num_zero_rows + num_ecc_op_gates) {
+            EXPECT_EQ(val, op_val);
         }
     }
 }

--- a/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
+++ b/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
@@ -100,10 +100,13 @@ TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
     auto q_ecc_op = prover.key->q_ecc_op_queue;
     for (size_t i = 0; i < circuit_size; ++i) {
         auto val = q_ecc_op[i];
+        auto anti_val = q_ecc_op[i] * (-1) + 1; // also needed in realtion
         if (i >= num_zero_rows && i < num_zero_rows + num_ecc_op_gates) {
             EXPECT_EQ(val, 1);
+            EXPECT_EQ(anti_val, 0);
         } else {
             EXPECT_EQ(val, 0);
+            EXPECT_EQ(anti_val, 1);
         }
     }
 }

--- a/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
+++ b/cpp/src/barretenberg/honk/composer/goblin_ultra_composer.test.cpp
@@ -56,7 +56,7 @@ TEST_F(GoblinUltraHonkComposerTests, Basic)
     auto composer = GoblinUltraComposer();
 }
 
-// WORKTODO: flesh this out!
+// TODO(luke): flesh this out or rework once prover/verifier is implemented.
 TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
 {
     auto builder = UltraCircuitBuilder();
@@ -98,7 +98,7 @@ TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
     auto circuit_size = prover.key->circuit_size;
 
     // Check that the ecc op selector is 1 on the block of ecc op gates and 0 elsewhere
-    auto q_ecc_op = prover.key->q_ecc_op_queue;
+    auto q_ecc_op = prover.key->lagrange_ecc_op;
     for (size_t i = 0; i < circuit_size; ++i) {
         auto val = q_ecc_op[i];
         auto anti_val = q_ecc_op[i] * (-1) + 1; // also needed in realtion
@@ -113,7 +113,6 @@ TEST_F(GoblinUltraHonkComposerTests, BasicExecutionTraceOrdering)
 
     auto op_wire_2 = prover.key->ecc_op_wire_2;
     auto w_2 = prover.key->w_r;
-    // q_ecc_op = prover.key->q_ecc_op_queue;
     for (size_t i = 0; i < circuit_size; ++i) {
         auto op_val = op_wire_2[i];
         auto val = w_2[i];

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
@@ -283,6 +283,10 @@ std::shared_ptr<typename Flavor::ProvingKey> UltraComposer_<Flavor>::compute_pro
 
     proving_key->contains_recursive_proof = contains_recursive_proof;
 
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        proving_key->num_ecc_op_gates = num_ecc_op_gates;
+    }
+
     return proving_key;
 }
 
@@ -332,6 +336,10 @@ std::shared_ptr<typename Flavor::VerificationKey> UltraComposer_<Flavor>::comput
     verification_key->table_4 = commitment_key->commit(proving_key->table_4);
     verification_key->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
     verification_key->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
+
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        verification_key->lagrange_ecc_op = commitment_key->commit(proving_key->lagrange_ecc_op);
+    }
 
     // // See `add_recusrive_proof()` for how this recursive data is assigned.
     // verification_key->recursive_proof_public_input_indices =

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
@@ -21,6 +21,7 @@ void UltraComposer_<Flavor>::compute_circuit_size_parameters(CircuitBuilder& cir
         lookups_size += table.lookup_gates.size();
     }
 
+    const size_t num_gates = circuit_constructor.num_gates;
     num_public_inputs = circuit_constructor.public_inputs.size();
 
     // If Goblin, we must account for ecc op gates

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
@@ -27,8 +27,13 @@ void UltraComposer_<Flavor>::compute_circuit_size_parameters(CircuitBuilder& cir
     const size_t minimum_circuit_size_due_to_lookups = tables_size + lookups_size + zero_row_offset;
 
     // number of populated rows in the execution trace
-    const size_t num_rows_populated_in_execution_trace =
+    size_t num_rows_populated_in_execution_trace =
         circuit_constructor.num_gates + circuit_constructor.public_inputs.size() + zero_row_offset;
+
+    // If Goblin, we must account for ecc op gates
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        num_rows_populated_in_execution_trace += circuit_constructor.num_ecc_op_gates;
+    }
 
     // The number of gates is max(lookup gates + tables, rows already populated in trace) + 1, where the +1 is due to
     // addition of a "zero row" at top of the execution trace to ensure wires and other polys are shiftable.
@@ -319,5 +324,6 @@ std::shared_ptr<typename Flavor::VerificationKey> UltraComposer_<Flavor>::comput
 }
 template class UltraComposer_<honk::flavor::Ultra>;
 template class UltraComposer_<honk::flavor::UltraGrumpkin>;
+template class UltraComposer_<honk::flavor::GoblinUltra>;
 
 } // namespace proof_system::honk

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
@@ -132,10 +132,8 @@ template <UltraFlavor Flavor> void UltraComposer_<Flavor>::compute_witness(Circu
     // have been committed to. The 4th wire on these gates will be a random linear combination of the first 3 wires,
     // using the plookup challenge `eta`. We need to update the records with an offset Because we shift the gates to
     // account for everything that comes before them in the execution trace, e.g. public inputs, a zero row, etc.
-    auto add_public_inputs_offset = [this](uint32_t gate_index) {
-        size_t offset = num_ecc_op_gates + num_public_inputs + num_zero_rows;
-        return gate_index + offset;
-    };
+    size_t offset = num_ecc_op_gates + num_public_inputs + num_zero_rows;
+    auto add_public_inputs_offset = [offset](uint32_t gate_index) { return gate_index + offset; };
     proving_key->memory_read_records = std::vector<uint32_t>();
     proving_key->memory_write_records = std::vector<uint32_t>();
 

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.cpp
@@ -168,6 +168,14 @@ template <UltraFlavor Flavor> void UltraComposer_<Flavor>::compute_witness(Circu
     computed_witness = true;
 }
 
+/**
+ * @brief Construct Goblin style ECC op wire polynomials
+ * @details The Ecc op wire values are assumed to have already been stored in the corresponding block of the
+ * conventional wire polynomials. The values for the ecc op wire polynomials are set based on those values.
+ *
+ * @tparam Flavor
+ * @param wire_polynomials
+ */
 template <UltraFlavor Flavor> void UltraComposer_<Flavor>::construct_ecc_op_wire_polynomials(auto& wire_polynomials)
 {
     std::array<polynomial, Flavor::NUM_WIRES> op_wire_polynomials;

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
@@ -71,6 +71,8 @@ template <UltraFlavor Flavor> class UltraComposer_ {
 
     void compute_witness(CircuitBuilder& circuit_constructor);
 
+    void construct_ecc_op_wire_polynomials(auto&);
+
     UltraProver_<Flavor> create_prover(CircuitBuilder& circuit_constructor);
     UltraVerifier_<Flavor> create_verifier(const CircuitBuilder& circuit_constructor);
 

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
@@ -23,7 +23,7 @@ template <UltraFlavor Flavor> class UltraComposer_ {
     using PCSVerificationKey = typename PCSParams::VerificationKey;
 
     // offset due to placing zero wires at the start of execution trace
-    static constexpr size_t zero_row_offset = Flavor::has_zero_row ? 1 : 0;
+    static constexpr size_t num_zero_rows = Flavor::has_zero_row ? 1 : 0;
 
     static constexpr std::string_view NAME_STRING = "UltraHonk";
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
@@ -44,6 +44,7 @@ template <UltraFlavor Flavor> class UltraComposer_ {
     size_t lookups_size = 0;        // total number of lookup gates
     size_t tables_size = 0;         // total number of table entries
     size_t num_public_inputs = 0;
+    size_t num_ecc_op_gates = 0;
 
     UltraComposer_()
         : crs_factory_(barretenberg::srs::get_crs_factory()){};

--- a/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
+++ b/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
@@ -3,6 +3,7 @@
 #include "barretenberg/honk/proof_system/ultra_prover.hpp"
 #include "barretenberg/honk/proof_system/ultra_verifier.hpp"
 #include "barretenberg/proof_system/composer/composer_lib.hpp"
+#include "barretenberg/proof_system/flavor/flavor.hpp"
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 
 #include <cstddef>
@@ -81,7 +82,9 @@ template <UltraFlavor Flavor> class UltraComposer_ {
 };
 extern template class UltraComposer_<honk::flavor::Ultra>;
 extern template class UltraComposer_<honk::flavor::UltraGrumpkin>;
+extern template class UltraComposer_<honk::flavor::GoblinUltra>;
 // TODO(#532): this pattern is weird; is this not instantiating the templates?
 using UltraComposer = UltraComposer_<honk::flavor::Ultra>;
 using UltraGrumpkinComposer = UltraComposer_<honk::flavor::UltraGrumpkin>;
+using GoblinUltraComposer = UltraComposer_<honk::flavor::GoblinUltra>;
 } // namespace proof_system::honk

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -27,7 +27,7 @@ namespace proof_system::honk::flavor {
 
 class GoblinUltra {
   public:
-    using CircuitBuilder = UltraCircuitBuilder; // WORKTODO
+    using CircuitBuilder = UltraCircuitBuilder;
     using FF = barretenberg::fr;
     using Polynomial = barretenberg::Polynomial<FF>;
     using PolynomialHandle = std::span<FF>;

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -95,22 +95,21 @@ class GoblinUltra {
         DataType& q_elliptic = std::get<8>(this->_data);
         DataType& q_aux = std::get<9>(this->_data);
         DataType& q_lookup = std::get<10>(this->_data);
-        // WORKTODO: this is more like "lagrange_first" than a selector. chi_ecc_op_queue?
-        DataType& q_ecc_op_queue = std::get<11>(this->_data);
-        DataType& sigma_1 = std::get<12>(this->_data);
-        DataType& sigma_2 = std::get<13>(this->_data);
-        DataType& sigma_3 = std::get<14>(this->_data);
-        DataType& sigma_4 = std::get<15>(this->_data);
-        DataType& id_1 = std::get<16>(this->_data);
-        DataType& id_2 = std::get<17>(this->_data);
-        DataType& id_3 = std::get<18>(this->_data);
-        DataType& id_4 = std::get<19>(this->_data);
-        DataType& table_1 = std::get<20>(this->_data);
-        DataType& table_2 = std::get<21>(this->_data);
-        DataType& table_3 = std::get<22>(this->_data);
-        DataType& table_4 = std::get<23>(this->_data);
-        DataType& lagrange_first = std::get<24>(this->_data);
-        DataType& lagrange_last = std::get<25>(this->_data);
+        DataType& sigma_1 = std::get<11>(this->_data);
+        DataType& sigma_2 = std::get<12>(this->_data);
+        DataType& sigma_3 = std::get<13>(this->_data);
+        DataType& sigma_4 = std::get<14>(this->_data);
+        DataType& id_1 = std::get<15>(this->_data);
+        DataType& id_2 = std::get<16>(this->_data);
+        DataType& id_3 = std::get<17>(this->_data);
+        DataType& id_4 = std::get<18>(this->_data);
+        DataType& table_1 = std::get<19>(this->_data);
+        DataType& table_2 = std::get<20>(this->_data);
+        DataType& table_3 = std::get<21>(this->_data);
+        DataType& table_4 = std::get<22>(this->_data);
+        DataType& lagrange_first = std::get<23>(this->_data);
+        DataType& lagrange_last = std::get<24>(this->_data);
+        DataType& lagrange_ecc_op = std::get<25>(this->_data); // indicator poly for ecc op gates
 
         static constexpr CircuitType CIRCUIT_TYPE = CircuitBuilder::CIRCUIT_TYPE;
 
@@ -179,21 +178,21 @@ class GoblinUltra {
         DataType& q_elliptic = std::get<8>(this->_data);
         DataType& q_aux = std::get<9>(this->_data);
         DataType& q_lookup = std::get<10>(this->_data);
-        DataType& q_ecc_op_queue = std::get<11>(this->_data);
-        DataType& sigma_1 = std::get<12>(this->_data);
-        DataType& sigma_2 = std::get<13>(this->_data);
-        DataType& sigma_3 = std::get<14>(this->_data);
-        DataType& sigma_4 = std::get<15>(this->_data);
-        DataType& id_1 = std::get<16>(this->_data);
-        DataType& id_2 = std::get<17>(this->_data);
-        DataType& id_3 = std::get<18>(this->_data);
-        DataType& id_4 = std::get<19>(this->_data);
-        DataType& table_1 = std::get<20>(this->_data);
-        DataType& table_2 = std::get<21>(this->_data);
-        DataType& table_3 = std::get<22>(this->_data);
-        DataType& table_4 = std::get<23>(this->_data);
-        DataType& lagrange_first = std::get<24>(this->_data);
-        DataType& lagrange_last = std::get<25>(this->_data);
+        DataType& sigma_1 = std::get<11>(this->_data);
+        DataType& sigma_2 = std::get<12>(this->_data);
+        DataType& sigma_3 = std::get<13>(this->_data);
+        DataType& sigma_4 = std::get<14>(this->_data);
+        DataType& id_1 = std::get<15>(this->_data);
+        DataType& id_2 = std::get<16>(this->_data);
+        DataType& id_3 = std::get<17>(this->_data);
+        DataType& id_4 = std::get<18>(this->_data);
+        DataType& table_1 = std::get<19>(this->_data);
+        DataType& table_2 = std::get<20>(this->_data);
+        DataType& table_3 = std::get<21>(this->_data);
+        DataType& table_4 = std::get<22>(this->_data);
+        DataType& lagrange_first = std::get<23>(this->_data);
+        DataType& lagrange_last = std::get<24>(this->_data);
+        DataType& lagrange_ecc_op = std::get<25>(this->_data);
         DataType& w_l = std::get<26>(this->_data);
         DataType& w_r = std::get<27>(this->_data);
         DataType& w_o = std::get<28>(this->_data);
@@ -225,42 +224,24 @@ class GoblinUltra {
         // Gemini-specific getters.
         std::vector<HandleType> get_unshifted() override
         {
-            return { q_c,
-                     q_l,
-                     q_r,
-                     q_o,
-                     q_4,
-                     q_m,
-                     q_arith,
-                     q_sort,
-                     q_elliptic,
-                     q_aux,
-                     q_lookup,
-                     q_ecc_op_queue,
-                     sigma_1,
-                     sigma_2,
-                     sigma_3,
-                     sigma_4,
-                     id_1,
-                     id_2,
-                     id_3,
-                     id_4,
-                     table_1,
-                     table_2,
-                     table_3,
-                     table_4,
-                     lagrange_first,
-                     lagrange_last,
-                     w_l,
-                     w_r,
-                     w_o,
-                     w_4,
-                     sorted_accum,
-                     z_perm,
-                     z_lookup,
-                     ecc_op_wire_1,
-                     ecc_op_wire_2,
-                     ecc_op_wire_3,
+            return { q_c,           q_l,
+                     q_r,           q_o,
+                     q_4,           q_m,
+                     q_arith,       q_sort,
+                     q_elliptic,    q_aux,
+                     q_lookup,      sigma_1,
+                     sigma_2,       sigma_3,
+                     sigma_4,       id_1,
+                     id_2,          id_3,
+                     id_4,          table_1,
+                     table_2,       table_3,
+                     table_4,       lagrange_first,
+                     lagrange_last, lagrange_ecc_op,
+                     w_l,           w_r,
+                     w_o,           w_4,
+                     sorted_accum,  z_perm,
+                     z_lookup,      ecc_op_wire_1,
+                     ecc_op_wire_2, ecc_op_wire_3,
                      ecc_op_wire_4 };
         };
         std::vector<HandleType> get_to_be_shifted() override
@@ -404,7 +385,6 @@ class GoblinUltra {
             q_elliptic = "__Q_ELLIPTIC";
             q_aux = "__Q_AUX";
             q_lookup = "__Q_LOOKUP";
-            q_ecc_op_queue = "__Q_ECC_OP_QUEUE";
             sigma_1 = "__SIGMA_1";
             sigma_2 = "__SIGMA_2";
             sigma_3 = "__SIGMA_3";
@@ -419,6 +399,7 @@ class GoblinUltra {
             table_4 = "__TABLE_4";
             lagrange_first = "__LAGRANGE_FIRST";
             lagrange_last = "__LAGRANGE_LAST";
+            lagrange_ecc_op = "__Q_ECC_OP_QUEUE";
         };
     };
 
@@ -438,7 +419,6 @@ class GoblinUltra {
             q_elliptic = verification_key->q_elliptic;
             q_aux = verification_key->q_aux;
             q_lookup = verification_key->q_lookup;
-            q_ecc_op_queue = verification_key->q_ecc_op_queue;
             sigma_1 = verification_key->sigma_1;
             sigma_2 = verification_key->sigma_2;
             sigma_3 = verification_key->sigma_3;
@@ -453,6 +433,7 @@ class GoblinUltra {
             table_4 = verification_key->table_4;
             lagrange_first = verification_key->lagrange_first;
             lagrange_last = verification_key->lagrange_last;
+            lagrange_ecc_op = verification_key->lagrange_ecc_op;
         }
     };
 };

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -94,6 +94,7 @@ class GoblinUltra {
         DataType& q_elliptic = std::get<8>(this->_data);
         DataType& q_aux = std::get<9>(this->_data);
         DataType& q_lookup = std::get<10>(this->_data);
+        // WORKTODO: this is more like "lagrange_first" than a selector. chi_ecc_op_queue?
         DataType& q_ecc_op_queue = std::get<11>(this->_data);
         DataType& sigma_1 = std::get<12>(this->_data);
         DataType& sigma_2 = std::get<13>(this->_data);
@@ -114,7 +115,7 @@ class GoblinUltra {
 
         std::vector<HandleType> get_selectors() override
         {
-            return { q_m, q_c, q_l, q_r, q_o, q_4, q_arith, q_sort, q_elliptic, q_aux, q_lookup, q_ecc_op_queue };
+            return { q_m, q_c, q_l, q_r, q_o, q_4, q_arith, q_sort, q_elliptic, q_aux, q_lookup };
         };
         std::vector<HandleType> get_sigma_polynomials() override { return { sigma_1, sigma_2, sigma_3, sigma_4 }; };
         std::vector<HandleType> get_id_polynomials() override { return { id_1, id_2, id_3, id_4 }; };

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -36,9 +36,6 @@ class GoblinUltra {
     using GroupElement = G1::element;
     using Commitment = G1::affine_element;
     using CommitmentHandle = G1::affine_element;
-    // UltraHonk will be run with KZG by default but temporarily we set the commitment to IPA to
-    // be able to do e2e tests with this pcs as well
-    // TODO: instantiate this with both IPA and KZG when the templating work is finished
     using PCSParams = pcs::kzg::Params;
     using PCS = pcs::kzg::KZG<PCSParams>;
 
@@ -46,12 +43,12 @@ class GoblinUltra {
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often
     // need containers of this size to hold related data, so we choose a name more agnostic than `NUM_POLYNOMIALS`.
     // Note: this number does not include the individual sorted list polynomials.
-    static constexpr size_t NUM_ALL_ENTITIES = 48; // 43 + 4 + 1?
+    static constexpr size_t NUM_ALL_ENTITIES = 48; // 43 (UH) + 4 op wires + 1 op wire "selector"
     // The number of polynomials precomputed to describe a circuit and to aid a prover in constructing a satisfying
     // assignment of witnesses. We again choose a neutral name.
-    static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 26; // 25 + 1?
+    static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 26; // 25 (UH) + 1 op wire "selector"
     // The total number of witness entities not including shifts.
-    static constexpr size_t NUM_WITNESS_ENTITIES = 15; // 11 + 4?
+    static constexpr size_t NUM_WITNESS_ENTITIES = 15; // 11 (UH) + 4 op wires
 
     using GrandProductRelations = std::tuple<sumcheck::UltraPermutationRelation<FF>, sumcheck::LookupRelation<FF>>;
 
@@ -299,7 +296,7 @@ class GoblinUltra {
         std::vector<uint32_t> memory_read_records;
         std::vector<uint32_t> memory_write_records;
 
-        size_t num_ecc_op_gates;
+        size_t num_ecc_op_gates; // needed to determine public input offset
 
         // The plookup wires that store plookup read data.
         std::array<PolynomialHandle, 3> get_table_column_wires() { return { w_l, w_r, w_o }; };

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -53,6 +53,8 @@ class GoblinUltra {
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 15; // 11 + 4?
 
+    using GrandProductRelations = std::tuple<sumcheck::UltraPermutationRelation<FF>, sumcheck::LookupRelation<FF>>;
+
     // define the tuple of Relations that comprise the Sumcheck relation
     using Relations = std::tuple<sumcheck::UltraArithmeticRelation<FF>,
                                  sumcheck::UltraPermutationRelation<FF>,

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -1,0 +1,458 @@
+#pragma once
+#include "barretenberg/ecc/curves/bn254/g1.hpp"
+#include "barretenberg/honk/pcs/commitment_key.hpp"
+#include "barretenberg/honk/pcs/kzg/kzg.hpp"
+#include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
+#include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
+#include "barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/elliptic_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/lookup_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/permutation_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/ultra_arithmetic_relation.hpp"
+#include "barretenberg/honk/transcript/transcript.hpp"
+#include "barretenberg/polynomials/evaluation_domain.hpp"
+#include "barretenberg/polynomials/polynomial.hpp"
+#include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
+#include "barretenberg/proof_system/flavor/flavor.hpp"
+#include "barretenberg/srs/factories/crs_factory.hpp"
+#include <array>
+#include <concepts>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace proof_system::honk::flavor {
+
+class GoblinUltra {
+  public:
+    using CircuitBuilder = UltraCircuitBuilder; // WORKTODO
+    using FF = barretenberg::fr;
+    using Polynomial = barretenberg::Polynomial<FF>;
+    using PolynomialHandle = std::span<FF>;
+    using G1 = barretenberg::g1;
+    using GroupElement = G1::element;
+    using Commitment = G1::affine_element;
+    using CommitmentHandle = G1::affine_element;
+    // UltraHonk will be run with KZG by default but temporarily we set the commitment to IPA to
+    // be able to do e2e tests with this pcs as well
+    // TODO: instantiate this with both IPA and KZG when the templating work is finished
+    using PCSParams = pcs::kzg::Params;
+    using PCS = pcs::kzg::KZG<PCSParams>;
+
+    static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
+    // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often
+    // need containers of this size to hold related data, so we choose a name more agnostic than `NUM_POLYNOMIALS`.
+    // Note: this number does not include the individual sorted list polynomials.
+    static constexpr size_t NUM_ALL_ENTITIES = 48; // 43 + 4 + 1?
+    // The number of polynomials precomputed to describe a circuit and to aid a prover in constructing a satisfying
+    // assignment of witnesses. We again choose a neutral name.
+    static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 26; // 25 + 1?
+    // The total number of witness entities not including shifts.
+    static constexpr size_t NUM_WITNESS_ENTITIES = 15; // 11 + 4?
+
+    // define the tuple of Relations that comprise the Sumcheck relation
+    using Relations = std::tuple<sumcheck::UltraArithmeticRelation<FF>,
+                                 sumcheck::UltraPermutationRelation<FF>,
+                                 sumcheck::LookupRelation<FF>,
+                                 sumcheck::GenPermSortRelation<FF>,
+                                 sumcheck::EllipticRelation<FF>,
+                                 sumcheck::AuxiliaryRelation<FF>
+                                 /*OpQueueConsistencyRelation*/>;
+
+    static constexpr size_t MAX_RELATION_LENGTH = get_max_relation_length<Relations>();
+
+    // MAX_RANDOM_RELATION_LENGTH = algebraic degree of sumcheck relation *after* multiplying by the `pow_zeta` random
+    // polynomial e.g. For \sum(x) [A(x) * B(x) + C(x)] * PowZeta(X), relation length = 2 and random relation length = 3
+    static constexpr size_t MAX_RANDOM_RELATION_LENGTH = MAX_RELATION_LENGTH + 1;
+    static constexpr size_t NUM_RELATIONS = std::tuple_size<Relations>::value;
+
+    // define the container for storing the univariate contribution from each relation in Sumcheck
+    using RelationUnivariates = decltype(create_relation_univariates_container<FF, Relations>());
+    using RelationValues = decltype(create_relation_values_container<FF, Relations>());
+
+    // Whether or not the first row of the execution trace is reserved for 0s to enable shifts
+    static constexpr bool has_zero_row = true;
+
+  private:
+    template <typename DataType, typename HandleType>
+    /**
+     * @brief A base class labelling precomputed entities and (ordered) subsets of interest.
+     * @details Used to build the proving key and verification key.
+     */
+    class PrecomputedEntities : public PrecomputedEntities_<DataType, HandleType, NUM_PRECOMPUTED_ENTITIES> {
+      public:
+        DataType& q_m = std::get<0>(this->_data);
+        DataType& q_c = std::get<1>(this->_data);
+        DataType& q_l = std::get<2>(this->_data);
+        DataType& q_r = std::get<3>(this->_data);
+        DataType& q_o = std::get<4>(this->_data);
+        DataType& q_4 = std::get<5>(this->_data);
+        DataType& q_arith = std::get<6>(this->_data);
+        DataType& q_sort = std::get<7>(this->_data);
+        DataType& q_elliptic = std::get<8>(this->_data);
+        DataType& q_aux = std::get<9>(this->_data);
+        DataType& q_lookup = std::get<10>(this->_data);
+        DataType& q_ecc_op_queue = std::get<11>(this->_data);
+        DataType& sigma_1 = std::get<12>(this->_data);
+        DataType& sigma_2 = std::get<13>(this->_data);
+        DataType& sigma_3 = std::get<14>(this->_data);
+        DataType& sigma_4 = std::get<15>(this->_data);
+        DataType& id_1 = std::get<16>(this->_data);
+        DataType& id_2 = std::get<17>(this->_data);
+        DataType& id_3 = std::get<18>(this->_data);
+        DataType& id_4 = std::get<19>(this->_data);
+        DataType& table_1 = std::get<20>(this->_data);
+        DataType& table_2 = std::get<21>(this->_data);
+        DataType& table_3 = std::get<22>(this->_data);
+        DataType& table_4 = std::get<23>(this->_data);
+        DataType& lagrange_first = std::get<24>(this->_data);
+        DataType& lagrange_last = std::get<25>(this->_data);
+
+        static constexpr CircuitType CIRCUIT_TYPE = CircuitBuilder::CIRCUIT_TYPE;
+
+        std::vector<HandleType> get_selectors() override
+        {
+            return { q_m, q_c, q_l, q_r, q_o, q_4, q_arith, q_sort, q_elliptic, q_aux, q_lookup, q_ecc_op_queue };
+        };
+        std::vector<HandleType> get_sigma_polynomials() override { return { sigma_1, sigma_2, sigma_3, sigma_4 }; };
+        std::vector<HandleType> get_id_polynomials() override { return { id_1, id_2, id_3, id_4 }; };
+
+        std::vector<HandleType> get_table_polynomials() { return { table_1, table_2, table_3, table_4 }; };
+    };
+
+    /**
+     * @brief Container for all witness polynomials used/constructed by the prover.
+     * @details Shifts are not included here since they do not occupy their own memory.
+     */
+    template <typename DataType, typename HandleType>
+    class WitnessEntities : public WitnessEntities_<DataType, HandleType, NUM_WITNESS_ENTITIES> {
+      public:
+        DataType& w_l = std::get<0>(this->_data);
+        DataType& w_r = std::get<1>(this->_data);
+        DataType& w_o = std::get<2>(this->_data);
+        DataType& w_4 = std::get<3>(this->_data);
+        DataType& sorted_1 = std::get<4>(this->_data);
+        DataType& sorted_2 = std::get<5>(this->_data);
+        DataType& sorted_3 = std::get<6>(this->_data);
+        DataType& sorted_4 = std::get<7>(this->_data);
+        DataType& sorted_accum = std::get<8>(this->_data);
+        DataType& z_perm = std::get<9>(this->_data);
+        DataType& z_lookup = std::get<10>(this->_data);
+        DataType& ecc_op_wire_1 = std::get<11>(this->_data);
+        DataType& ecc_op_wire_2 = std::get<12>(this->_data);
+        DataType& ecc_op_wire_3 = std::get<13>(this->_data);
+        DataType& ecc_op_wire_4 = std::get<14>(this->_data);
+
+        std::vector<HandleType> get_wires() override { return { w_l, w_r, w_o, w_4 }; };
+        std::vector<HandleType> get_ecc_op_wires()
+        {
+            return { ecc_op_wire_1, ecc_op_wire_2, ecc_op_wire_3, ecc_op_wire_4 };
+        };
+        // The sorted concatenations of table and witness data needed for plookup.
+        std::vector<HandleType> get_sorted_polynomials() { return { sorted_1, sorted_2, sorted_3, sorted_4 }; };
+    };
+
+    /**
+     * @brief A base class labelling all entities (for instance, all of the polynomials used by the prover during
+     * sumcheck) in this Honk variant along with particular subsets of interest
+     * @details Used to build containers for: the prover's polynomial during sumcheck; the sumcheck's folded
+     * polynomials; the univariates consturcted during during sumcheck; the evaluations produced by sumcheck.
+     *
+     * Symbolically we have: AllEntities = PrecomputedEntities + WitnessEntities + "ShiftedEntities". It could be
+     * implemented as such, but we have this now.
+     */
+    template <typename DataType, typename HandleType>
+    class AllEntities : public AllEntities_<DataType, HandleType, NUM_ALL_ENTITIES> {
+      public:
+        DataType& q_c = std::get<0>(this->_data);
+        DataType& q_l = std::get<1>(this->_data);
+        DataType& q_r = std::get<2>(this->_data);
+        DataType& q_o = std::get<3>(this->_data);
+        DataType& q_4 = std::get<4>(this->_data);
+        DataType& q_m = std::get<5>(this->_data);
+        DataType& q_arith = std::get<6>(this->_data);
+        DataType& q_sort = std::get<7>(this->_data);
+        DataType& q_elliptic = std::get<8>(this->_data);
+        DataType& q_aux = std::get<9>(this->_data);
+        DataType& q_lookup = std::get<10>(this->_data);
+        DataType& q_ecc_op_queue = std::get<11>(this->_data);
+        DataType& sigma_1 = std::get<12>(this->_data);
+        DataType& sigma_2 = std::get<13>(this->_data);
+        DataType& sigma_3 = std::get<14>(this->_data);
+        DataType& sigma_4 = std::get<15>(this->_data);
+        DataType& id_1 = std::get<16>(this->_data);
+        DataType& id_2 = std::get<17>(this->_data);
+        DataType& id_3 = std::get<18>(this->_data);
+        DataType& id_4 = std::get<19>(this->_data);
+        DataType& table_1 = std::get<20>(this->_data);
+        DataType& table_2 = std::get<21>(this->_data);
+        DataType& table_3 = std::get<22>(this->_data);
+        DataType& table_4 = std::get<23>(this->_data);
+        DataType& lagrange_first = std::get<24>(this->_data);
+        DataType& lagrange_last = std::get<25>(this->_data);
+        DataType& w_l = std::get<26>(this->_data);
+        DataType& w_r = std::get<27>(this->_data);
+        DataType& w_o = std::get<28>(this->_data);
+        DataType& w_4 = std::get<29>(this->_data);
+        DataType& sorted_accum = std::get<30>(this->_data);
+        DataType& z_perm = std::get<31>(this->_data);
+        DataType& z_lookup = std::get<32>(this->_data);
+        DataType& ecc_op_wire_1 = std::get<33>(this->_data);
+        DataType& ecc_op_wire_2 = std::get<34>(this->_data);
+        DataType& ecc_op_wire_3 = std::get<35>(this->_data);
+        DataType& ecc_op_wire_4 = std::get<36>(this->_data);
+        DataType& table_1_shift = std::get<37>(this->_data);
+        DataType& table_2_shift = std::get<38>(this->_data);
+        DataType& table_3_shift = std::get<39>(this->_data);
+        DataType& table_4_shift = std::get<40>(this->_data);
+        DataType& w_l_shift = std::get<41>(this->_data);
+        DataType& w_r_shift = std::get<42>(this->_data);
+        DataType& w_o_shift = std::get<43>(this->_data);
+        DataType& w_4_shift = std::get<44>(this->_data);
+        DataType& sorted_accum_shift = std::get<45>(this->_data);
+        DataType& z_perm_shift = std::get<46>(this->_data);
+        DataType& z_lookup_shift = std::get<47>(this->_data);
+
+        std::vector<HandleType> get_wires() override { return { w_l, w_r, w_o, w_4 }; };
+        std::vector<HandleType> get_ecc_op_wires()
+        {
+            return { ecc_op_wire_1, ecc_op_wire_2, ecc_op_wire_3, ecc_op_wire_4 };
+        };
+        // Gemini-specific getters.
+        std::vector<HandleType> get_unshifted() override
+        {
+            return { q_c,
+                     q_l,
+                     q_r,
+                     q_o,
+                     q_4,
+                     q_m,
+                     q_arith,
+                     q_sort,
+                     q_elliptic,
+                     q_aux,
+                     q_lookup,
+                     q_ecc_op_queue,
+                     sigma_1,
+                     sigma_2,
+                     sigma_3,
+                     sigma_4,
+                     id_1,
+                     id_2,
+                     id_3,
+                     id_4,
+                     table_1,
+                     table_2,
+                     table_3,
+                     table_4,
+                     lagrange_first,
+                     lagrange_last,
+                     w_l,
+                     w_r,
+                     w_o,
+                     w_4,
+                     sorted_accum,
+                     z_perm,
+                     z_lookup,
+                     ecc_op_wire_1,
+                     ecc_op_wire_2,
+                     ecc_op_wire_3,
+                     ecc_op_wire_4 };
+        };
+        std::vector<HandleType> get_to_be_shifted() override
+        {
+            return { table_1, table_2, table_3, table_4, w_l, w_r, w_o, w_4, sorted_accum, z_perm, z_lookup };
+        };
+        std::vector<HandleType> get_shifted() override
+        {
+            return { table_1_shift, table_2_shift, table_3_shift,      table_4_shift, w_l_shift,     w_r_shift,
+                     w_o_shift,     w_4_shift,     sorted_accum_shift, z_perm_shift,  z_lookup_shift };
+        };
+
+        AllEntities() = default;
+
+        AllEntities(const AllEntities& other)
+            : AllEntities_<DataType, HandleType, NUM_ALL_ENTITIES>(other){};
+
+        AllEntities(AllEntities&& other)
+            : AllEntities_<DataType, HandleType, NUM_ALL_ENTITIES>(other){};
+
+        AllEntities& operator=(const AllEntities& other)
+        {
+            if (this == &other) {
+                return *this;
+            }
+            AllEntities_<DataType, HandleType, NUM_ALL_ENTITIES>::operator=(other);
+            return *this;
+        }
+
+        AllEntities& operator=(AllEntities&& other)
+        {
+            AllEntities_<DataType, HandleType, NUM_ALL_ENTITIES>::operator=(other);
+            return *this;
+        }
+
+        ~AllEntities() = default;
+    };
+
+  public:
+    /**
+     * @brief The proving key is responsible for storing the polynomials used by the prover.
+     * @note TODO(Cody): Maybe multiple inheritance is the right thing here. In that case, nothing should eve inherit
+     * from ProvingKey.
+     */
+    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial, PolynomialHandle>,
+                                          WitnessEntities<Polynomial, PolynomialHandle>> {
+      public:
+        // Expose constructors on the base class
+        using Base = ProvingKey_<PrecomputedEntities<Polynomial, PolynomialHandle>,
+                                 WitnessEntities<Polynomial, PolynomialHandle>>;
+        using Base::Base;
+
+        std::vector<uint32_t> memory_read_records;
+        std::vector<uint32_t> memory_write_records;
+
+        // The plookup wires that store plookup read data.
+        std::array<PolynomialHandle, 3> get_table_column_wires() { return { w_l, w_r, w_o }; };
+    };
+
+    /**
+     * @brief The verification key is responsible for storing the the commitments to the precomputed (non-witnessk)
+     * polynomials used by the verifier.
+     *
+     * @note Note the discrepancy with what sort of data is stored here vs in the proving key. We may want to resolve
+     * that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for portability of our
+     * circuits.
+     */
+    using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment, CommitmentHandle>>;
+
+    /**
+     * @brief A container for polynomials handles; only stores spans.
+     */
+    using ProverPolynomials = AllEntities<PolynomialHandle, PolynomialHandle>;
+
+    /**
+     * @brief A container for storing the partially evaluated multivariates produced by sumcheck.
+     */
+    class PartiallyEvaluatedMultivariates : public AllEntities<Polynomial, PolynomialHandle> {
+
+      public:
+        PartiallyEvaluatedMultivariates() = default;
+        PartiallyEvaluatedMultivariates(const size_t circuit_size)
+        {
+            // Storage is only needed after the first partial evaluation, hence polynomials of size (n / 2)
+            for (auto& poly : this->_data) {
+                poly = Polynomial(circuit_size / 2);
+            }
+        }
+    };
+
+    /**
+     * @brief A container for univariates produced during the hot loop in sumcheck.
+     * @todo TODO(#390): Simplify this by moving MAX_RELATION_LENGTH?
+     */
+    template <size_t MAX_RELATION_LENGTH>
+    using ExtendedEdges =
+        AllEntities<sumcheck::Univariate<FF, MAX_RELATION_LENGTH>, sumcheck::Univariate<FF, MAX_RELATION_LENGTH>>;
+
+    /**
+     * @brief A container for the polynomials evaluations produced during sumcheck, which are purported to be the
+     * evaluations of polynomials committed in earlier rounds.
+     */
+    class ClaimedEvaluations : public AllEntities<FF, FF> {
+      public:
+        using Base = AllEntities<FF, FF>;
+        using Base::Base;
+        ClaimedEvaluations(std::array<FF, NUM_ALL_ENTITIES> _data_in) { this->_data = _data_in; }
+    };
+
+    /**
+     * @brief A container for commitment labels.
+     * @note It's debatable whether this should inherit from AllEntities. since most entries are not strictly needed. It
+     * has, however, been useful during debugging to have these labels available.
+     *
+     */
+    class CommitmentLabels : public AllEntities<std::string, std::string> {
+      public:
+        CommitmentLabels()
+        {
+            w_l = "W_L";
+            w_r = "W_R";
+            w_o = "W_O";
+            w_4 = "W_4";
+            z_perm = "Z_PERM";
+            z_lookup = "Z_LOOKUP";
+            sorted_accum = "SORTED_ACCUM";
+            ecc_op_wire_1 = "ECC_OP_WIRE_1";
+            ecc_op_wire_2 = "ECC_OP_WIRE_2";
+            ecc_op_wire_3 = "ECC_OP_WIRE_3";
+            ecc_op_wire_4 = "ECC_OP_WIRE_4";
+
+            // The ones beginning with "__" are only used for debugging
+            q_c = "__Q_C";
+            q_l = "__Q_L";
+            q_r = "__Q_R";
+            q_o = "__Q_O";
+            q_4 = "__Q_4";
+            q_m = "__Q_M";
+            q_arith = "__Q_ARITH";
+            q_sort = "__Q_SORT";
+            q_elliptic = "__Q_ELLIPTIC";
+            q_aux = "__Q_AUX";
+            q_lookup = "__Q_LOOKUP";
+            q_ecc_op_queue = "__Q_ECC_OP_QUEUE";
+            sigma_1 = "__SIGMA_1";
+            sigma_2 = "__SIGMA_2";
+            sigma_3 = "__SIGMA_3";
+            sigma_4 = "__SIGMA_4";
+            id_1 = "__ID_1";
+            id_2 = "__ID_2";
+            id_3 = "__ID_3";
+            id_4 = "__ID_4";
+            table_1 = "__TABLE_1";
+            table_2 = "__TABLE_2";
+            table_3 = "__TABLE_3";
+            table_4 = "__TABLE_4";
+            lagrange_first = "__LAGRANGE_FIRST";
+            lagrange_last = "__LAGRANGE_LAST";
+        };
+    };
+
+    class VerifierCommitments : public AllEntities<Commitment, CommitmentHandle> {
+      public:
+        VerifierCommitments(std::shared_ptr<VerificationKey> verification_key, VerifierTranscript<FF> transcript)
+        {
+            static_cast<void>(transcript);
+            q_m = verification_key->q_m;
+            q_l = verification_key->q_l;
+            q_r = verification_key->q_r;
+            q_o = verification_key->q_o;
+            q_4 = verification_key->q_4;
+            q_c = verification_key->q_c;
+            q_arith = verification_key->q_arith;
+            q_sort = verification_key->q_sort;
+            q_elliptic = verification_key->q_elliptic;
+            q_aux = verification_key->q_aux;
+            q_lookup = verification_key->q_lookup;
+            q_ecc_op_queue = verification_key->q_ecc_op_queue;
+            sigma_1 = verification_key->sigma_1;
+            sigma_2 = verification_key->sigma_2;
+            sigma_3 = verification_key->sigma_3;
+            sigma_4 = verification_key->sigma_4;
+            id_1 = verification_key->id_1;
+            id_2 = verification_key->id_2;
+            id_3 = verification_key->id_3;
+            id_4 = verification_key->id_4;
+            table_1 = verification_key->table_1;
+            table_2 = verification_key->table_2;
+            table_3 = verification_key->table_3;
+            table_4 = verification_key->table_4;
+            lagrange_first = verification_key->lagrange_first;
+            lagrange_last = verification_key->lagrange_last;
+        }
+    };
+};
+
+} // namespace proof_system::honk::flavor

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -5,6 +5,7 @@
 #include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/elliptic_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/lookup_relation.hpp"
@@ -58,8 +59,8 @@ class GoblinUltra {
                                  sumcheck::LookupRelation<FF>,
                                  sumcheck::GenPermSortRelation<FF>,
                                  sumcheck::EllipticRelation<FF>,
-                                 sumcheck::AuxiliaryRelation<FF>
-                                 /*OpQueueConsistencyRelation*/>;
+                                 sumcheck::AuxiliaryRelation<FF>,
+                                 sumcheck::EccOpQueueRelation<FF>>;
 
     static constexpr size_t MAX_RELATION_LENGTH = get_max_relation_length<Relations>();
 

--- a/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -299,6 +299,8 @@ class GoblinUltra {
         std::vector<uint32_t> memory_read_records;
         std::vector<uint32_t> memory_write_records;
 
+        size_t num_ecc_op_gates;
+
         // The plookup wires that store plookup read data.
         std::array<PolynomialHandle, 3> get_table_column_wires() { return { w_l, w_r, w_o }; };
     };

--- a/cpp/src/barretenberg/honk/proof_system/prover_library.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover_library.cpp
@@ -1,4 +1,5 @@
 #include "prover_library.hpp"
+#include "barretenberg/honk/flavor/goblin_ultra.hpp"
 #include "barretenberg/honk/flavor/standard.hpp"
 #include "barretenberg/honk/flavor/standard_grumpkin.hpp"
 #include "barretenberg/honk/flavor/ultra.hpp"
@@ -99,5 +100,3 @@ template typename honk::flavor::UltraGrumpkin::Polynomial compute_sorted_list_ac
 template void add_plookup_memory_records_to_wire_4<honk::flavor::UltraGrumpkin>(
     std::shared_ptr<typename honk::flavor::UltraGrumpkin::ProvingKey>& key,
     typename honk::flavor::UltraGrumpkin::FF eta);
-
-} // namespace proof_system::honk::prover_library

--- a/cpp/src/barretenberg/honk/proof_system/prover_library.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/prover_library.cpp
@@ -87,11 +87,15 @@ void add_plookup_memory_records_to_wire_4(std::shared_ptr<typename Flavor::Provi
     }
 }
 
+// flavor::Ultra
+
 template typename honk::flavor::Ultra::Polynomial compute_sorted_list_accumulator<honk::flavor::Ultra>(
     std::shared_ptr<typename honk::flavor::Ultra::ProvingKey>& key, typename honk::flavor::Ultra::FF eta);
 
 template void add_plookup_memory_records_to_wire_4<honk::flavor::Ultra>(
     std::shared_ptr<typename honk::flavor::Ultra::ProvingKey>& key, typename honk::flavor::Ultra::FF eta);
+
+// flavor::UltraGrumpkin
 
 template typename honk::flavor::UltraGrumpkin::Polynomial compute_sorted_list_accumulator<honk::flavor::UltraGrumpkin>(
     std::shared_ptr<typename honk::flavor::UltraGrumpkin::ProvingKey>& key,
@@ -100,3 +104,13 @@ template typename honk::flavor::UltraGrumpkin::Polynomial compute_sorted_list_ac
 template void add_plookup_memory_records_to_wire_4<honk::flavor::UltraGrumpkin>(
     std::shared_ptr<typename honk::flavor::UltraGrumpkin::ProvingKey>& key,
     typename honk::flavor::UltraGrumpkin::FF eta);
+
+// flavor::GoblinUltra
+
+template typename honk::flavor::GoblinUltra::Polynomial compute_sorted_list_accumulator<honk::flavor::GoblinUltra>(
+    std::shared_ptr<typename honk::flavor::GoblinUltra::ProvingKey>& key, typename honk::flavor::GoblinUltra::FF eta);
+
+template void add_plookup_memory_records_to_wire_4<honk::flavor::GoblinUltra>(
+    std::shared_ptr<typename honk::flavor::GoblinUltra::ProvingKey>& key, typename honk::flavor::GoblinUltra::FF eta);
+
+} // namespace proof_system::honk::prover_library

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
@@ -74,27 +74,25 @@ UltraProver_<Flavor>::UltraProver_(std::shared_ptr<typename Flavor::ProvingKey> 
     prover_polynomials.w_r_shift = key->w_r.shifted();
     prover_polynomials.w_o_shift = key->w_o.shifted();
 
-    // Add public inputs to transcript from the second wire polynomial; The PI have been written into the wires at the
-    // 0th or 1st index depending on whether or not a zero row is utilized.
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        prover_polynomials.ecc_op_wire_1 = key->ecc_op_wire_1;
+        prover_polynomials.ecc_op_wire_2 = key->ecc_op_wire_2;
+        prover_polynomials.ecc_op_wire_3 = key->ecc_op_wire_3;
+        prover_polynomials.ecc_op_wire_4 = key->ecc_op_wire_4;
+        prover_polynomials.lagrange_ecc_op = key->lagrange_ecc_op;
+    }
+
+    // Add public inputs to transcript from the second wire polynomial; This requires determination of the offset at
+    // which the PI have been written into the wires relative to the 0th index.
     std::span<FF> public_wires_source = prover_polynomials.w_r;
-    const size_t pub_input_offset = Flavor::has_zero_row ? 1 : 0;
+    public_input_offset = Flavor::has_zero_row ? 1 : 0;
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        public_input_offset += key->num_ecc_op_gates;
+    }
 
     for (size_t i = 0; i < key->num_public_inputs; ++i) {
-        size_t idx = i + pub_input_offset;
+        size_t idx = i + public_input_offset;
         public_inputs.emplace_back(public_wires_source[idx]);
-    }
-}
-
-/**
- * @brief Commit to the first three wires only
- *
- */
-template <UltraFlavor Flavor> void UltraProver_<Flavor>::compute_wire_commitments()
-{
-    auto wire_polys = key->get_wires();
-    auto labels = commitment_labels.get_wires();
-    for (size_t idx = 0; idx < 3; ++idx) {
-        queue.add_commitment(wire_polys[idx], labels[idx]);
     }
 }
 
@@ -109,6 +107,7 @@ template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_preamble_round(
 
     transcript.send_to_verifier("circuit_size", circuit_size);
     transcript.send_to_verifier("public_input_size", num_public_inputs);
+    transcript.send_to_verifier("public_input_offset", static_cast<uint32_t>(public_input_offset));
 
     for (size_t i = 0; i < key->num_public_inputs; ++i) {
         auto public_input_i = public_inputs[i];
@@ -122,10 +121,20 @@ template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_preamble_round(
  */
 template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_wire_commitments_round()
 {
+    // Commit to the first three wire polynomials; the fourth is committed to after the addition of memory records.
     auto wire_polys = key->get_wires();
     auto labels = commitment_labels.get_wires();
     for (size_t idx = 0; idx < 3; ++idx) {
         queue.add_commitment(wire_polys[idx], labels[idx]);
+    }
+
+    // If Goblin, commit to the ECC op wire polynomials
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        auto op_wire_polys = key->get_ecc_op_wires();
+        auto labels = commitment_labels.get_ecc_op_wires();
+        for (size_t idx = 0; idx < Flavor::NUM_WIRES; ++idx) {
+            queue.add_commitment(op_wire_polys[idx], labels[idx]);
+        }
     }
 }
 
@@ -162,7 +171,11 @@ template <UltraFlavor Flavor> void UltraProver_<Flavor>::execute_grand_product_c
     // Compute and store parameters required by relations in Sumcheck
     auto [beta, gamma] = transcript.get_challenges("beta", "gamma");
 
-    auto public_input_delta = compute_public_input_delta<Flavor>(public_inputs, beta, gamma, key->circuit_size);
+    // WORKTODO: yuk! need to decide how to handle offset in compute_public_input_delta. Right now it's -1 b/c I'm
+    // accounting for leading zeros both in the prover and in the function.
+    auto pi_offset_yuk = public_input_offset - 1;
+    auto public_input_delta =
+        compute_public_input_delta<Flavor>(public_inputs, beta, gamma, key->circuit_size, pi_offset_yuk);
     auto lookup_grand_product_delta = compute_lookup_grand_product_delta(beta, gamma, key->circuit_size);
 
     relation_parameters.beta = beta;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.cpp
@@ -338,5 +338,6 @@ template <UltraFlavor Flavor> plonk::proof& UltraProver_<Flavor>::construct_proo
 
 template class UltraProver_<honk::flavor::Ultra>;
 template class UltraProver_<honk::flavor::UltraGrumpkin>;
+template class UltraProver_<honk::flavor::GoblinUltra>;
 
 } // namespace proof_system::honk

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
@@ -39,14 +39,13 @@ template <UltraFlavor Flavor> class UltraProver_ {
     void execute_shplonk_partial_evaluation_round();
     void execute_final_pcs_round();
 
-    void compute_wire_commitments();
-
     plonk::proof& export_proof();
     plonk::proof& construct_proof();
 
     ProverTranscript<FF> transcript;
 
     std::vector<FF> public_inputs;
+    size_t public_input_offset; // offset of the PI relative to 0th index in the wire polynomials
 
     sumcheck::RelationParameters<FF> relation_parameters;
 

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/honk/flavor/goblin_ultra.hpp"
 #include "barretenberg/honk/flavor/ultra.hpp"
 #include "barretenberg/honk/flavor/ultra_grumpkin.hpp"
 #include "barretenberg/honk/pcs/gemini/gemini.hpp"
@@ -80,6 +81,7 @@ template <UltraFlavor Flavor> class UltraProver_ {
 
 extern template class UltraProver_<honk::flavor::Ultra>;
 extern template class UltraProver_<honk::flavor::UltraGrumpkin>;
+extern template class UltraProver_<honk::flavor::GoblinUltra>;
 
 using UltraProver = UltraProver_<honk::flavor::Ultra>;
 

--- a/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_prover.hpp
@@ -45,7 +45,7 @@ template <UltraFlavor Flavor> class UltraProver_ {
     ProverTranscript<FF> transcript;
 
     std::vector<FF> public_inputs;
-    size_t public_input_offset; // offset of the PI relative to 0th index in the wire polynomials
+    size_t pub_inputs_offset; // offset of the PI relative to 0th index in the wire polynomials
 
     sumcheck::RelationParameters<FF> relation_parameters;
 

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -54,7 +54,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     // TODO(Adrian): Change the initialization of the transcript to take the VK hash?
     const auto circuit_size = transcript.template receive_from_prover<uint32_t>("circuit_size");
     const auto public_input_size = transcript.template receive_from_prover<uint32_t>("public_input_size");
-    const auto public_input_offset = transcript.template receive_from_prover<uint32_t>("public_input_offset");
+    const auto pub_inputs_offset = transcript.template receive_from_prover<uint32_t>("pub_inputs_offset");
 
     if (circuit_size != key->circuit_size) {
         return false;
@@ -97,9 +97,8 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     // Get permutation challenges
     auto [beta, gamma] = transcript.get_challenges("beta", "gamma");
 
-    // WORKTODO: Ick!
     const FF public_input_delta =
-        compute_public_input_delta<Flavor>(public_inputs, beta, gamma, circuit_size, public_input_offset - 1);
+        compute_public_input_delta<Flavor>(public_inputs, beta, gamma, circuit_size, pub_inputs_offset);
     const FF lookup_grand_product_delta = compute_lookup_grand_product_delta<FF>(beta, gamma, circuit_size);
 
     relation_parameters.beta = beta;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -159,5 +159,6 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
 
 template class UltraVerifier_<honk::flavor::Ultra>;
 template class UltraVerifier_<honk::flavor::UltraGrumpkin>;
+template class UltraVerifier_<honk::flavor::GoblinUltra>;
 
 } // namespace proof_system::honk

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -54,6 +54,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     // TODO(Adrian): Change the initialization of the transcript to take the VK hash?
     const auto circuit_size = transcript.template receive_from_prover<uint32_t>("circuit_size");
     const auto public_input_size = transcript.template receive_from_prover<uint32_t>("public_input_size");
+    const auto public_input_offset = transcript.template receive_from_prover<uint32_t>("public_input_offset");
 
     if (circuit_size != key->circuit_size) {
         return false;
@@ -68,10 +69,22 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
         public_inputs.emplace_back(public_input_i);
     }
 
-    // Get commitments to first three wires
+    // Get commitments to first three wire polynomials
     commitments.w_l = transcript.template receive_from_prover<Commitment>(commitment_labels.w_l);
     commitments.w_r = transcript.template receive_from_prover<Commitment>(commitment_labels.w_r);
     commitments.w_o = transcript.template receive_from_prover<Commitment>(commitment_labels.w_o);
+
+    // If Goblin, get commitments to ECC op wire polynomials
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        commitments.ecc_op_wire_1 =
+            transcript.template receive_from_prover<Commitment>(commitment_labels.ecc_op_wire_1);
+        commitments.ecc_op_wire_2 =
+            transcript.template receive_from_prover<Commitment>(commitment_labels.ecc_op_wire_2);
+        commitments.ecc_op_wire_3 =
+            transcript.template receive_from_prover<Commitment>(commitment_labels.ecc_op_wire_3);
+        commitments.ecc_op_wire_4 =
+            transcript.template receive_from_prover<Commitment>(commitment_labels.ecc_op_wire_4);
+    }
 
     // Get challenge for sorted list batching and wire four memory records
     auto eta = transcript.get_challenge("eta");
@@ -84,7 +97,9 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     // Get permutation challenges
     auto [beta, gamma] = transcript.get_challenges("beta", "gamma");
 
-    const FF public_input_delta = compute_public_input_delta<Flavor>(public_inputs, beta, gamma, circuit_size);
+    // WORKTODO: Ick!
+    const FF public_input_delta =
+        compute_public_input_delta<Flavor>(public_inputs, beta, gamma, circuit_size, public_input_offset - 1);
     const FF lookup_grand_product_delta = compute_lookup_grand_product_delta<FF>(beta, gamma, circuit_size);
 
     relation_parameters.beta = beta;

--- a/cpp/src/barretenberg/honk/proof_system/ultra_verifier.hpp
+++ b/cpp/src/barretenberg/honk/proof_system/ultra_verifier.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/honk/flavor/goblin_ultra.hpp"
 #include "barretenberg/honk/flavor/ultra.hpp"
 #include "barretenberg/honk/flavor/ultra_grumpkin.hpp"
 #include "barretenberg/honk/sumcheck/sumcheck.hpp"
@@ -29,6 +30,7 @@ template <typename Flavor> class UltraVerifier_ {
 
 extern template class UltraVerifier_<honk::flavor::Ultra>;
 extern template class UltraVerifier_<honk::flavor::UltraGrumpkin>;
+extern template class UltraVerifier_<honk::flavor::GoblinUltra>;
 
 using UltraVerifier = UltraVerifier_<honk::flavor::Ultra>;
 

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp
@@ -27,7 +27,16 @@ template <typename FF> class EccOpQueueRelationBase {
     /**
      * @brief Expression for the generalized permutation sort gate.
      * @details The relation is defined as C(extended_edges(X)...) =
-     *    // WORKTODO: comments here and throughout relation!
+     *    \alpha_{base} *
+     *       ( \Sum_{i=0}^3 \alpha^i * (w_i - w_{op,i}) * \chi_{ecc_op} +
+     *         \Sum_{i=0}^3 \alpha^{i+4} w_{op,i} * \bar{\chi}_{ecc_op} )
+     *
+     * where w_{op,i} are the ecc op gate wires, \chi_{ecc_op} is the indicator for the portion of the domain
+     * representing ecc op gates and \bar{\chi} is the indicator on the complementary domain.
+     *
+     * The first four sub-relations check that the values in the conventional wires are identical to the values in the
+     * ecc op wires over the portion of the execution trace representing ECC op queue gates. The next four check
+     * that the op wire polynomials are identically zero everywhere else.
      *
      * @param evals transformed to `evals + C(extended_edges(X)...)*scaling_factor`
      * @param extended_edges an std::array containing the fully extended Univariate edges.
@@ -51,52 +60,52 @@ template <typename FF> class EccOpQueueRelationBase {
         auto op_wire_2 = View(extended_edges.ecc_op_wire_2);
         auto op_wire_3 = View(extended_edges.ecc_op_wire_3);
         auto op_wire_4 = View(extended_edges.ecc_op_wire_4);
-        auto q_ecc_op_queue = View(extended_edges.q_ecc_op_queue);
+        auto lagrange_ecc_op = View(extended_edges.lagrange_ecc_op);
 
-        // If q_ecc_op_queue is the indicator for ecc_op_gates, this is the indicator for the complement
-        auto complement_q_ecc_op = q_ecc_op_queue * FF(-1) + FF(1);
+        // If lagrange_ecc_op is the indicator for ecc_op_gates, this is the indicator for the complement
+        auto complement_ecc_op = lagrange_ecc_op * FF(-1) + FF(1);
 
         // Contribution (1)
         auto tmp = op_wire_1 - w_1;
-        tmp *= q_ecc_op_queue;
+        tmp *= lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<0>(accumulators) += tmp;
 
         // Contribution (2)
         tmp = op_wire_2 - w_2;
-        tmp *= q_ecc_op_queue;
+        tmp *= lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<1>(accumulators) += tmp;
 
         // Contribution (3)
         tmp = op_wire_3 - w_3;
-        tmp *= q_ecc_op_queue;
+        tmp *= lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<2>(accumulators) += tmp;
 
         // Contribution (4)
         tmp = op_wire_4 - w_4;
-        tmp *= q_ecc_op_queue;
+        tmp *= lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<3>(accumulators) += tmp;
 
         // Contribution (5)
-        tmp = op_wire_1 * complement_q_ecc_op;
+        tmp = op_wire_1 * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<4>(accumulators) += tmp;
 
         // Contribution (6)
-        tmp = op_wire_2 * complement_q_ecc_op;
+        tmp = op_wire_2 * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<5>(accumulators) += tmp;
 
         // Contribution (7)
-        tmp = op_wire_3 * complement_q_ecc_op;
+        tmp = op_wire_3 * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<6>(accumulators) += tmp;
 
         // Contribution (8)
-        tmp = op_wire_4 * complement_q_ecc_op;
+        tmp = op_wire_4 * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<7>(accumulators) += tmp;
     };

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp
@@ -8,23 +8,26 @@
 
 namespace proof_system::honk::sumcheck {
 
-// WORKTODO: ADD zero check on op wires
 template <typename FF> class EccOpQueueRelationBase {
   public:
     // 1 + polynomial degree of this relation
-    static constexpr size_t RELATION_LENGTH = 3; //
+    static constexpr size_t RELATION_LENGTH = 3; // degree(q * (w - w_op_queue)) = 2
 
-    static constexpr size_t LEN_1 = 3; // range constrain sub-relation 1
-    static constexpr size_t LEN_2 = 3; // range constrain sub-relation 2
-    static constexpr size_t LEN_3 = 3; // range constrain sub-relation 3
-    static constexpr size_t LEN_4 = 3; // range constrain sub-relation 4
+    static constexpr size_t LEN_1 = 3; // wire - op-queue-wire consistency sub-relation 1
+    static constexpr size_t LEN_2 = 3; // wire - op-queue-wire consistency sub-relation 2
+    static constexpr size_t LEN_3 = 3; // wire - op-queue-wire consistency sub-relation 3
+    static constexpr size_t LEN_4 = 3; // wire - op-queue-wire consistency sub-relation 4
+    static constexpr size_t LEN_5 = 3; // op-queue-wire vanishes sub-relation 1
+    static constexpr size_t LEN_6 = 3; // op-queue-wire vanishes sub-relation 2
+    static constexpr size_t LEN_7 = 3; // op-queue-wire vanishes sub-relation 3
+    static constexpr size_t LEN_8 = 3; // op-queue-wire vanishes sub-relation 4
     template <template <size_t...> typename AccumulatorTypesContainer>
-    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2, LEN_3, LEN_4>;
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2, LEN_3, LEN_4, LEN_5, LEN_6, LEN_7, LEN_8>;
 
     /**
      * @brief Expression for the generalized permutation sort gate.
      * @details The relation is defined as C(extended_edges(X)...) =
-     *    TODO
+     *    // WORKTODO: comments here and throughout relation!
      *
      * @param evals transformed to `evals + C(extended_edges(X)...)*scaling_factor`
      * @param extended_edges an std::array containing the fully extended Univariate edges.
@@ -39,7 +42,6 @@ template <typename FF> class EccOpQueueRelationBase {
     {
         // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
         //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
-
         using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
         auto w_1 = View(extended_edges.w_l);
         auto w_2 = View(extended_edges.w_r);
@@ -50,6 +52,9 @@ template <typename FF> class EccOpQueueRelationBase {
         auto op_wire_3 = View(extended_edges.ecc_op_wire_3);
         auto op_wire_4 = View(extended_edges.ecc_op_wire_4);
         auto q_ecc_op_queue = View(extended_edges.q_ecc_op_queue);
+
+        // If q_ecc_op_queue is the indicator for ecc_op_gates, this is the indicator for the complement
+        auto complement_q_ecc_op = q_ecc_op_queue * FF(-1) + FF(1);
 
         // Contribution (1)
         auto tmp = op_wire_1 - w_1;
@@ -74,6 +79,26 @@ template <typename FF> class EccOpQueueRelationBase {
         tmp *= q_ecc_op_queue;
         tmp *= scaling_factor;
         std::get<3>(accumulators) += tmp;
+
+        // Contribution (5)
+        tmp = op_wire_1 * complement_q_ecc_op;
+        tmp *= scaling_factor;
+        std::get<4>(accumulators) += tmp;
+
+        // Contribution (6)
+        tmp = op_wire_2 * complement_q_ecc_op;
+        tmp *= scaling_factor;
+        std::get<5>(accumulators) += tmp;
+
+        // Contribution (7)
+        tmp = op_wire_3 * complement_q_ecc_op;
+        tmp *= scaling_factor;
+        std::get<6>(accumulators) += tmp;
+
+        // Contribution (8)
+        tmp = op_wire_4 * complement_q_ecc_op;
+        tmp *= scaling_factor;
+        std::get<7>(accumulators) += tmp;
     };
 };
 

--- a/cpp/src/barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp
@@ -1,0 +1,82 @@
+#pragma once
+#include <array>
+#include <tuple>
+
+#include "../polynomials/univariate.hpp"
+#include "relation_parameters.hpp"
+#include "relation_types.hpp"
+
+namespace proof_system::honk::sumcheck {
+
+// WORKTODO: ADD zero check on op wires
+template <typename FF> class EccOpQueueRelationBase {
+  public:
+    // 1 + polynomial degree of this relation
+    static constexpr size_t RELATION_LENGTH = 3; //
+
+    static constexpr size_t LEN_1 = 3; // range constrain sub-relation 1
+    static constexpr size_t LEN_2 = 3; // range constrain sub-relation 2
+    static constexpr size_t LEN_3 = 3; // range constrain sub-relation 3
+    static constexpr size_t LEN_4 = 3; // range constrain sub-relation 4
+    template <template <size_t...> typename AccumulatorTypesContainer>
+    using AccumulatorTypesBase = AccumulatorTypesContainer<LEN_1, LEN_2, LEN_3, LEN_4>;
+
+    /**
+     * @brief Expression for the generalized permutation sort gate.
+     * @details The relation is defined as C(extended_edges(X)...) =
+     *    TODO
+     *
+     * @param evals transformed to `evals + C(extended_edges(X)...)*scaling_factor`
+     * @param extended_edges an std::array containing the fully extended Univariate edges.
+     * @param parameters contains beta, gamma, and public_input_delta, ....
+     * @param scaling_factor optional term to scale the evaluation before adding to evals.
+     */
+    template <typename AccumulatorTypes>
+    void static add_edge_contribution_impl(typename AccumulatorTypes::Accumulators& accumulators,
+                                           const auto& extended_edges,
+                                           const RelationParameters<FF>&,
+                                           const FF& scaling_factor)
+    {
+        // OPTIMIZATION?: Karatsuba in general, at least for some degrees?
+        //       See https://hackmd.io/xGLuj6biSsCjzQnYN-pEiA?both
+
+        using View = typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type;
+        auto w_1 = View(extended_edges.w_l);
+        auto w_2 = View(extended_edges.w_r);
+        auto w_3 = View(extended_edges.w_o);
+        auto w_4 = View(extended_edges.w_4);
+        auto op_wire_1 = View(extended_edges.ecc_op_wire_1);
+        auto op_wire_2 = View(extended_edges.ecc_op_wire_2);
+        auto op_wire_3 = View(extended_edges.ecc_op_wire_3);
+        auto op_wire_4 = View(extended_edges.ecc_op_wire_4);
+        auto q_ecc_op_queue = View(extended_edges.q_ecc_op_queue);
+
+        // Contribution (1)
+        auto tmp = op_wire_1 - w_1;
+        tmp *= q_ecc_op_queue;
+        tmp *= scaling_factor;
+        std::get<0>(accumulators) += tmp;
+
+        // Contribution (2)
+        tmp = op_wire_2 - w_2;
+        tmp *= q_ecc_op_queue;
+        tmp *= scaling_factor;
+        std::get<1>(accumulators) += tmp;
+
+        // Contribution (3)
+        tmp = op_wire_3 - w_3;
+        tmp *= q_ecc_op_queue;
+        tmp *= scaling_factor;
+        std::get<2>(accumulators) += tmp;
+
+        // Contribution (4)
+        tmp = op_wire_4 - w_4;
+        tmp *= q_ecc_op_queue;
+        tmp *= scaling_factor;
+        std::get<3>(accumulators) += tmp;
+    };
+};
+
+template <typename FF> using EccOpQueueRelation = RelationWrapper<FF, EccOpQueueRelationBase>;
+
+} // namespace proof_system::honk::sumcheck

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
@@ -474,7 +474,7 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
 
     ProverPolynomials prover_polynomials;
 
-    prover_polynomials.q_ecc_op_queue = prover.key->q_ecc_op_queue;
+    prover_polynomials.lagrange_ecc_op = prover.key->lagrange_ecc_op;
     prover_polynomials.ecc_op_wire_1 = prover.key->ecc_op_wire_1;
     prover_polynomials.ecc_op_wire_2 = prover.key->ecc_op_wire_2;
     prover_polynomials.ecc_op_wire_3 = prover.key->ecc_op_wire_3;

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
@@ -61,6 +61,145 @@ template <typename Flavor> void check_relation(auto relation, auto circuit_size,
     }
 }
 
+template <typename Flavor> void create_some_add_gates(auto& circuit_builder)
+{
+    fr a = fr::random_element();
+
+    // Add some basic add gates; incorporate a public input for non-trivial PI-delta
+    uint32_t a_idx = circuit_builder.add_public_variable(a);
+    fr b = fr::random_element();
+    fr c = a + b;
+    fr d = a + c;
+    uint32_t b_idx = circuit_builder.add_variable(b);
+    uint32_t c_idx = circuit_builder.add_variable(c);
+    uint32_t d_idx = circuit_builder.add_variable(d);
+    for (size_t i = 0; i < 16; i++) {
+        circuit_builder.create_add_gate({ a_idx, b_idx, c_idx, 1, 1, -1, 0 });
+        circuit_builder.create_add_gate({ d_idx, c_idx, a_idx, 1, -1, -1, 0 });
+    }
+
+    // If Ultra arithmetization, add a big add gate with use of next row to test q_arith = 2
+    if constexpr (IsUltraFlavor<Flavor>) {
+        fr e = a + b + c + d;
+        uint32_t e_idx = circuit_builder.add_variable(e);
+
+        uint32_t zero_idx = circuit_builder.zero_idx;
+        circuit_builder.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, -1, -1, -1, -1, 0 }, true); // use next row
+        circuit_builder.create_big_add_gate({ zero_idx, zero_idx, zero_idx, e_idx, 0, 0, 0, 0, 0 }, false);
+    }
+}
+
+template <typename Flavor> void create_some_lookup_gates(auto& circuit_builder)
+{
+    // Add some lookup gates (related to pedersen hashing)
+    barretenberg::fr pedersen_input_value = fr::random_element();
+    const fr input_hi = uint256_t(pedersen_input_value).slice(126, 256);
+    const fr input_lo = uint256_t(pedersen_input_value).slice(0, 126);
+    const auto input_hi_index = circuit_builder.add_variable(input_hi);
+    const auto input_lo_index = circuit_builder.add_variable(input_lo);
+
+    const auto sequence_data_hi = plookup::get_lookup_accumulators(plookup::MultiTableId::PEDERSEN_LEFT_HI, input_hi);
+    const auto sequence_data_lo = plookup::get_lookup_accumulators(plookup::MultiTableId::PEDERSEN_LEFT_LO, input_lo);
+
+    circuit_builder.create_gates_from_plookup_accumulators(
+        plookup::MultiTableId::PEDERSEN_LEFT_HI, sequence_data_hi, input_hi_index);
+    circuit_builder.create_gates_from_plookup_accumulators(
+        plookup::MultiTableId::PEDERSEN_LEFT_LO, sequence_data_lo, input_lo_index);
+}
+
+template <typename Flavor> void create_some_genperm_sort_gates(auto& circuit_builder)
+{
+    // Add a sort gate (simply checks that consecutive inputs have a difference of < 4)
+    using FF = typename Flavor::FF;
+    auto a_idx = circuit_builder.add_variable(FF(0));
+    auto b_idx = circuit_builder.add_variable(FF(1));
+    auto c_idx = circuit_builder.add_variable(FF(2));
+    auto d_idx = circuit_builder.add_variable(FF(3));
+    circuit_builder.create_sort_constraint({ a_idx, b_idx, c_idx, d_idx });
+}
+
+template <typename Flavor> void create_some_RAM_gates(auto& circuit_builder)
+{
+    // Add some RAM gates
+    uint32_t ram_values[8]{
+        circuit_builder.add_variable(fr::random_element()), circuit_builder.add_variable(fr::random_element()),
+        circuit_builder.add_variable(fr::random_element()), circuit_builder.add_variable(fr::random_element()),
+        circuit_builder.add_variable(fr::random_element()), circuit_builder.add_variable(fr::random_element()),
+        circuit_builder.add_variable(fr::random_element()), circuit_builder.add_variable(fr::random_element()),
+    };
+
+    size_t ram_id = circuit_builder.create_RAM_array(8);
+
+    for (size_t i = 0; i < 8; ++i) {
+        circuit_builder.init_RAM_element(ram_id, i, ram_values[i]);
+    }
+
+    auto a_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(5));
+    EXPECT_EQ(a_idx != ram_values[5], true);
+
+    auto b_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(4));
+    auto c_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(1));
+
+    circuit_builder.write_RAM_array(ram_id, circuit_builder.add_variable(4), circuit_builder.add_variable(500));
+    auto d_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(4));
+
+    EXPECT_EQ(circuit_builder.get_variable(d_idx), 500);
+
+    // ensure these vars get used in another arithmetic gate
+    const auto e_value = circuit_builder.get_variable(a_idx) + circuit_builder.get_variable(b_idx) +
+                         circuit_builder.get_variable(c_idx) + circuit_builder.get_variable(d_idx);
+    auto e_idx = circuit_builder.add_variable(e_value);
+
+    circuit_builder.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, -1, -1, -1, -1, 0 }, true);
+    circuit_builder.create_big_add_gate(
+        {
+            circuit_builder.zero_idx,
+            circuit_builder.zero_idx,
+            circuit_builder.zero_idx,
+            e_idx,
+            0,
+            0,
+            0,
+            0,
+            0,
+        },
+        false);
+}
+
+template <typename Flavor> void create_some_elliptic_curve_addition_gates(auto& circuit_builder)
+{
+    // Add an elliptic curve addition gate
+    grumpkin::g1::affine_element p1 = crypto::generators::get_generator_data({ 0, 0 }).generator;
+    grumpkin::g1::affine_element p2 = crypto::generators::get_generator_data({ 0, 1 }).generator;
+
+    grumpkin::fq beta_scalar = grumpkin::fq::cube_root_of_unity();
+    grumpkin::g1::affine_element p2_endo = p2;
+    p2_endo.x *= beta_scalar;
+
+    grumpkin::g1::affine_element p3(grumpkin::g1::element(p1) - grumpkin::g1::element(p2_endo));
+
+    uint32_t x1 = circuit_builder.add_variable(p1.x);
+    uint32_t y1 = circuit_builder.add_variable(p1.y);
+    uint32_t x2 = circuit_builder.add_variable(p2.x);
+    uint32_t y2 = circuit_builder.add_variable(p2.y);
+    uint32_t x3 = circuit_builder.add_variable(p3.x);
+    uint32_t y3 = circuit_builder.add_variable(p3.y);
+
+    ecc_add_gate gate{ x1, y1, x2, y2, x3, y3, beta_scalar, -1 };
+    circuit_builder.create_ecc_add_gate(gate);
+}
+
+template <typename Flavor> void create_some_ecc_op_queue_gates(auto& circuit_builder)
+{
+    static_assert(IsGoblinFlavor<Flavor>);
+    const size_t num_ecc_operations = 10; // arbitrary
+    for (size_t i = 0; i < num_ecc_operations; ++i) {
+        auto point = g1::affine_one * fr::random_element();
+        auto scalar = fr::random_element();
+        circuit_builder.queue_ecc_mul_accum(point, scalar);
+    }
+}
+
 class RelationCorrectnessTests : public ::testing::Test {
   protected:
     static void SetUpTestSuite() { barretenberg::srs::init_crs_factory("../srs_db/ignition"); }
@@ -81,24 +220,12 @@ TEST_F(RelationCorrectnessTests, StandardRelationCorrectness)
     using Flavor = honk::flavor::Standard;
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
-    // using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     // Create a composer and a dummy circuit with a few gates
     auto circuit_constructor = StandardCircuitBuilder();
-    fr a = fr::one();
-    // Using the public variable to check that public_input_delta is computed and added to the relation correctly
-    uint32_t a_idx = circuit_constructor.add_public_variable(a);
-    fr b = fr::one();
-    fr c = a + b;
-    fr d = a + c;
-    uint32_t b_idx = circuit_constructor.add_variable(b);
-    uint32_t c_idx = circuit_constructor.add_variable(c);
-    uint32_t d_idx = circuit_constructor.add_variable(d);
-    for (size_t i = 0; i < 16; i++) {
-        circuit_constructor.create_add_gate({ a_idx, b_idx, c_idx, fr::one(), fr::one(), fr::neg_one(), fr::zero() });
-        circuit_constructor.create_add_gate(
-            { d_idx, c_idx, a_idx, fr::one(), fr::neg_one(), fr::neg_one(), fr::zero() });
-    }
+
+    create_some_add_gates<Flavor>(circuit_constructor);
+
     // Create a prover (it will compute proving key and witness)
     auto composer = StandardComposer();
     auto prover = composer.create_prover(circuit_constructor);
@@ -163,132 +290,23 @@ TEST_F(RelationCorrectnessTests, StandardRelationCorrectness)
  * indices
  *
  */
-// TODO(luke): possibly make circuit construction one or many functions to clarify the individual components
 // TODO(luke): Add a gate that sets q_arith = 3 to check secondary arithmetic relation
 TEST_F(RelationCorrectnessTests, UltraRelationCorrectness)
 {
     using Flavor = honk::flavor::Ultra;
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
-    // using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     // Create a composer and then add an assortment of gates designed to ensure that the constraint(s) represented
     // by each relation are non-trivially exercised.
     auto circuit_constructor = UltraCircuitBuilder();
 
-    barretenberg::fr pedersen_input_value = fr::random_element();
-    fr a = fr::one();
-    // Using the public variable to check that public_input_delta is computed and added to the relation correctly
-    // TODO(luke): add method "add_public_variable" to UH circuit_constructor
-    // uint32_t a_idx = circuit_constructor.add_public_variable(a);
-
-    // Add some basic add gates
-    uint32_t a_idx = circuit_constructor.add_variable(a);
-    fr b = fr::one();
-    fr c = a + b;
-    fr d = a + c;
-    uint32_t b_idx = circuit_constructor.add_variable(b);
-    uint32_t c_idx = circuit_constructor.add_variable(c);
-    uint32_t d_idx = circuit_constructor.add_variable(d);
-    for (size_t i = 0; i < 16; i++) {
-        circuit_constructor.create_add_gate({ a_idx, b_idx, c_idx, 1, 1, -1, 0 });
-        circuit_constructor.create_add_gate({ d_idx, c_idx, a_idx, 1, -1, -1, 0 });
-    }
-
-    // Add a big add gate with use of next row to test q_arith = 2
-    fr e = a + b + c + d;
-    uint32_t e_idx = circuit_constructor.add_variable(e);
-
-    uint32_t zero_idx = circuit_constructor.zero_idx;
-    circuit_constructor.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, -1, -1, -1, -1, 0 }, true); // use next row
-    circuit_constructor.create_big_add_gate({ zero_idx, zero_idx, zero_idx, e_idx, 0, 0, 0, 0, 0 }, false);
-
-    // Add some lookup gates (related to pedersen hashing)
-    const fr input_hi = uint256_t(pedersen_input_value).slice(126, 256);
-    const fr input_lo = uint256_t(pedersen_input_value).slice(0, 126);
-    const auto input_hi_index = circuit_constructor.add_variable(input_hi);
-    const auto input_lo_index = circuit_constructor.add_variable(input_lo);
-
-    const auto sequence_data_hi = plookup::get_lookup_accumulators(plookup::MultiTableId::PEDERSEN_LEFT_HI, input_hi);
-    const auto sequence_data_lo = plookup::get_lookup_accumulators(plookup::MultiTableId::PEDERSEN_LEFT_LO, input_lo);
-
-    circuit_constructor.create_gates_from_plookup_accumulators(
-        plookup::MultiTableId::PEDERSEN_LEFT_HI, sequence_data_hi, input_hi_index);
-    circuit_constructor.create_gates_from_plookup_accumulators(
-        plookup::MultiTableId::PEDERSEN_LEFT_LO, sequence_data_lo, input_lo_index);
-
-    // Add a sort gate (simply checks that consecutive inputs have a difference of < 4)
-    a_idx = circuit_constructor.add_variable(FF(0));
-    b_idx = circuit_constructor.add_variable(FF(1));
-    c_idx = circuit_constructor.add_variable(FF(2));
-    d_idx = circuit_constructor.add_variable(FF(3));
-    circuit_constructor.create_sort_constraint({ a_idx, b_idx, c_idx, d_idx });
-
-    // Add an elliptic curve addition gate
-    grumpkin::g1::affine_element p1 = crypto::generators::get_generator_data({ 0, 0 }).generator;
-    grumpkin::g1::affine_element p2 = crypto::generators::get_generator_data({ 0, 1 }).generator;
-
-    grumpkin::fq beta_scalar = grumpkin::fq::cube_root_of_unity();
-    grumpkin::g1::affine_element p2_endo = p2;
-    p2_endo.x *= beta_scalar;
-
-    grumpkin::g1::affine_element p3(grumpkin::g1::element(p1) - grumpkin::g1::element(p2_endo));
-
-    uint32_t x1 = circuit_constructor.add_variable(p1.x);
-    uint32_t y1 = circuit_constructor.add_variable(p1.y);
-    uint32_t x2 = circuit_constructor.add_variable(p2.x);
-    uint32_t y2 = circuit_constructor.add_variable(p2.y);
-    uint32_t x3 = circuit_constructor.add_variable(p3.x);
-    uint32_t y3 = circuit_constructor.add_variable(p3.y);
-
-    ecc_add_gate gate{ x1, y1, x2, y2, x3, y3, beta_scalar, -1 };
-    circuit_constructor.create_ecc_add_gate(gate);
-
-    // Add some RAM gates
-    uint32_t ram_values[8]{
-        circuit_constructor.add_variable(fr::random_element()), circuit_constructor.add_variable(fr::random_element()),
-        circuit_constructor.add_variable(fr::random_element()), circuit_constructor.add_variable(fr::random_element()),
-        circuit_constructor.add_variable(fr::random_element()), circuit_constructor.add_variable(fr::random_element()),
-        circuit_constructor.add_variable(fr::random_element()), circuit_constructor.add_variable(fr::random_element()),
-    };
-
-    size_t ram_id = circuit_constructor.create_RAM_array(8);
-
-    for (size_t i = 0; i < 8; ++i) {
-        circuit_constructor.init_RAM_element(ram_id, i, ram_values[i]);
-    }
-
-    a_idx = circuit_constructor.read_RAM_array(ram_id, circuit_constructor.add_variable(5));
-    EXPECT_EQ(a_idx != ram_values[5], true);
-
-    b_idx = circuit_constructor.read_RAM_array(ram_id, circuit_constructor.add_variable(4));
-    c_idx = circuit_constructor.read_RAM_array(ram_id, circuit_constructor.add_variable(1));
-
-    circuit_constructor.write_RAM_array(
-        ram_id, circuit_constructor.add_variable(4), circuit_constructor.add_variable(500));
-    d_idx = circuit_constructor.read_RAM_array(ram_id, circuit_constructor.add_variable(4));
-
-    EXPECT_EQ(circuit_constructor.get_variable(d_idx), 500);
-
-    // ensure these vars get used in another arithmetic gate
-    const auto e_value = circuit_constructor.get_variable(a_idx) + circuit_constructor.get_variable(b_idx) +
-                         circuit_constructor.get_variable(c_idx) + circuit_constructor.get_variable(d_idx);
-    e_idx = circuit_constructor.add_variable(e_value);
-
-    circuit_constructor.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, -1, -1, -1, -1, 0 }, true);
-    circuit_constructor.create_big_add_gate(
-        {
-            circuit_constructor.zero_idx,
-            circuit_constructor.zero_idx,
-            circuit_constructor.zero_idx,
-            e_idx,
-            0,
-            0,
-            0,
-            0,
-            0,
-        },
-        false);
+    // Create an assortment of representative gates
+    create_some_add_gates<Flavor>(circuit_constructor);
+    create_some_lookup_gates<Flavor>(circuit_constructor);
+    create_some_genperm_sort_gates<Flavor>(circuit_constructor);
+    create_some_elliptic_curve_addition_gates<Flavor>(circuit_constructor);
+    create_some_RAM_gates<Flavor>(circuit_constructor);
 
     // Create a prover (it will compute proving key and witness)
     auto composer = UltraComposer();
@@ -395,39 +413,18 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
     using Flavor = honk::flavor::GoblinUltra;
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
-    // using ClaimedEvaluations = typename Flavor::ClaimedEvaluations;
 
     // Create a composer and then add an assortment of gates designed to ensure that the constraint(s) represented
     // by each relation are non-trivially exercised.
     auto builder = UltraCircuitBuilder();
 
-    // Using the public variable to check that public_input_delta is computed and added to the relation correctly
-    // TODO(luke): add method "add_public_variable" to UH builder
-    // uint32_t a_idx = builder.add_public_variable(a);
-
-    // Add some ecc op gates
-    for (size_t i = 0; i < 10; ++i) {
-        builder.queue_ecc_add_accum(g1::affine_one);
-    }
-
-    // Add some public inputs
-    for (size_t i = 0; i < 10; ++i) {
-        builder.add_public_variable(fr::random_element());
-    }
-
-    // Add some basic add gates
-    fr a = fr::random_element();
-    fr b = fr::one();
-    fr c = a + b;
-    fr d = a + c;
-    uint32_t a_idx = builder.add_public_variable(a);
-    uint32_t b_idx = builder.add_variable(b);
-    uint32_t c_idx = builder.add_variable(c);
-    uint32_t d_idx = builder.add_variable(d);
-    for (size_t i = 0; i < 16; i++) {
-        builder.create_add_gate({ a_idx, b_idx, c_idx, 1, 1, -1, 0 });
-        builder.create_add_gate({ d_idx, c_idx, a_idx, 1, -1, -1, 0 });
-    }
+    // Create an assortment of representative gates
+    create_some_add_gates<Flavor>(builder);
+    create_some_lookup_gates<Flavor>(builder);
+    create_some_genperm_sort_gates<Flavor>(builder);
+    create_some_elliptic_curve_addition_gates<Flavor>(builder);
+    create_some_RAM_gates<Flavor>(builder);
+    create_some_ecc_op_queue_gates<Flavor>(builder); // Goblin!
 
     // Create a prover (it will compute proving key and witness)
     auto composer = GoblinUltraComposer();

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
@@ -466,12 +466,6 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
     // Add RAM/ROM memory records to wire four
     prover_library::add_plookup_memory_records_to_wire_4<Flavor>(prover.key, eta);
 
-    // Compute grand product polynomial
-    prover.key->z_perm = prover_library::compute_permutation_grand_product<Flavor>(prover.key, beta, gamma);
-
-    // Compute lookup grand product polynomial
-    prover.key->z_lookup = prover_library::compute_lookup_grand_product<Flavor>(prover.key, eta, beta, gamma);
-
     ProverPolynomials prover_polynomials;
 
     prover_polynomials.lagrange_ecc_op = prover.key->lagrange_ecc_op;
@@ -498,10 +492,6 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
     prover_polynomials.table_2_shift = prover.key->table_2.shifted();
     prover_polynomials.table_3_shift = prover.key->table_3.shifted();
     prover_polynomials.table_4_shift = prover.key->table_4.shifted();
-    prover_polynomials.z_perm = prover.key->z_perm;
-    prover_polynomials.z_perm_shift = prover.key->z_perm.shifted();
-    prover_polynomials.z_lookup = prover.key->z_lookup;
-    prover_polynomials.z_lookup_shift = prover.key->z_lookup.shifted();
     prover_polynomials.q_m = prover.key->q_m;
     prover_polynomials.q_l = prover.key->q_l;
     prover_polynomials.q_r = prover.key->q_r;
@@ -523,6 +513,9 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
     prover_polynomials.id_4 = prover.key->id_4;
     prover_polynomials.lagrange_first = prover.key->lagrange_first;
     prover_polynomials.lagrange_last = prover.key->lagrange_last;
+
+    // Compute grand product polynomials for permutation + lookup
+    grand_product_library::compute_grand_products<Flavor>(prover.key, prover_polynomials, params);
 
     // Check that selectors are nonzero to ensure corresponding relation has nontrivial contribution
     ensure_non_zero(prover.key->q_arith);

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
@@ -6,6 +6,7 @@
 #include "barretenberg/honk/proof_system/prover_library.hpp"
 #include "barretenberg/honk/sumcheck/relations/arithmetic_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp"
+#include "barretenberg/honk/sumcheck/relations/ecc_op_queue_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/elliptic_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/gen_perm_sort_relation.hpp"
 #include "barretenberg/honk/sumcheck/relations/lookup_relation.hpp"
@@ -474,11 +475,10 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
     ProverPolynomials prover_polynomials;
 
     prover_polynomials.q_ecc_op_queue = prover.key->q_ecc_op_queue;
-    // WORKTODO: make this real
-    prover_polynomials.ecc_op_wire_1 = prover.key->w_l;
-    prover_polynomials.ecc_op_wire_2 = prover.key->w_l;
-    prover_polynomials.ecc_op_wire_3 = prover.key->w_l;
-    prover_polynomials.ecc_op_wire_4 = prover.key->w_l;
+    prover_polynomials.ecc_op_wire_1 = prover.key->ecc_op_wire_1;
+    prover_polynomials.ecc_op_wire_2 = prover.key->ecc_op_wire_2;
+    prover_polynomials.ecc_op_wire_3 = prover.key->ecc_op_wire_3;
+    prover_polynomials.ecc_op_wire_4 = prover.key->ecc_op_wire_4;
 
     prover_polynomials.w_l = prover.key->w_l;
     prover_polynomials.w_r = prover.key->w_r;
@@ -537,7 +537,8 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
                                 honk::sumcheck::LookupRelation<FF>(),
                                 honk::sumcheck::GenPermSortRelation<FF>(),
                                 honk::sumcheck::EllipticRelation<FF>(),
-                                honk::sumcheck::AuxiliaryRelation<FF>());
+                                honk::sumcheck::AuxiliaryRelation<FF>(),
+                                honk::sumcheck::EccOpQueueRelation<FF>());
 
     // Check that each relation is satisfied across each row of the prover polynomials
     check_relation<Flavor>(std::get<0>(relations), circuit_size, prover_polynomials, params);
@@ -546,6 +547,7 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
     check_relation<Flavor>(std::get<3>(relations), circuit_size, prover_polynomials, params);
     check_relation<Flavor>(std::get<4>(relations), circuit_size, prover_polynomials, params);
     check_relation<Flavor>(std::get<5>(relations), circuit_size, prover_polynomials, params);
+    check_relation<Flavor>(std::get<6>(relations), circuit_size, prover_polynomials, params);
 }
 
 } // namespace test_honk_relations

--- a/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
@@ -320,8 +320,9 @@ TEST_F(RelationCorrectnessTests, UltraRelationCorrectness)
 
     // Compute public input delta
     const auto public_inputs = circuit_constructor.get_public_inputs();
-    auto public_input_delta =
-        honk::compute_public_input_delta<Flavor>(public_inputs, beta, gamma, prover.key->circuit_size);
+    const size_t pub_inputs_offset = Flavor::has_zero_row ? 1 : 0;
+    auto public_input_delta = honk::compute_public_input_delta<Flavor>(
+        public_inputs, beta, gamma, prover.key->circuit_size, pub_inputs_offset);
     auto lookup_grand_product_delta =
         honk::compute_lookup_grand_product_delta<FF>(beta, gamma, prover.key->circuit_size);
 
@@ -440,9 +441,9 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
     const auto public_inputs = builder.get_public_inputs();
 
     // If Goblin, must account for the fact that PI are offset in the wire polynomials by the number of ecc op gates
-    size_t pub_inputs_offset = 0;
+    size_t pub_inputs_offset = Flavor::has_zero_row ? 1 : 0;
     if constexpr (IsGoblinFlavor<Flavor>) {
-        pub_inputs_offset = builder.num_ecc_op_gates;
+        pub_inputs_offset += builder.num_ecc_op_gates;
     }
     auto public_input_delta = honk::compute_public_input_delta<Flavor>(
         public_inputs, beta, gamma, prover.key->circuit_size, pub_inputs_offset);

--- a/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
@@ -630,8 +630,9 @@ TEST_F(SumcheckTests, RealCircuitUltra)
 
     // Compute public input delta
     const auto public_inputs = circuit_constructor.get_public_inputs();
-    auto public_input_delta =
-        honk::compute_public_input_delta<Flavor>(public_inputs, beta, gamma, prover.key->circuit_size);
+    size_t pub_inputs_offset = Flavor::has_zero_row ? 1 : 0;
+    auto public_input_delta = honk::compute_public_input_delta<Flavor>(
+        public_inputs, beta, gamma, prover.key->circuit_size, pub_inputs_offset);
     auto lookup_grand_product_delta =
         honk::compute_lookup_grand_product_delta<FF>(beta, gamma, prover.key->circuit_size);
 

--- a/cpp/src/barretenberg/honk/utils/grand_product_delta.hpp
+++ b/cpp/src/barretenberg/honk/utils/grand_product_delta.hpp
@@ -11,17 +11,21 @@ namespace proof_system::honk {
  * @param beta random linear-combination term to combine both (wʲ, IDʲ) and (wʲ, σʲ)
  * @param gamma Schwartz-Zippel random evaluation to ensure ∏ᵢ (γ + Sᵢ) = ∏ᵢ (γ + Tᵢ)
  * @param domain_size Total number of rows required for the circuit (power of 2)
+ * @param offset Extent to which PI are offset from the 0th index in the wire polynomials, for example, due to inclusion
+ * of Goblin style ecc op gates at the top of the execution trace. (Leading zero row is accounted for separately).
  * @return Field Public input Δ
  */
 template <typename Flavor>
 typename Flavor::FF compute_public_input_delta(std::span<const typename Flavor::FF> public_inputs,
                                                const typename Flavor::FF& beta,
                                                const typename Flavor::FF& gamma,
-                                               const size_t domain_size)
+                                               const size_t domain_size,
+                                               size_t offset = 0)
 {
     using Field = typename Flavor::FF;
     Field numerator = Field::one();
     Field denominator = Field::one();
+    // WORKTODO: update comment to account for existence of possible "offset"
 
     // Let m be the number of public inputs x₀,…, xₘ₋₁.
     // Recall that we broke the permutation σ⁰ by changing the mapping
@@ -44,7 +48,7 @@ typename Flavor::FF compute_public_input_delta(std::span<const typename Flavor::
     // set the expected value for the start of iteration i+1.
     // Note: If a zero row is included at the start of the execution
     // trace, the indices of the PI are offset by 1.
-    const size_t offset = Flavor::has_zero_row ? 1 : 0;
+    offset += Flavor::has_zero_row ? 1 : 0;
     Field numerator_acc = gamma + (beta * Field(domain_size + offset));
     Field denominator_acc = gamma - beta * Field(1 + offset);
 

--- a/cpp/src/barretenberg/honk/utils/grand_product_delta.hpp
+++ b/cpp/src/barretenberg/honk/utils/grand_product_delta.hpp
@@ -12,7 +12,7 @@ namespace proof_system::honk {
  * @param gamma Schwartz-Zippel random evaluation to ensure ∏ᵢ (γ + Sᵢ) = ∏ᵢ (γ + Tᵢ)
  * @param domain_size Total number of rows required for the circuit (power of 2)
  * @param offset Extent to which PI are offset from the 0th index in the wire polynomials, for example, due to inclusion
- * of Goblin style ECC op gates at the top of the execution trace. (Leading zero row is accounted for separately).
+ * of a leading zero row or Goblin style ECC op gates at the top of the execution trace.
  * @return Field Public input Δ
  */
 template <typename Flavor>
@@ -48,7 +48,6 @@ typename Flavor::FF compute_public_input_delta(std::span<const typename Flavor::
     // Note: The public inputs may be offset from the 0th index of the wires, for example due to the inclusion of an
     // initial zero row or Goblin-stlye ECC op gates. Accordingly, the indices i in the above formulas are given by i =
     // [0, m-1] + offset, i.e. i = offset, 1 + offset, …, m - 1 + offset.
-    offset += Flavor::has_zero_row ? 1 : 0;
     Field numerator_acc = gamma + (beta * Field(domain_size + offset));
     Field denominator_acc = gamma - beta * Field(1 + offset);
 

--- a/cpp/src/barretenberg/honk/utils/grand_product_delta.hpp
+++ b/cpp/src/barretenberg/honk/utils/grand_product_delta.hpp
@@ -12,7 +12,7 @@ namespace proof_system::honk {
  * @param gamma Schwartz-Zippel random evaluation to ensure ∏ᵢ (γ + Sᵢ) = ∏ᵢ (γ + Tᵢ)
  * @param domain_size Total number of rows required for the circuit (power of 2)
  * @param offset Extent to which PI are offset from the 0th index in the wire polynomials, for example, due to inclusion
- * of Goblin style ecc op gates at the top of the execution trace. (Leading zero row is accounted for separately).
+ * of Goblin style ECC op gates at the top of the execution trace. (Leading zero row is accounted for separately).
  * @return Field Public input Δ
  */
 template <typename Flavor>
@@ -25,7 +25,6 @@ typename Flavor::FF compute_public_input_delta(std::span<const typename Flavor::
     using Field = typename Flavor::FF;
     Field numerator = Field::one();
     Field denominator = Field::one();
-    // WORKTODO: update comment to account for existence of possible "offset"
 
     // Let m be the number of public inputs x₀,…, xₘ₋₁.
     // Recall that we broke the permutation σ⁰ by changing the mapping
@@ -46,8 +45,9 @@ typename Flavor::FF compute_public_input_delta(std::span<const typename Flavor::
     //      denominator_acc = γ - β⋅(1+i) = γ - β   - β⋅i
     // at the end of the loop, add and subtract β to each term respectively to
     // set the expected value for the start of iteration i+1.
-    // Note: If a zero row is included at the start of the execution
-    // trace, the indices of the PI are offset by 1.
+    // Note: The public inputs may be offset from the 0th index of the wires, for example due to the inclusion of an
+    // initial zero row or Goblin-stlye ECC op gates. Accordingly, the indices i in the above formulas are given by i =
+    // [0, m-1] + offset, i.e. i = offset, 1 + offset, …, m - 1 + offset.
     offset += Flavor::has_zero_row ? 1 : 0;
     Field numerator_acc = gamma + (beta * Field(domain_size + offset));
     Field denominator_acc = gamma - beta * Field(1 + offset);

--- a/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
+++ b/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
@@ -51,15 +51,14 @@ template <typename FF> void UltraCircuitBuilder_<FF>::finalize_circuit()
 }
 
 /**
- * @brief Avoid zero-polynomials and ensure first coeff of wire polynomials is 0
+ * @brief Ensure all polynomials have at least one non-zero coefficient to avoid commiting to the zero-polynomial
  *
  * @param in Structure containing variables and witness selectors
  */
 // TODO(#423): This function adds valid (but arbitrary) gates to ensure that the circuit which includes
 // them will not result in any zero-polynomials. It also ensures that the first coefficient of the wire
 // polynomials is zero, which is required for them to be shiftable.
-// TODO(#423)(luke): Add 0 as a PI since PI always start at the 0th index of the wire polynomials?
-// TODO(luke): may need to reevaluate once aux relation is implemented
+// TODO(luke): Add ECC op gate to ensure op wires are non-zero?
 template <typename FF> void UltraCircuitBuilder_<FF>::add_gates_to_ensure_all_polys_are_non_zero()
 {
     // First add a gate to simultaneously ensure first entries of all wires is zero and to add a non

--- a/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
+++ b/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
@@ -66,9 +66,10 @@ void construct_selector_polynomials(const typename Flavor::CircuitBuilder& circu
  *
  * @details We can think of the entries in the wire polynomials as reflecting the structure of the circuit execution
  * trace. The execution trace is broken up into several distinct blocks, depending on Flavor. For example, for Goblin
- * Ultra Honk, the order is: leading zero row, ECC op gates, public inputs, conventional wires. We construct the
- * wire polynomials accordingly by applying appropriate "offsets" for each block. The actual values are determined by
- * corresponding arrays of indices into the variables vector of the circuit builder.
+ * Ultra Honk, the order is: leading zero row, ECC op gates, public inputs, conventional wires. The actual values used
+ * to populate the wire polynomials are determined by corresponding arrays of indices into the variables vector of the
+ * circuit builder, and their location in the polynomials is determined by applying the appropriate "offset" for the
+ * corresponding block.
  *
  * @tparam Flavor provides the circuit constructor type and the number of wires.
  * @param circuit_constructor

--- a/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
+++ b/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
@@ -25,6 +25,7 @@ void construct_selector_polynomials(const typename Flavor::CircuitBuilder& circu
     // and (2) construct ecc op gate selector polynomial.
     // Note 1: All other selectors will be automatically and correctly initialized to 0 on this domain.
     // Note 2: If applicable, the ecc op gates are shifted down by 1 to account for a zero row.
+    // TODO(luke): Move this out of this function and directly into compute_proving_key?
     if constexpr (IsGoblinFlavor<Flavor>) {
         const size_t num_ecc_op_gates = circuit_constructor.num_ecc_op_gates;
         gate_offset += num_ecc_op_gates;

--- a/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
+++ b/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
@@ -111,6 +111,8 @@ std::vector<CyclicPermutation> compute_wire_copy_cycles(const typename Flavor::C
         // Iterate over all variables of the ecc op gates, and add a corresponding node to the cycle for that variable
         for (size_t i = 0; i < num_ecc_op_gates; ++i) {
             // Note: We exclude the first op wire since it contains the op codes which are not stored in variables
+            // TODO(luke): Kesha pointed out that we may need to constrain the op code values in some way, either with a
+            // copy cycle that constrains them to a constant or with a relation. Resolve this.
             for (size_t op_wire_idx = 1; op_wire_idx < 4; ++op_wire_idx) {
                 const uint32_t var_index = circuit_constructor.real_variable_index[op_wires[op_wire_idx][i]];
                 const auto wire_index = static_cast<uint32_t>(op_wire_idx);

--- a/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
+++ b/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
@@ -65,8 +65,7 @@ namespace {
  * the witness wires that must have the same value.
  *
  * @tparam program_width Program width
- * WORKTODO: Add a comment to this block that explains how these copy cycles effectively determine the execution trace
- * order via the "offsets". Clean up the other comments accordingly
+ *
  * */
 template <typename Flavor>
 std::vector<CyclicPermutation> compute_wire_copy_cycles(const typename Flavor::CircuitBuilder& circuit_constructor)

--- a/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
+++ b/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
@@ -11,6 +11,7 @@
 #include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
 #include "barretenberg/polynomials/iterate_over_domain.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
+#include "barretenberg/proof_system/flavor/flavor.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -107,15 +108,15 @@ std::vector<CyclicPermutation> compute_wire_copy_cycles(const typename Flavor::C
         pub_inputs_offset += num_ecc_op_gates;
         gates_offset += num_ecc_op_gates;
 
+        const auto& op_wires = circuit_constructor.ecc_op_wires;
         // Iterate over all variables of the ecc op gates, and add a corresponding node to the cycle for that variable
         for (size_t i = 0; i < num_ecc_op_gates; ++i) {
-            size_t op_wire_idx = 0;
-            for (auto& op_wire : circuit_constructor.ecc_op_wires) {
-                const uint32_t var_index = circuit_constructor.real_variable_index[op_wire[i]];
-                const auto op_wire_index = static_cast<uint32_t>(op_wire_idx);
-                const auto op_gate_idx = static_cast<uint32_t>(i + op_gates_offset);
-                copy_cycles[var_index].emplace_back(cycle_node{ op_wire_index, op_gate_idx });
-                ++op_wire_idx;
+            // Note: We exclude the first op wire since it contains the op codes which are not stored in variables
+            for (size_t op_wire_idx = 1; op_wire_idx < 4; ++op_wire_idx) {
+                const uint32_t var_index = circuit_constructor.real_variable_index[op_wires[op_wire_idx][i]];
+                const auto wire_index = static_cast<uint32_t>(op_wire_idx);
+                const auto gate_idx = static_cast<uint32_t>(i + op_gates_offset);
+                copy_cycles[var_index].emplace_back(cycle_node{ wire_index, gate_idx });
             }
         }
     }

--- a/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
+++ b/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
@@ -100,7 +100,7 @@ std::vector<CyclicPermutation> compute_wire_copy_cycles(const typename Flavor::C
     size_t pub_inputs_offset = num_zero_rows;
     size_t gates_offset = num_public_inputs + num_zero_rows;
 
-    // If Goblin, adjust offsets to account for ecc op gates
+    // If Goblin, adjust offsets to account for ecc op gates and update copy cycles to include these gates
     if constexpr (IsGoblinFlavor<Flavor>) {
         // Set ecc op gate offset and update offsets for PI and conventional gates
         const size_t op_gates_offset = num_zero_rows;

--- a/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
+++ b/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
@@ -64,6 +64,8 @@ namespace {
  * the witness wires that must have the same value.
  *
  * @tparam program_width Program width
+ * WORKTODO: Add a comment to this block that explains how these copy cycles effectively determine the execution trace
+ * order via the "offsets". Clean up the other comments accordingly
  * */
 template <typename Flavor>
 std::vector<CyclicPermutation> compute_wire_copy_cycles(const typename Flavor::CircuitBuilder& circuit_constructor)
@@ -72,10 +74,6 @@ std::vector<CyclicPermutation> compute_wire_copy_cycles(const typename Flavor::C
     const size_t num_gates = circuit_constructor.num_gates;
     std::span<const uint32_t> public_inputs = circuit_constructor.public_inputs;
     const size_t num_public_inputs = public_inputs.size();
-
-    // Define offsets for placement of public inputs and gates in execution trace
-    const size_t pub_inputs_offset = Flavor::has_zero_row ? 1 : 0;
-    const size_t gates_offset = num_public_inputs + pub_inputs_offset;
 
     // Each variable represents one cycle
     const size_t number_of_cycles = circuit_constructor.variables.size();
@@ -87,12 +85,38 @@ std::vector<CyclicPermutation> compute_wire_copy_cycles(const typename Flavor::C
 
     // For some flavors, we need to ensure the value in the 0th index of each wire is 0 to allow for left-shift by 1. To
     // do this, we add the wires of the first gate in the execution trace to the "zero index" copy cycle.
-    if (Flavor::has_zero_row) {
+    if constexpr (Flavor::has_zero_row) {
         for (size_t wire_idx = 0; wire_idx < Flavor::NUM_WIRES; ++wire_idx) {
             const auto wire_index = static_cast<uint32_t>(wire_idx);
             const uint32_t gate_index = 0;                          // place zeros at 0th index
             const uint32_t zero_idx = circuit_constructor.zero_idx; // index of constant zero in variables
             copy_cycles[zero_idx].emplace_back(cycle_node{ wire_index, gate_index });
+        }
+    }
+
+    // Define offsets for placement of public inputs and gates in execution trace
+    const size_t num_zero_rows = Flavor::has_zero_row ? 1 : 0;
+    size_t pub_inputs_offset = num_zero_rows;
+    size_t gates_offset = num_public_inputs + num_zero_rows;
+
+    // If Goblin, adjust offsets to account for ecc op gates
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        // Set ecc op gate offset and update offsets for PI and conventional gates
+        const size_t op_gates_offset = num_zero_rows;
+        const size_t num_ecc_op_gates = circuit_constructor.num_ecc_op_gates;
+        pub_inputs_offset += num_ecc_op_gates;
+        gates_offset += num_ecc_op_gates;
+
+        // Iterate over all variables of the ecc op gates, and add a corresponding node to the cycle for that variable
+        for (size_t i = 0; i < num_ecc_op_gates; ++i) {
+            size_t op_wire_idx = 0;
+            for (auto& op_wire : circuit_constructor.ecc_op_wires) {
+                const uint32_t var_index = circuit_constructor.real_variable_index[op_wire[i]];
+                const auto op_wire_index = static_cast<uint32_t>(op_wire_idx);
+                const auto op_gate_idx = static_cast<uint32_t>(i + op_gates_offset);
+                copy_cycles[var_index].emplace_back(cycle_node{ op_wire_index, op_gate_idx });
+                ++op_wire_idx;
+            }
         }
     }
 
@@ -224,9 +248,14 @@ PermutationMapping<Flavor::NUM_WIRES> compute_permutation_mapping(
     const auto num_public_inputs = static_cast<uint32_t>(circuit_constructor.public_inputs.size());
 
     // The public inputs are placed at the top of the execution trace, potentially offset by a zero row.
-    const size_t zero_row_offset = Flavor::has_zero_row ? 1 : 0;
+    const size_t num_zero_rows = Flavor::has_zero_row ? 1 : 0;
+    size_t pub_input_offset = num_zero_rows;
+    // If Goblin, PI are further offset by number of ecc op gates
+    if constexpr (IsGoblinFlavor<Flavor>) {
+        pub_input_offset += circuit_constructor.num_ecc_op_gates;
+    }
     for (size_t i = 0; i < num_public_inputs; ++i) {
-        size_t idx = i + zero_row_offset;
+        size_t idx = i + pub_input_offset;
         mapping.sigmas[0][idx].row_index = static_cast<uint32_t>(idx);
         mapping.sigmas[0][idx].column_index = 0;
         mapping.sigmas[0][idx].is_public_input = true;

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -294,7 +294,7 @@ namespace proof_system {
  * @tparam U A parameter pack of types being checked against T.
  */
 // clang-format off
-//WORKTODO: In which of these does Goblin belong?
+
 template <typename T>
 concept IsPlonkFlavor = IsAnyOf<T, plonk::flavor::Standard, plonk::flavor::Turbo, plonk::flavor::Ultra>;
 

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -275,6 +275,7 @@ class Standard;
 class StandardGrumpkin;
 class Ultra;
 class UltraGrumpkin;
+class GoblinUltra;
 } // namespace proof_system::honk::flavor
 
 // Forward declare plonk flavors
@@ -293,17 +294,21 @@ namespace proof_system {
  * @tparam U A parameter pack of types being checked against T.
  */
 // clang-format off
+//WORKTODO: In which of these does Goblin belong?
 template <typename T>
 concept IsPlonkFlavor = IsAnyOf<T, plonk::flavor::Standard, plonk::flavor::Turbo, plonk::flavor::Ultra>;
 
 template <typename T> 
-concept IsHonkFlavor = IsAnyOf<T, honk::flavor::Standard, honk::flavor::Ultra, honk::flavor::StandardGrumpkin, honk::flavor::UltraGrumpkin>;
+concept IsHonkFlavor = IsAnyOf<T, honk::flavor::Standard, honk::flavor::Ultra, honk::flavor::StandardGrumpkin, honk::flavor::UltraGrumpkin, honk::flavor::GoblinUltra>;
+
+template <typename T> 
+concept IsGoblinFlavor = IsAnyOf<T, honk::flavor::GoblinUltra>;
 
 template <typename T> concept IsGrumpkinFlavor = IsAnyOf<T, honk::flavor::StandardGrumpkin, honk::flavor::UltraGrumpkin>;
 
 template <typename T> concept StandardFlavor = IsAnyOf<T, honk::flavor::Standard,  honk::flavor::StandardGrumpkin>;
 
-template <typename T> concept UltraFlavor = IsAnyOf<T, honk::flavor::Ultra, honk::flavor::UltraGrumpkin>;
+template <typename T> concept UltraFlavor = IsAnyOf<T, honk::flavor::Ultra, honk::flavor::UltraGrumpkin, honk::flavor::GoblinUltra>;
 
 // clang-format on
 } // namespace proof_system

--- a/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
+++ b/cpp/src/barretenberg/proof_system/flavor/flavor.hpp
@@ -302,6 +302,9 @@ template <typename T>
 concept IsHonkFlavor = IsAnyOf<T, honk::flavor::Standard, honk::flavor::Ultra, honk::flavor::StandardGrumpkin, honk::flavor::UltraGrumpkin, honk::flavor::GoblinUltra>;
 
 template <typename T> 
+concept IsUltraFlavor = IsAnyOf<T, honk::flavor::Ultra, honk::flavor::UltraGrumpkin, honk::flavor::GoblinUltra>;
+
+template <typename T> 
 concept IsGoblinFlavor = IsAnyOf<T, honk::flavor::GoblinUltra>;
 
 template <typename T> concept IsGrumpkinFlavor = IsAnyOf<T, honk::flavor::StandardGrumpkin, honk::flavor::UltraGrumpkin>;


### PR DESCRIPTION
# Description

The Composer, Prover and Verifier for Goblin Ultra Honk. These are implemented as instantiations of the existing "Ultra" template classes, e.g. `GoblinUltraComposer = UltraComposer_<flavor::GoblinUltra>`, etc.

This work makes it possible to create and verify a Goblin Ultra Honk proof. "Verification" here means confirmation that the ECC op gates have been correctly incorporated into the circuit (checked via a new relation) plus genuine verification of the conventional UltraHonk proof. The _correctness_ of the the ECC op gates is of course not verified, as that is the role of the other components of the Goblin stack.

The new "op gate consistency" relation simply checks that the op wire values have been correctly copied into the conventional wires (needed for copy constraints) and that the op wire polynomials vanish everywhere outside the range of ECC op gates.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
