### PR TITLE
fix: for variable size keccak, inputs are zeroed after the requested length

### DIFF
--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -5,6 +5,7 @@
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/serialize/test_helper.hpp"
 #include "ecdsa_secp256k1.hpp"
+#include "keccak_constraint.hpp"
 TEST(acir_format, msgpack_logic_constraint)
 {
     auto [actual, expected] = msgpack_roundtrip(acir_format::LogicConstraint{});
@@ -262,6 +263,84 @@ TEST(acir_format, test_schnorr_verify_small_range)
           84, 137, 184, 221, 176, 121, 179, 27,  63,  70,  54,    16,    176, 250, 39, 239, 1,   0,   0,   0 });
 
     auto prover = composer.create_ultra_with_keccak_prover();
+    auto proof = prover.construct_proof();
+
+    auto verifier = composer.create_ultra_with_keccak_verifier();
+
+    EXPECT_EQ(verifier.verify_proof(proof), true);
+}
+
+TEST(acir_format, test_var_keccak)
+{
+    acir_format::HashInput input1;
+    input1.witness = 1;
+    input1.num_bits = 8;
+    acir_format::HashInput input2;
+    input2.witness = 2;
+    input2.num_bits = 8;
+    acir_format::HashInput input3;
+    input3.witness = 3;
+    input3.num_bits = 8;
+    acir_format::KeccakVarConstraint keccak;
+    keccak.inputs = { input1, input2, input3 };
+    keccak.var_message_size = 4;
+    keccak.result = { 5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36 };
+
+    acir_format::RangeConstraint range_a{
+        .witness = 1,
+        .num_bits = 8,
+    };
+    acir_format::RangeConstraint range_b{
+        .witness = 2,
+        .num_bits = 8,
+    };
+    acir_format::RangeConstraint range_c{
+        .witness = 3,
+        .num_bits = 8,
+    };
+    acir_format::RangeConstraint range_d{
+        .witness = 4,
+        .num_bits = 8,
+    };
+
+    auto dummy = poly_triple{
+        .a = 1,
+        .b = 0,
+        .c = 0,
+        .q_m = 0,
+        .q_l = 1,
+        .q_r = 0,
+        .q_o = 0,
+        .q_c = fr::neg_one() * fr(4),
+    };
+
+    acir_format::acir_format constraint_system{
+        .varnum = 37,
+        .public_inputs = {},
+        .fixed_base_scalar_mul_constraints = {},
+        .logic_constraints = {},
+        .range_constraints = { range_a, range_b, range_c, range_d },
+        .schnorr_constraints = {},
+        .ecdsa_k1_constraints = {},
+        .ecdsa_r1_constraints = {},
+        .sha256_constraints = {},
+        .blake2s_constraints = {},
+        .keccak_constraints = {},
+        .keccak_var_constraints = { keccak },
+        .hash_to_field_constraints = {},
+        .pedersen_constraints = {},
+        .block_constraints = {},
+        .recursion_constraints = {},
+        .constraints = { dummy },
+    };
+
+    auto composer = acir_format::create_circuit_with_witness(constraint_system, { 4, 2, 6, 2 });
+
+    std::cout << "made composer" << std::endl;
+
+    auto prover = composer.create_ultra_with_keccak_prover();
+
     auto proof = prover.construct_proof();
 
     auto verifier = composer.create_ultra_with_keccak_verifier();

--- a/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -337,8 +337,6 @@ TEST(acir_format, test_var_keccak)
 
     auto composer = acir_format::create_circuit_with_witness(constraint_system, { 4, 2, 6, 2 });
 
-    std::cout << "made composer" << std::endl;
-
     auto prover = composer.create_ultra_with_keccak_prover();
 
     auto proof = prover.construct_proof();

--- a/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -568,8 +568,16 @@ template <typename Composer> byte_array<Composer> keccak<Composer>::sponge_squee
  * @return std::vector<field_t<Composer>>
  */
 template <typename Composer>
-std::vector<field_t<Composer>> keccak<Composer>::format_input_lanes(byte_array_ct& input, const uint32_ct& num_bytes)
+std::vector<field_t<Composer>> keccak<Composer>::format_input_lanes(byte_array_ct& _input, const uint32_ct& num_bytes)
 {
+    byte_array_ct input(_input);
+
+    // make sure that every byte past `num_bytes` is zero!
+    for (size_t i = 0; i < input.size(); ++i) {
+        bool_ct valid_byte = uint32_ct(static_cast<uint32_t>(i)) < num_bytes;
+        input.set_byte(i, (input[i] * valid_byte));
+    }
+
     auto* ctx = input.get_context();
 
     // We require that `num_bytes` does not exceed the size of our input byte array.

--- a/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -285,3 +285,35 @@ TEST(stdlib_keccak, test_double_block_variable_length)
     bool proof_result = verifier.verify_proof(proof);
     EXPECT_EQ(proof_result, true);
 }
+
+TEST(stdlib_keccak, test_variable_length_nonzero_input_greater_than_byte_array_size)
+{
+    Composer composer = Composer();
+    std::string input = "";
+    size_t target_length = 2;
+    size_t byte_array_length = 200;
+    for (size_t i = 0; i < target_length; ++i) {
+        input += "a";
+    }
+    std::vector<uint8_t> input_expected(input.begin(), input.end());
+    std::vector<uint8_t> expected = stdlib::keccak<Composer>::hash_native(input_expected);
+    for (size_t i = target_length; i < byte_array_length; ++i) {
+        input += "a";
+    }
+    std::vector<uint8_t> input_v(input.begin(), input.end());
+
+    byte_array input_arr(&composer, input_v);
+
+    uint32_ct length(witness_ct(&composer, 2));
+    byte_array output = stdlib::keccak<Composer>::hash(input_arr, length);
+
+    EXPECT_EQ(output.get_value(), expected);
+
+    auto prover = composer.create_prover();
+    auto verifier = composer.create_verifier();
+
+    auto proof = prover.construct_proof();
+
+    bool proof_result = verifier.verify_proof(proof);
+    EXPECT_EQ(proof_result, true);
+}


### PR DESCRIPTION
# Description

Solves https://github.com/noir-lang/noir/issues/1934

# Checklist:

- [X] I have reviewed my diff in github, line by line.
- [X] Every change is related to the PR description.
- [X] The branch has been merged with/rebased against the head of its merge target.
- [X] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [] There are no circuit changes, OR a cryptographer has been assigned for review.
- [X] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [X] If existing code has been modified, such documentation has been added or updated.
- [X] No superfluous `include` directives have been added.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [X] I'm happy for the PR to be merged at the reviewer's next convenience.
