### PR TITLE
fix: bin reference when installing package

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -9,8 +9,10 @@
     "displayName": "bb.js",
     "tsconfig": "./tsconfig.json"
   },
-  "main": "./dest/index.js",
-  "bin": "./dest/main.js",
+  "main": "./dest/node/index.js",
+  "bin": {
+    "bb": "dest/node/main.js"
+  },
   "files": [
     "src/",
     "dest/",


### PR DESCRIPTION
# Description

Fix paths for bin installation.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] The branch has been merged with/rebased against the head of its merge target.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
- [ ] No superfluous `include` directives have been added.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to any issue(s) it resolves.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
