### PR TITLE
Fix Argument Processing for Non-Pointer Types in Clang Binding Script…

### DIFF
--- a/scripts/decls_json.py
+++ b/scripts/decls_json.py
@@ -54,14 +54,15 @@ def process_files(files: List[str]) -> List[dict]:
                             {
                                 'name': arg.spelling,
                                 'type': arg.type.spelling,
-                            } for arg in node.get_arguments() if arg.type.get_canonical().get_pointee().is_const_qualified() or arg.type.get_canonical().is_const_qualified()
+                            } for arg in node.get_arguments() if (arg.type.get_canonical().get_pointee() and arg.type.get_canonical().get_pointee().is_const_qualified()) or arg.type.get_canonical().is_const_qualified()
                         ],
                         'outArgs': [
                             {
                                 'name': arg.spelling,
                                 'type': arg.type.spelling,
-                            } for arg in node.get_arguments() if not (arg.type.get_canonical().get_pointee().is_const_qualified() or arg.type.get_canonical().is_const_qualified())
-                        ],
+                            } for arg in node.get_arguments() if not ((arg.type.get_canonical().get_pointee() and arg.type.get_canonical().get_pointee().is_const_qualified()) or arg.type.get_canonical().is_const_qualified()
+                            )
+                        ],                       
                         'isAsync': has_annotation(node, 'async_wasm_export')
                     }
                     result.append(func)


### PR DESCRIPTION
**Problem**:  
The original code for processing function arguments contains a logical error when handling non-pointer types. Specifically, the following fragment assumes that every argument is a pointer type and calls `get_pointee()` without checking for its validity:

```python
'inArgs': [
    {
        'name': arg.spelling,
        'type': arg.type.spelling,
    } for arg in node.get_arguments() if arg.type.get_canonical().get_pointee().is_const_qualified() or arg.type.get_canonical().is_const_qualified()
],
'outArgs': [
    {
        'name': arg.spelling,
        'type': arg.type.spelling,
    } for arg in node.get_arguments() if not (arg.type.get_canonical().get_pointee().is_const_qualified() or arg.type.get_canonical().is_const_qualified())
],
```

If the argument is not a pointer (e.g., `int` or `float`), `get_pointee()` will return `None`, causing an exception when attempting to call `is_const_qualified()`.

---

**Fix**:  
Add a check to ensure that `get_pointee()` is not `None` before attempting to access its methods. Updated code:

```python
'inArgs': [
    {
        'name': arg.spelling,
        'type': arg.type.spelling,
    } for arg in node.get_arguments() if (
        arg.type.get_canonical().get_pointee() and arg.type.get_canonical().get_pointee().is_const_qualified()
    ) or arg.type.get_canonical().is_const_qualified()
],
'outArgs': [
    {
        'name': arg.spelling,
        'type': arg.type.spelling,
    } for arg in node.get_arguments() if not (
        (arg.type.get_canonical().get_pointee() and arg.type.get_canonical().get_pointee().is_const_qualified())
        or arg.type.get_canonical().is_const_qualified()
    )
],
```

---

**Reasoning**:  
1. **Null Safety**: The added condition ensures that `get_pointee()` is only called if it returns a valid object, preventing potential exceptions.
2. **Preserved Logic**: The core logic remains intact, correctly categorizing `inArgs` and `outArgs` based on the `const` qualifier.

---

**Importance**:  
This fix is critical for reliability. Without it, the code will fail when encountering non-pointer arguments, such as primitive types (`int`, `float`). This would make the script unusable for analyzing functions with non-pointer parameters. The adjustment ensures robust handling of all argument types, aligning the implementation with its intended functionality.