### PR TITLE
Typos/fix

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -157,7 +157,7 @@ barretenberg-acir-tests-bb.js:
     RUN BROWSER=chrome THREAD_MODEL=mt ./run_acir_tests_browser.sh verify_honk_proof
     # Run UltraHonk recursive verification through bb.js on chrome testing single-threaded browser support.
     RUN BROWSER=chrome THREAD_MODEL=st ./run_acir_tests_browser.sh verify_honk_proof
-    # Commenting for now as fails intermittently. Unreproducable on mainframe.
+    # Commenting for now as fails intermittently. Unreproducible on mainframe.
     # See https://github.com/AztecProtocol/aztec-packages/issues/2104
     #RUN BROWSER=webkit THREAD_MODEL=st ./run_acir_tests_browser.sh 1_mul
     # TODO(https://github.com/noir-lang/noir/issues/5106)

--- a/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
+++ b/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
@@ -61,7 +61,7 @@ Prover get_prover(void (*test_circuit_function)(typename Prover::Flavor::Circuit
 };
 
 /**
- * @brief Performs proof constuction for benchmarks based on a provided circuit function
+ * @brief Performs proof construction for benchmarks based on a provided circuit function
  *
  * @details This function assumes state.range refers to num_iterations which is the number of times to perform a given
  * basic operation in the circuit, e.g. number of hashes


### PR DESCRIPTION
# Fix: Corrected typos in source files

## Changes
- `cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp:64`: "constuction" corrected to "construction".
- `Earthfile:160`: "Unreproducable" corrected to "Unreproducible".

## Purpose
- Ensured code and documentation accuracy.

