### PR TITLE
Fixes in Code Syntax, Method Names, and Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Barretenberg (or `bb` for short) is an optimized elliptic curve library for the 
     - [WASM](#wasm)
     - [How to run](#how-to-run)
   - [Debugging](#debugging)
-    - [Debugging Verification Failures](#debugging-verifification-failures)
+    - [Debugging Verification Failures](#debugging-verification-failures)
     - [Improving LLDB Debugging](#improving-lldb-debugging)
     - [Using Tracy to Profile Memory/CPU](#using-tracy-to-profile-memorycpu)
 
@@ -396,7 +396,7 @@ cmake --build --preset default --target run_ecc_bench
 
 ### Debugging
 
-#### Debugging Verifification Failures
+#### Debugging Verification Failures
 
 The CircuitChecker::check_circuit function is used to get the gate index and block information about a failing circuit constraint.
 If you are in a scenario where you have a failing call to check_circuit and wish to get more information out of it than just the gate index, you can use this feature to get a stack trace, see example below.

--- a/cpp/docs/Fuzzing.md
+++ b/cpp/docs/Fuzzing.md
@@ -81,7 +81,7 @@ mkdir minimized_crashes
 ./bin/<fuzzer_executable> -minimize_crash=1 -artifact_prefix=minimized_crashes <crash_file>
 ```
 
-Also, both bigfield and safeuint fuzzer containt the SHOW_INFORMATION preprocessor cases, which enable the printing of instructions and values to make debugging the crash easier.
+Also, both bigfield and safeuint fuzzer contain the SHOW_INFORMATION preprocessor cases, which enable the printing of instructions and values to make debugging the crash easier.
 
 # Coverage reports
 

--- a/cpp/src/barretenberg/smt_verification/README.md
+++ b/cpp/src/barretenberg/smt_verification/README.md
@@ -10,9 +10,9 @@ Then just build with `smt-verification` preset.
 
 ### There're four new methods inside Standard and Ultra CircuitBuilders
 
-- ```set_variable_name(u32 index, str name)``` - assignes a name to a variable. Specifically, binds a name with the first index of an equivalence class.
+- ```set_variable_name(u32 index, str name)``` - assigns a name to a variable. Specifically, binds a name with the first index of an equivalence class.
 
-**!Note that you don't have to name a zero or one(in standard). It has the name `zero` by default.**
+**!Note that you don't have to name a zero or one (in standard). It has the name `zero` by default.**
 
 - ```update_variable_names(u32 idx)``` - in case you've called ```assert_equal``` and ```update_real_variable_indices``` somewhere and you know that two or more variables from the equivalence class have separate names, call this method. Idx is the index of one of the variables of this class. The name of the first variable in class will remain.
 
@@ -88,7 +88,7 @@ To store it on the disk just do the following
     There's also a function `smt_timer(Solver& s)` in `barretenberg/smt_verification/util/smt_util.hpp` that will run the `check`, measure the time in minutes:seconds and send it to stdout.
 
 
-    All the tables are exoported directly from circuit, but if you want to create your own table, there're two methods for this:
+    All the tables are exported directly from circuit, but if you want to create your own table, there're two methods for this:
 
     - `Solver::create_table(vector<cvc5::Term>& table)` - creates a set of values. 
     - `Solver::create_lookup_table(vector<vector<cvc5::Term>>& table)` - creates a table with three columns.
@@ -109,7 +109,7 @@ To store it on the disk just do the following
 
     - `smt_terms::TermType::FFTerm` - symbolic variables that simulate finite field arithmetic. 
     - `smt_terms::TermType::FFITerm` - symbolic variables that simulate integer elements which behave like finite field ones. Useful, when you want to create range constraints. Bad, when you try multiplication.
-    - `smt_terms::TermType::ITerm` - symbolic variables that simulate ordinary integer elements. Useful, when you want to create range constraints and operate with signed values that are not shrinked modulo smth.
+    - `smt_terms::TermType::ITerm` - symbolic variables that simulate ordinary integer elements. Useful, when you want to create range constraints and operate with signed values that are not shrunk modulo smth.
     - `smt_terms::TermType::BVTerm` - symbolic variables that simulate $\pmod{2^n}$ arithmetic. Useful, when you test uint circuits. Supports range constraints and bitwise operations. Doesn't behave like finite field element.
 
     All these types use different solver engines. The most general one is `FFTerm`.
@@ -121,7 +121,7 @@ To store it on the disk just do the following
     - ```smt_circuit::StandardCircuit circuit(CircuitSchema c_info, Solver* s, TermType type, str tag="", bool optimizations=true)```
     - ```smt_circuit::UltraCircuit circuit(CircuitSchema c_info, Solver* s, TermType type, str tag="", bool optimizations=true)```
 	
-	It will generate all the symbolic values of the circuit wires, add all the gate constrains, create a map `term_name->STerm` and the inverse of it. Where `term_name` is the name you provided earlier.
+	It will generate all the symbolic values of the circuit wires, add all the gate constraints, create a map `term_name->STerm` and the inverse of it. Where `term_name` is the name you provided earlier.
 
     In case you want to create two similar circuits with the same `solver` and `schema`, then you should specify the `tag`(name) of a circuit. 
 
@@ -176,21 +176,21 @@ To store it on the disk just do the following
     **!Note `Bool(a == b)` won't work since `a==b` will create an equality constraint as I mentioned earlier and the return type of this operation is `void`.**
 
 ## 3. Post model checking
-After generating all the constrains you should call `bool res = solver.check()` and depending on your goal it could be `true` or `false`.
+After generating all the constraints you should call `bool res = solver.check()` and depending on your goal it could be `true` or `false`.
 
 In case you expected `false` but `true` was returned you can then check what went wrong.
-You should generate an unordered map with `str->term` values and ask the solver to obtain `unoredered_map<str, str> res = solver.model(unordered_map<str, FFTerm> terms)`.
+You should generate an unordered map with `str->term` values and ask the solver to obtain `unordered_map<str, str> res = solver.model(unordered_map<str, FFTerm> terms)`.
    Or you can provide a vector of terms that you want to check and the return map will contain their symbolic names that are given during initialization. Specifically either it's the name that you set or `var_{i}`.
    
 Now you have the values of the specified terms, which resulted into `true` result. 
 **!Note that the return values are decimal strings/binary strings**, so if you want to use them later you should use `FFConst` with base 10, etc.
 
 Also, there is a header file "barretenberg/smt_verification/utl/smt_util.hpp" that contains two useful functions:
-- `default_model(verctor<str> special_names, circuit1, circuit2, *solver, fname="witness.out", bool pack = true)`
+- `default_model(vector<str> special_names, circuit1, circuit2, *solver, fname="witness.out", bool pack = true)`
 - `default_model_single(vector<str> special_names, circuit, *solver, fname="witness.out, bool pack = true)`
 
 These functions will write witness variables in c-like array format into file named `fname`.
-The vector of `special_names` is the values that you want ot see in stdout.
+The vector of `special_names` is the values that you want to see in stdout.
 `pack` argument tells this function to save an `msgpack` buffer of the witness on disk. Name of the file will be `fname`.pack 
 
 You can then import the saved witness using one of the following functions:
@@ -201,10 +201,10 @@ You can then import the saved witness using one of the following functions:
 ## 4. Automated verification of a unique witness
 There's a static member of `StandardCircuit` and `UltraCircuit` 
 
-- `pair<StandardCircuit, StandardCircuit> StandardCircuit::unique_wintes(CircuitSchema circuit_info, Solver*, TermType type, vector<str> equal, bool optimizations)`
-- `pair<UltraCircuit, UltraCircuit> UltraCircuit::unique_wintes(CircuitSchema circuit_info, Solver*, TermType type, vector<str> equal, bool optimizations)`
+- `pair<StandardCircuit, StandardCircuit> StandardCircuit::unique_witness(CircuitSchema circuit_info, Solver*, TermType type, vector<str> equal, bool optimizations)`
+- `pair<UltraCircuit, UltraCircuit> UltraCircuit::unique_witness(CircuitSchema circuit_info, Solver*, TermType type, vector<str> equal, bool optimizations)`
 
-They will create two separate circuits, constrain variables with names from `equal` to be equal acrosss the circuits, and set all the other variables to be not equal at the same time.
+They will create two separate circuits, constrain variables with names from `equal` to be equal across the circuits, and set all the other variables to be not equal at the same time.
 
 Another one is 
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -58,7 +58,7 @@ Commands:
   prove_and_verify [options]  Generate a proof and verify it. Process exits with success or failure code.
   prove [options]             Generate a proof and write it to a file.
   gates [options]             Print gate count to standard output.
-  verify [options]            Verify a proof. Process exists with success or failure code.
+  verify [options]            Verify a proof. Process exits with success or failure code.
   contract [options]          Output solidity verification key contract.
   write_vk [options]          Output verification key.
   proof_as_fields [options]   Return the proof as fields elements


### PR DESCRIPTION
### 1. Spelling correction in heading:

**Debugging Verificication Failures → Debugging Verification Failures**

> Fixed typo in "Verification" (removed extra 'i').

### 2. Word corrections:

**containt → contain**

> Fixed typo in the word (incorrect form).

### 3. Spelling correction:

**prenting → printing**

> Fixed typo in "printing" (missing 'i').

**constrains → constraints**

> Fixed typo in multiple places (missing 't').

### 4. Link formatting:

**(#debugging-verificication-failures) → (#debugging-verification-failures)**

> Fixed typo in the markdown link to match the corrected heading.

### 5. Method description correction:

**assignes a name → assigns a name**

> Fixed typo in the word (incorrect spelling).

### 6.  Word correction:

**exoported → exported**

> Fixed typo in the word (removed extra 'o').

### 7. Past participle form correction:

**shrinked → shrunk**

> Fixed incorrect past participle form of "shrink".


###  8.  Map type correction:

**unoredered_map → unordered_map**

> Fixed typo in C++ container name (removed extra 'e').

###  9. Parameter type correction:

**verctor<str> → vector<str>**

> Fixed typo in template parameter name.

### 10. Text correction:

**want ot see → want to see**

> Fixed transposed letters in "to".

### 11.Method name correction:

**unique_wintes → unique_witness**

> Fixed typo in method name (missing 's').

### 12. Word correction:

**acrosss → across**

> Fixed typo (removed extra 's').

### 13. Word correction:

**exists → exits**

> Fixed incorrect word usage in process description (changed from "exists" to "exits" as it refers to program termination).
