### PR TITLE
Typo fix in main.cpp

### DIFF
--- a/cpp/src/barretenberg/bb/main.cpp
+++ b/cpp/src/barretenberg/bb/main.cpp
@@ -949,7 +949,7 @@ void write_vk_honk(const std::string& bytecodePath, const std::string& outputPat
 
 /**
  * @brief Compute and write to file a MegaHonk VK for a circuit to be accumulated in the IVC
- * @note This method differes from write_vk_honk<MegaFlavor> in that it handles kernel circuits which require special
+ * @note This method differs from write_vk_honk<MegaFlavor> in that it handles kernel circuits which require special
  * treatment (i.e. construction of mock IVC state to correctly complete the kernel logic).
  *
  * @param bytecodePath


### PR DESCRIPTION
# Pull Request Title: Typo fix in main.cpp

## Description:
This pull request fixes a typo in the comment within the `main.cpp` file. The word "differes" has been corrected to "differs."

## Changes:
- Corrected the spelling of "differes" to "differs" in the comment explaining the method.

## File(s) Modified:
- `cpp/src/barretenberg/bb/main.cpp`

## Reasoning:
Correcting the typo improves clarity and ensures that the comment is grammatically correct.

## Checklist:
- [x] The code follows the project's coding guidelines.
- [x] All relevant tests are passing.
- [x] I have updated the documentation (if necessary).
- [x] I have tested the changes locally.

## Related Issues:
N/A

## Additional Notes:
N/A
