### PR TITLE
Fix Typo in `README.md`

### DIFF
--- a/cpp/src/barretenberg/smt_verification/README.md
+++ b/cpp/src/barretenberg/smt_verification/README.md
@@ -10,7 +10,7 @@ Then just build with `smt-verification` preset.
 
 ### There're four new methods inside Standard and Ultra CircuitBuilders
 
-- ```set_variable_name(u32 index, str name)``` - assignes a name to a variable. Specifically, binds a name with the first index of an equivalence class.
+- ```set_variable_name(u32 index, str name)``` - assigns a name to a variable. Specifically, binds a name with the first index of an equivalence class.
 
 **!Note that you don't have to name a zero or one(in standard). It has the name `zero` by default.**
 


### PR DESCRIPTION
# Pull Request Title: Fix Typo in `README.md` - "assignes" to "assigns"

## Summary:
This pull request addresses a typo in the `README.md` file within the `cpp/src/barretenberg/smt_verification` directory to improve clarity and professionalism in the documentation:
- Corrected the spelling of **"assignes"** to **"assigns"** in the description of the `set_variable_name` method.

## Changes Made:
- **README.md**:
  - Fixed the typo in the explanation of the `set_variable_name` method under the **Standard and Ultra CircuitBuilders** section.

## Files Changed:
- `cpp/src/barretenberg/smt_verification/README.md`

## Testing:
- This is a documentation-only update and does not impact the functionality or codebase.

## Additional Notes:
- Accurate documentation enhances the ease of understanding for contributors and users of the project.
- This correction ensures consistency in grammar and helps maintain a professional standard.

---


