### PR TITLE
Fix incorrect field types in exports.json to align with Fr for scalar values

### DIFF
--- a/exports.json
+++ b/exports.json
@@ -248,7 +248,7 @@
     "inArgs": [
       {
         "name": "private_key",
-        "type": "fq::in_buf"
+        "type": "fr::in_buf"
       }
     ],
     "outArgs": [
@@ -303,7 +303,7 @@
       },
       {
         "name": "private_key",
-        "type": "fq::in_buf"
+        "type": "fr::in_buf"
       },
       {
         "name": "signer_round_one_private_buf",
@@ -321,7 +321,7 @@
     "outArgs": [
       {
         "name": "round_two_buf",
-        "type": "fq::out_buf"
+        "type": "fr::out_buf"
       },
       {
         "name": "success",
@@ -347,7 +347,7 @@
       },
       {
         "name": "round_two_buf",
-        "type": "fq::vec_in_buf"
+        "type": "fr::vec_in_buf"
       }
     ],
     "outArgs": [


### PR DESCRIPTION
### Changes made in exports.json:
**Line 251: "type": "fq::in_buf" → "type": "fr::in_buf"
Line 306: "type": "fq::in_buf" → "type": "fr::in_buf"
Line 324: "type": "fq::out_buf" → "type": "fr::out_buf"
Line 350: "type": "fq::vec_in_buf" → "type": "fr::vec_in_buf"**

Arguments for these changes:
Field Purpose Distinction:
Fr (Field of scalars): Used for cryptographic operations - private keys, nonces, signatures
Fq (Field of coordinates): Used for elliptic curve point coordinates and curve arithmetic

The changed parameters are scalar values (private keys, signature components), so they must use Fr
These changes align the code with cryptographic standards and mathematical requirements of the Schnorr signature scheme.