### PR TITLE
Fix typo in documentation: "Verifification" -> "Verification"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Barretenberg (or `bb` for short) is an optimized elliptic curve library for the 
     - [WASM](#wasm)
     - [How to run](#how-to-run)
   - [Debugging](#debugging)
-    - [Debugging Verification Failures](#debugging-verifification-failures)
+    - [Debugging Verification Failures](#debugging-Verification-failures)
     - [Improving LLDB Debugging](#improving-lldb-debugging)
     - [Using Tracy to Profile Memory/CPU](#using-tracy-to-profile-memorycpu)
 
@@ -396,7 +396,7 @@ cmake --build --preset default --target run_ecc_bench
 
 ### Debugging
 
-#### Debugging Verifification Failures
+#### Debugging Verification Failures
 
 The CircuitChecker::check_circuit function is used to get the gate index and block information about a failing circuit constraint.
 If you are in a scenario where you have a failing call to check_circuit and wish to get more information out of it than just the gate index, you can use this feature to get a stack trace, see example below.


### PR DESCRIPTION
Fix typo in documentation: "Verifification" -> "Verification"
