### PR TITLE
chore: Add None check for child.spelling in decls_json.py

### DIFF
--- a/scripts/decls_json.py
+++ b/scripts/decls_json.py
@@ -8,7 +8,7 @@ clang.cindex.Config.set_library_file('/usr/lib/llvm-18/lib/libclang-18.so.1')
 
 def has_annotation(node, annotation):
     for child in node.get_children():
-        if child.kind == clang.cindex.CursorKind.ANNOTATE_ATTR and annotation in child.spelling:
+        if child.kind == clang.cindex.CursorKind.ANNOTATE_ATTR and child.spelling and annotation in child.spelling:
             return True
     return False
 


### PR DESCRIPTION
`child.spelling` could potentially be `None`, which might cause errors in the code.
I've added a check to handle this case and avoid any unexpected issues. 