### PR TITLE
fix broken link Doxyfile

### DIFF
--- a/cpp/docs/Doxyfile
+++ b/cpp/docs/Doxyfile
@@ -1436,7 +1436,7 @@ HTML_INDEX_NUM_ENTRIES = 100
 # output directory. Running make will produce the docset in that directory and
 # running make install will install the docset in
 # ~/Library/Developer/Shared/Documentation/DocSets so that Xcode will find it at
-# startup. See https://developer.apple.com/library/archive/featuredarticles/Doxy
+# startup. See 
 # genXcode/_index.html for more information.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.


### PR DESCRIPTION
Fixed an incorrect link in `cpp/docs/Doxyfile`.