### PR TITLE
feat: add normalized_cache to UltraCircuitBuilder

### DIFF
--- a/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -525,6 +525,9 @@ template <typename Builder> field_t<Builder> field_t<Builder>::add_two(const fie
  */
 template <typename Builder> field_t<Builder> field_t<Builder>::normalize() const
 {
+    if (context && context->has_normalized(witness_index, multiplicative_constant, additive_constant)) {
+        return context->get_normalized(witness_index, multiplicative_constant, additive_constant);
+    }
     if (witness_index == IS_CONSTANT ||
         ((multiplicative_constant == bb::fr::one()) && (additive_constant == bb::fr::zero()))) {
         return *this;
@@ -557,6 +560,7 @@ template <typename Builder> field_t<Builder> field_t<Builder>::normalize() const
                                .c_scaling = bb::fr::neg_one(),
                                .const_scaling = additive_constant });
     result.tag = tag;
+    context->cache_normalized(witness_index, multiplicative_constant, additive_constant, result);
     return result;
 }
 

--- a/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -736,6 +736,28 @@ uint32_t UltraCircuitBuilder_<ExecutionTrace>::put_constant_variable(const FF& v
     }
 }
 
+template <typename ExecutionTrace>
+field_t<UltraCircuitBuilder_<ExecutionTrace>> UltraCircuitBuilder_<ExecutionTrace>::get_normalized(
+    uint32_t witness_index, const bb::fr& mul, const bb::fr& add) const
+{
+    return normalized_cache.at({witness_index, mul, add});
+}
+
+template <typename ExecutionTrace>
+bool UltraCircuitBuilder_<ExecutionTrace>::has_normalized(
+    uint32_t witness_index, const bb::fr& mul, const bb::fr& add) const
+{
+    return normalized_cache.contains({witness_index, mul, add});
+}
+
+template <typename ExecutionTrace>
+void UltraCircuitBuilder_<ExecutionTrace>::cache_normalized(
+    uint32_t witness_index, const bb::fr& mul, const bb::fr& add,
+    const field_t<UltraCircuitBuilder_<ExecutionTrace>>& normalized)
+{
+    normalized_cache[{witness_index, mul, add}] = normalized;
+}
+
 /**
  * @brief Get the basic table with provided ID from the set of tables for the present circuit; create it if it doesnt
  * yet exist

--- a/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -330,6 +330,8 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     std::vector<uint32_t> used_witnesses;
     std::vector<cached_partial_non_native_field_multiplication> cached_partial_non_native_field_multiplications;
 
+    std::unordered_map<std::tuple<uint32_t, bb::fr, bb::fr>, field_t<UltraCircuitBuilder>, boost::hash<std::tuple<uint32_t, bb::fr, bb::fr>>> normalized_cache;
+
     bool circuit_finalized = false;
 
     std::vector<fr> ipa_proof;
@@ -717,6 +719,19 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     std::vector<uint32_t> get_used_witnesses() const { return used_witnesses; }
 
     void update_used_witnesses(uint32_t var_idx) { used_witnesses.emplace_back(var_idx); }
+
+    field_t<UltraCircuitBuilder> get_normalized(uint32_t witness_index, const bb::fr& mul, const bb::fr& add) const {
+    return normalized_cache.at({witness_index, mul, add});
+    }
+
+    bool has_normalized(uint32_t witness_index, const bb::fr& mul, const bb::fr& add) const {
+    return normalized_cache.contains({witness_index, mul, add});
+    }
+
+    void cache_normalized(uint32_t witness_index, const bb::fr& mul, const bb::fr& add, const field_t<UltraCircuitBuilder>& normalized) {
+    normalized_cache[{witness_index, mul, add}] = normalized;
+    }
+
 
     /**x
      * @brief Print the number and composition of gates in the circuit


### PR DESCRIPTION
## Summary
Closes #1052 

This PR introduces a `normalized_cache` mechanism to the `UltraCircuitBuilder` to support memoization of normalized witness variables.

## Changes

- Added `normalized_cache` as a member field in `UltraCircuitBuilder`.
- Implemented the following methods:
  - `has_normalized(...)`
  - `get_normalized(...)`
  - `cache_normalized(...)`
- All methods are field-agnostic and templated over `ExecutionTrace`.

## Motivation

The cache allows the builder to reuse previously computed normalized values, avoiding redundant work and improving performance in cases where normalization is invoked multiple times for the same inputs.

